### PR TITLE
Move emotion-mdx into source

### DIFF
--- a/theme-ui/.gitignore
+++ b/theme-ui/.gitignore
@@ -1,0 +1,1 @@
+coverage

--- a/theme-ui/.npmignore
+++ b/theme-ui/.npmignore
@@ -1,3 +1,4 @@
 babel.config.js
 *.test.js
 coverage
+__snapshots__

--- a/theme-ui/__snapshots__/index.test.js.snap
+++ b/theme-ui/__snapshots__/index.test.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`creates non-standard components 1`] = `
+<sup
+  className="css-tq928n"
+>
+  hey
+</sup>
+`;
+
+exports[`renders 1`] = `
+<h1
+  className="css-0"
+>
+  Hello
+</h1>
+`;
+
+exports[`renders with styles 1`] = `
+<h1
+  className="css-tq928n"
+>
+  Hello
+</h1>
+`;

--- a/theme-ui/index.js
+++ b/theme-ui/index.js
@@ -1,10 +1,132 @@
-import React from 'react'
-import { ComponentProvider } from 'emotion-mdx'
+import React, { useContext } from 'react'
+import { jsx } from '@emotion/core'
+import { ThemeProvider as EmotionProvider } from 'emotion-theming'
+import { MDXProvider } from '@mdx-js/react'
 import css from '@styled-system/css'
+import merge from 'lodash.merge'
+import get from 'lodash.get'
 
 export { css } from '@styled-system/css'
-export { Context, Styled } from 'emotion-mdx'
 
+const tags = [
+  'p',
+  'a',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'img',
+  'pre',
+  'code',
+  'ol',
+  'ul',
+  'li',
+  'blockquote',
+  'hr',
+  'em',
+  'table',
+  'tr',
+  'th',
+  'td',
+  'em',
+  'strong',
+  'delete',
+  // mdx
+  'wrapper',
+  'inlineCode',
+  'thematicBreak',
+  // extras
+  'div',
+]
+
+const aliases = {
+  inlineCode: 'code',
+  thematicBreak: 'hr',
+  wrapper: 'div',
+}
+
+const alias = n => aliases[n] || n
+
+const themed = key => theme => theme.css(get(theme, `styles.${key}`))(theme)
+
+const styled = (tag, key) => ({ as = tag, ...props }) => jsx(alias(as), {
+  ...props,
+  css: themed(key)
+})
+
+const components = {}
+
+export const Styled = React.forwardRef(({
+  tag = 'div',
+  ...props
+}, ref) => {
+  const components = useComponents()
+  const type = components[tag] || 'div'
+  return jsx(type, { ...props, ref })
+})
+
+const createStyled = tag => React.forwardRef((props, ref) =>
+  jsx(Styled, { ref, tag, ...props })
+)
+
+tags.forEach(tag => {
+  components[tag] = styled(tag, tag)
+  Styled[tag] = createStyled(tag)
+})
+
+const createComponents = (components = {}) => {
+  const next = {}
+  Object.keys(components).forEach(key => {
+    next[key] = styled(components[key], key)
+    Styled[key] = createStyled(key)
+  })
+  return next
+}
+
+const noop = n => () => n
+
+const baseContext = {
+  theme: {
+    css: noop,
+  },
+  components,
+}
+
+export const Context = React.createContext(baseContext)
+
+export const ComponentProvider = ({
+  theme,
+  components,
+  transform,
+  ...props
+}) => {
+  const outer = useContext(Context)
+  const context = merge({}, outer, {
+    theme: merge({}, theme, {
+      css: transform,
+    }),
+    components: createComponents(components),
+  })
+
+  return (
+    <EmotionProvider theme={context.theme}>
+      <MDXProvider components={context.components}>
+        <Context.Provider value={context}>
+          {props.children}
+        </Context.Provider>
+      </MDXProvider>
+    </EmotionProvider>
+  )
+}
+
+export const useComponents = () => {
+  const context = useContext(Context)
+  return context.components
+}
+
+// This could be removed, but keeping the theme-ui API intact
 export const ThemeProvider = props =>
   <ComponentProvider
     {...props}

--- a/theme-ui/index.test.js
+++ b/theme-ui/index.test.js
@@ -1,0 +1,112 @@
+/** @jsx mdx */
+import { mdx } from '@mdx-js/react'
+import renderer from 'react-test-renderer'
+import { matchers } from 'jest-emotion'
+import {
+  ComponentProvider,
+  Styled,
+  useComponents,
+} from './index'
+
+expect.extend(matchers)
+
+const renderJSON = el => renderer.create(el).toJSON()
+
+test('renders', () => {
+  const json = renderJSON(
+    <ComponentProvider>
+      <h1>Hello</h1>
+    </ComponentProvider>
+  )
+  expect(json).toMatchSnapshot()
+})
+
+test('renders with styles', () => {
+  const json = renderJSON(
+    <ComponentProvider
+      theme={{
+        styles: {
+          h1: {
+            color: 'tomato'
+          }
+        }
+      }}>
+      <h1>Hello</h1>
+    </ComponentProvider>
+  )
+  expect(json).toMatchSnapshot()
+})
+
+test('renders with useComponents', () => {
+  let components
+  const Beep = props => {
+    components = useComponents()
+    return false
+  }
+  const json = renderJSON(
+    <ComponentProvider>
+      <Beep />
+    </ComponentProvider>
+  )
+  expect(typeof components).toBe('object')
+  expect(components.h1).toBeTruthy()
+})
+
+test('creates non-standard components', () => {
+  const json = renderJSON(
+    <ComponentProvider
+      components={{
+        sup: 'sup',
+      }}
+      theme={{
+        styles: {
+          sup: {
+            color: 'tomato'
+          }
+        }
+      }}>
+      <sup>hey</sup>
+    </ComponentProvider>
+  )
+  expect(json).toMatchSnapshot()
+  expect(json).toHaveStyleRule('color', 'tomato')
+})
+
+test('styles React components', () => {
+  const Beep = props => <h2 {...props}>Boop</h2>
+  const json = renderJSON(
+    <ComponentProvider
+      components={{
+        Beep: props => <h2 {...props}>Boop</h2>
+      }}
+      theme={{
+        styles: {
+          Beep: {
+            color: 'tomato'
+          }
+        }
+      }}>
+      <Styled tag='Beep' />
+    </ComponentProvider>
+  )
+  expect(json.type).toBe('h2')
+  expect(json).toHaveStyleRule('color', 'tomato')
+})
+
+test('components accept an `as` prop', () => {
+  const Beep = props => <h2 {...props} />
+  const json = renderJSON(
+    <ComponentProvider
+      theme={{
+        styles: {
+          h1: {
+            color: 'tomato',
+          }
+        }
+      }}>
+      <Styled.h1 as={Beep}>Beep boop</Styled.h1>
+    </ComponentProvider>
+  )
+  expect(json.type).toBe('h2')
+  expect(json).toHaveStyleRule('color', 'tomato')
+})

--- a/theme-ui/package.json
+++ b/theme-ui/package.json
@@ -8,11 +8,10 @@
     "test": "jest"
   },
   "dependencies": {
-    "@emotion/core": "^10.0.10",
     "@styled-system/css": "^1.0.3",
     "css-what": "^2.1.3",
-    "emotion-mdx": "^1.0.0-6",
-    "emotion-theming": "^10.0.10",
+    "jest-emotion": "^10.0.10",
+    "lodash.get": "^4.4.2",
     "lodash.merge": "^4.6.1",
     "styled-system": "^4.1.0",
     "typography": "^0.16.19"
@@ -21,8 +20,19 @@
     "@babel/core": "^7.4.3",
     "@babel/preset-env": "^7.4.3",
     "@babel/preset-react": "^7.0.0",
+    "@emotion/core": "^10.0.10",
+    "@mdx-js/mdx": "^1.0.0-rc.0",
+    "@mdx-js/react": "^1.0.0-rc.0",
+    "emotion-theming": "^10.0.10",
     "jest": "^24.7.0",
     "jest-emotion": "^10.0.10",
+    "react-test-renderer": "^16.8.6",
     "typography-theme-wordpress-2016": "^0.16.19"
+  },
+  "peerDependencies": {
+    "@emotion/core": "^10.0.10",
+    "@mdx-js/mdx": "^1.0.0-rc.0",
+    "@mdx-js/react": "^1.0.0-rc.0",
+    "emotion-theming": "^10.0.10"
   }
 }

--- a/theme-ui/typography.js
+++ b/theme-ui/typography.js
@@ -16,7 +16,7 @@ const parseSelectors = styles => {
       if (parent.type === 'universal') return
       if (parent.type !== 'tag') {
         // todo...
-        console.log('!TAG', selector, parent.type)
+        // console.log('!TAG', selector, parent.type)
         return
       }
 

--- a/theme-ui/typography.test.js
+++ b/theme-ui/typography.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import toStyles from './typography-mdx'
+import toStyles from './typography'
 import theme from 'typography-theme-wordpress-2016'
 
 test('converts typography theme to styles object', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1242,10 +1242,34 @@
     unist-builder "^1.0.1"
     unist-util-visit "^1.3.0"
 
+"@mdx-js/mdx@^1.0.0-rc.0":
+  version "1.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@mdx-js/mdx/-/mdx-1.0.0-rc.0.tgz#c31c8dae9c08e6494018e0fde4a0d87a7364f7a8"
+  integrity sha512-PpDmC9i1LJKAK/BNce75D8QZS05ccfVMJZKGalogvGw0b8R+vQcMBtlklbVOqk10oVBe1TYYbRdniOkt1ziHMw==
+  dependencies:
+    "@babel/plugin-proposal-object-rest-spread" "^7.3.2"
+    "@babel/plugin-syntax-jsx" "^7.2.0"
+    change-case "^3.0.2"
+    detab "^2.0.0"
+    hast-util-raw "^5.0.0"
+    mdast-util-to-hast "^4.0.0"
+    remark-mdx "^1.0.0-rc.0"
+    remark-parse "^6.0.0"
+    remark-squeeze-paragraphs "^3.0.1"
+    to-style "^1.3.3"
+    unified "^7.0.0"
+    unist-builder "^1.0.1"
+    unist-util-visit "^1.3.0"
+
 "@mdx-js/react@^1.0.0-alpha.17":
   version "1.0.0-alpha.17"
   resolved "https://registry.yarnpkg.com/@mdx-js/react/-/react-1.0.0-alpha.17.tgz#96bd93ed8f4743bf7d6f89e13eb0852acaa36f48"
   integrity sha512-D4T5robG27ydlWqkPe9HGZRDitmoTR0NJUGpdWUR5Qyww1vFeYkDv2QL9frY4gO+4RJm7Be82ixN0+iPNe2kaA==
+
+"@mdx-js/react@^1.0.0-rc.0":
+  version "1.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@mdx-js/react/-/react-1.0.0-rc.0.tgz#1863287fe20a396c13280e155a29dbf9f8a40889"
+  integrity sha512-yE/eEUDBkdSdsSdXvantAn8Q6CdM+u2Nor2IRaN8Fe+p8IGpMfHqLFS3WSIZpodGB4PYUxRsGINDl7ITSZXQyg==
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -9443,7 +9467,7 @@ react-hot-loader@^4.6.2:
     shallowequal "^1.0.2"
     source-map "^0.7.3"
 
-react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
+react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
@@ -9460,6 +9484,16 @@ react-side-effect@^1.1.0:
   dependencies:
     exenv "^1.2.1"
     shallowequal "^1.0.1"
+
+react-test-renderer@^16.8.6:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.8.6.tgz#188d8029b8c39c786f998aa3efd3ffe7642d5ba1"
+  integrity sha512-H2srzU5IWYT6cZXof6AhUcx/wEyJddQ8l7cLM/F7gDXYyPr4oq+vCIxJYXVGhId1J706sqziAjuOEjyNkfgoEw==
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    react-is "^16.8.6"
+    scheduler "^0.13.6"
 
 react@^16.8.6:
   version "16.8.6"
@@ -9699,6 +9733,19 @@ remark-mdx@^1.0.0-alpha.13:
   version "1.0.0-alpha.13"
   resolved "https://registry.yarnpkg.com/remark-mdx/-/remark-mdx-1.0.0-alpha.13.tgz#39f1fa55996d9a55d8d83418d046926ef8fd7a88"
   integrity sha512-XgSCbCejpv6IDem9iyTLXgsVJ1X9UW/IeQU0Yi/k9Eqwynlare2t1/z989s2yD1kTdG+KTmjKsysvlrDnvvQcw==
+  dependencies:
+    "@babel/core" "^7.2.2"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-proposal-object-rest-spread" "^7.3.2"
+    "@babel/plugin-syntax-jsx" "^7.2.0"
+    is-alphabetical "^1.0.2"
+    remark-parse "^6.0.0"
+    unified "^7.0.0"
+
+remark-mdx@^1.0.0-rc.0:
+  version "1.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/remark-mdx/-/remark-mdx-1.0.0-rc.0.tgz#c6886f208bf7ca06368fd10a123106af7284dbac"
+  integrity sha512-hCh7/HV8aSGGWRudqThCXsxuu6j3FaXh5x2nfqLysm+50la2evldzXWxZmBU15WoNwTP5W4akXKFad+tMt1Eig==
   dependencies:
     "@babel/core" "^7.2.2"
     "@babel/helper-plugin-utils" "^7.0.0"
@@ -10924,6 +10971,20 @@ text-table@0.2.0, text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
+
+theme-ui@0.0.0-4:
+  version "0.0.0-4"
+  resolved "https://registry.yarnpkg.com/theme-ui/-/theme-ui-0.0.0-4.tgz#6c94cf1b632b5f78cf00c62bdbdd3ec7dbc86d06"
+  integrity sha512-5XUkVW26KXxp6o0BWiQMMlIBhg+O7d/famej4JdIKetkec/E+1Mc27fRShyls0RYhnHXyHc0oi0YXk4zbpDZHQ==
+  dependencies:
+    "@emotion/core" "^10.0.10"
+    "@styled-system/css" "^1.0.3"
+    css-what "^2.1.3"
+    emotion-mdx "^1.0.0-6"
+    emotion-theming "^10.0.10"
+    lodash.merge "^4.6.1"
+    styled-system "^4.1.0"
+    typography "^0.16.19"
 
 throat@^4.0.0:
   version "4.1.0"


### PR DESCRIPTION
Since `emotion-mdx` is pretty coupled to the React context, and it was just an experiment to get to what the theme-ui lib does, I'm moving it into the source code here. Hopefully it will make iterating on this library a little easier