### PR TITLE
Use @emotion/styled

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -26,7 +26,7 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-helmet": "^5.2.0",
-    "theme-ui": "^0.0.4",
+    "theme-ui": "^0.0.5-0",
     "typography-theme-alton": "^0.16.19",
     "typography-theme-anonymous": "^0.15.10",
     "typography-theme-bootstrap": "^0.16.19",

--- a/docs/src/pages/no-layout.mdx
+++ b/docs/src/pages/no-layout.mdx
@@ -1,4 +1,3 @@
 
 # No Layout
 
-Does this page blow up still?

--- a/docs/src/pages/no-layout.mdx
+++ b/docs/src/pages/no-layout.mdx
@@ -1,0 +1,4 @@
+
+# No Layout
+
+Does this page blow up still?

--- a/theme-ui/index.js
+++ b/theme-ui/index.js
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react'
 import { jsx } from '@emotion/core'
+import styled from '@emotion/styled'
 import { ThemeProvider as EmotionProvider } from 'emotion-theming'
 import { MDXProvider } from '@mdx-js/react'
 import css from '@styled-system/css'
@@ -51,14 +52,6 @@ const alias = n => aliases[n] || n
 
 const themed = key => theme => css(get(theme, `styles.${key}`))(theme)
 
-const styled = (tag, key) => ({
-  as = tag,
-  ...props
-}) => jsx(alias(as), {
-  ...props,
-  css: themed(key)
-})
-
 export const Styled = React.forwardRef(({
   tag = 'div',  // tag is used as a key in theme.styles
   as,           // as replaces the rendered element type
@@ -73,7 +66,7 @@ export const Styled = React.forwardRef(({
 
 const components = {}
 tags.forEach(tag => {
-  components[tag] = styled(tag, tag)
+  components[tag] = styled(alias(tag))(props => themed(tag)(props.theme))
   Styled[tag] = React.forwardRef((props, ref) =>
     jsx(Styled, { ref, tag, ...props })
   )
@@ -87,7 +80,7 @@ export const Context = React.createContext({
 const createComponents = (components = {}) => {
   const next = {}
   Object.keys(components).forEach(key => {
-    next[key] = styled(components[key], key)
+    next[key] = styled(components[key])(props => themed(key)(props.theme))
   })
   return next
 }

--- a/theme-ui/package.json
+++ b/theme-ui/package.json
@@ -8,6 +8,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@emotion/styled": "^10.0.10",
     "@styled-system/css": "^1.0.3",
     "css-what": "^2.1.3",
     "jest-emotion": "^10.0.10",

--- a/theme-ui/package.json
+++ b/theme-ui/package.json
@@ -8,7 +8,6 @@
     "test": "jest"
   },
   "dependencies": {
-    "@emotion/styled": "^10.0.10",
     "@styled-system/css": "^1.0.3",
     "css-what": "^2.1.3",
     "jest-emotion": "^10.0.10",
@@ -22,6 +21,7 @@
     "@babel/preset-env": "^7.4.3",
     "@babel/preset-react": "^7.0.0",
     "@emotion/core": "^10.0.10",
+    "@emotion/styled": "^10.0.10",
     "@mdx-js/mdx": "^1.0.0-rc.0",
     "@mdx-js/react": "^1.0.0-rc.0",
     "emotion-theming": "^10.0.10",
@@ -32,6 +32,7 @@
   },
   "peerDependencies": {
     "@emotion/core": "^10.0.10",
+    "@emotion/styled": "^10.0.10",
     "@mdx-js/mdx": "^1.0.0-rc.0",
     "@mdx-js/react": "^1.0.0-rc.0",
     "emotion-theming": "^10.0.10"

--- a/theme-ui/package.json
+++ b/theme-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "theme-ui",
-  "version": "0.0.4",
+  "version": "0.0.5-0",
   "main": "index.js",
   "author": "Brent Jackson <jxnblk@gmail.com>",
   "license": "MIT",

--- a/yarn.lock
+++ b/yarn.lock
@@ -810,6 +810,13 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.7.1.tgz#9833722341379fb7d67f06a4b00ab3c37913da53"
   integrity sha512-OYpa/Sg+2GDX+jibUfpZVn1YqSVRpYmTLF2eyAfrFTIJSbwyIrc+YscayoykvaOME/wV4BV0Sa0yqdMrgse6mA==
 
+"@emotion/is-prop-valid@0.7.3":
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.7.3.tgz#a6bf4fa5387cbba59d44e698a4680f481a8da6cc"
+  integrity sha512-uxJqm/sqwXw3YPA5GXX365OBcJGFtxUVkB6WyezqFHlNe9jqUWH5ur2O2M8dGBz61kn1g3ZBlzUunFQXQIClhA==
+  dependencies:
+    "@emotion/memoize" "0.7.1"
+
 "@emotion/memoize@0.7.1":
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.1.tgz#e93c13942592cf5ef01aa8297444dc192beee52f"
@@ -830,6 +837,24 @@
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-0.9.2.tgz#74e5c6b5e489a1ba30ab246ab5eedd96916487c4"
   integrity sha512-pVBLzIbC/QCHDKJF2E82V2H/W/B004mDFQZiyo/MSR+VC4pV5JLG0TF/zgQDFvP3fZL/5RTPGEmXlYJBMUuJ+A==
+
+"@emotion/styled-base@^10.0.10":
+  version "10.0.10"
+  resolved "https://registry.yarnpkg.com/@emotion/styled-base/-/styled-base-10.0.10.tgz#ffb811295c9dcd9b3c12bf93301d7d8bcb02e6f4"
+  integrity sha512-uZwKrBfcH7jCRAQi5ZxsEGIZ+1Zr9/lof4TMsIolC0LSwpnWkQ+JRJLy+p4ZyATee9SdmyCV0sG/VTngVSnrpA==
+  dependencies:
+    "@emotion/is-prop-valid" "0.7.3"
+    "@emotion/serialize" "^0.11.6"
+    "@emotion/utils" "0.11.1"
+    object-assign "^4.1.1"
+
+"@emotion/styled@^10.0.10":
+  version "10.0.10"
+  resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-10.0.10.tgz#ec241a9389a585b2c2638b709c262c28469ed92e"
+  integrity sha512-k4p5WxwYJUVYKBlwOmfpqxeSwdPHqUycLHJY9ftleEvMfphYLB8lt9oPEkEty5XH4URh/wyUfZ2wW2ojrHODWA==
+  dependencies:
+    "@emotion/styled-base" "^10.0.10"
+    babel-plugin-emotion "^10.0.9"
 
 "@emotion/stylis@0.8.3":
   version "0.8.3"


### PR DESCRIPTION
Using a custom `styled` function meant that all props were being forwarded to the element, which was causing issues with `gatsby-mdx` when `theme-ui`'s `wrapper` component was being used as the root page component. I'm not sure whether it makes sense for `theme-ui` to include a default `wrapper` component at all, but using `@emotion/styled` helps ensure non-HTML props aren't passed down to the underlying elements without having to completely reinvent the wheel