### PR TITLE
Add node_modules to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .cache
 public
 package-lock.json
+node_modules


### PR DESCRIPTION
After cloning and installing dependencies, `node_modules` were being tracked by git. This prevents that.