### PR TITLE
Update `@styled-system/css` package

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -26,7 +26,7 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-helmet": "^5.2.0",
-    "theme-ui": "^0.0.8",
+    "theme-ui": "*",
     "typography-theme-alton": "^0.16.19",
     "typography-theme-anonymous": "^0.15.10",
     "typography-theme-bootstrap": "^0.16.19",

--- a/theme-ui/layout.js
+++ b/theme-ui/layout.js
@@ -2,6 +2,8 @@ import React from 'react'
 import styled from '@emotion/styled'
 import {
   width,
+  space,
+  color,
   flex,
   alignItems,
   justifyContent,
@@ -15,6 +17,8 @@ export const Box = styled('div')(css({
   minWidth: 0,
 }),
   width,
+  space,
+  color,
   flex
 )
 

--- a/theme-ui/package.json
+++ b/theme-ui/package.json
@@ -9,7 +9,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@styled-system/css": "^1.0.3",
+    "@styled-system/css": "^2.0.0-0",
     "css-what": "^2.1.3",
     "jest-emotion": "^10.0.10",
     "lodash.get": "^4.4.2",

--- a/theme-ui/package.json
+++ b/theme-ui/package.json
@@ -9,7 +9,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@styled-system/css": "^2.0.0-0",
+    "@styled-system/css": "^2.0.0",
     "css-what": "^2.1.3",
     "jest-emotion": "^10.0.10",
     "lodash.get": "^4.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1095,10 +1095,23 @@
   resolved "https://registry.yarnpkg.com/@stefanprobst/lokijs/-/lokijs-1.5.6-b.tgz#6a36a86dbe132e702e6b15ffd3ce4139aebfe942"
   integrity sha512-MNodHp46og+Sdde/LCxTLrxcD5Dimu21R/Fer2raXMG1XtHSV2+vZnkIV87OPAxuf2NiDj1W5hN7Q2MYUfQQ8w==
 
-"@styled-system/css@^2.0.0-0":
-  version "2.0.0-0"
-  resolved "https://registry.yarnpkg.com/@styled-system/css/-/css-2.0.0-0.tgz#f4cd62e3d86ef553a7ed34cffa031d559705d2c9"
-  integrity sha512-nVmeJxLqXH7tW8B+0V3IHkLNRET9y1tzIUXo5++HW6BJ8trUhH7V5711iyBBvKy8nK0DgyCZH/GbeHLVCfmOYA==
+"@styled-system/css@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@styled-system/css/-/css-1.0.3.tgz#34e24d585707a796b6e8940466c26f5a6761b8c1"
+  integrity sha512-YXT8+00hFo/zk4oZeHxbysNgUc1wEYrTjpRreFIJxF6vgNkqg+fu70jmyP2JQ7f2I9C+Ssvg7GZ+RSp50RfosA==
+  dependencies:
+    lodash.flatten "^4.4.0"
+    lodash.isobject "^3.0.2"
+    lodash.merge "^4.6.1"
+    lodash.omit "^4.5.0"
+    lodash.pick "^4.4.0"
+    lodash.pickby "^4.6.0"
+    styled-system "^4.1.0-0"
+
+"@styled-system/css@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@styled-system/css/-/css-2.0.0.tgz#1cdb89182ddec16fab63d088093917df3745179b"
+  integrity sha512-lM1D6QEx40fH6sYPBWXGHK0qSjxwWM98dwsdwjE/M+K9GdTpKg2FAtprJOTl0RymtBJ5/qs4L34EGw4QBsbk4g==
   dependencies:
     lodash.get "^4.4.2"
 
@@ -7103,7 +7116,7 @@ lodash.filter@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.filter/-/lodash.filter-4.6.0.tgz#668b1d4981603ae1cc5a6fa760143e480b4c4ace"
   integrity sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4=
 
-lodash.flatten@^4.2.0:
+lodash.flatten@^4.2.0, lodash.flatten@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
   integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
@@ -7127,6 +7140,11 @@ lodash.isnumber@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
   integrity sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=
+
+lodash.isobject@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/lodash.isobject/-/lodash.isobject-3.0.2.tgz#3c8fb8d5b5bf4bf90ae06e14f2a530a4ed935e1d"
+  integrity sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0=
 
 lodash.kebabcase@^4.1.1:
   version "4.1.1"
@@ -7158,10 +7176,15 @@ lodash.omit@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
   integrity sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=
 
-lodash.pick@^4.2.1:
+lodash.pick@^4.2.1, lodash.pick@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
   integrity sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=
+
+lodash.pickby@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.pickby/-/lodash.pickby-4.6.0.tgz#7dea21d8c18d7703a27c704c15d3b84a67e33aff"
+  integrity sha1-feoh2MGNdwOifHBMFdO4SmfjOv8=
 
 lodash.reduce@^4.4.0:
   version "4.6.0"
@@ -10601,7 +10624,7 @@ style-to-object@^0.2.1:
   dependencies:
     css "2.2.4"
 
-styled-system@^4.1.0:
+styled-system@^4.1.0, styled-system@^4.1.0-0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/styled-system/-/styled-system-4.1.0.tgz#e5a58be23b89cf8fb7b181c8e425ab107b166693"
   integrity sha512-ioIAJ029tRr6eJhiUrE3VZeahN+GBuJHv/jmckkfikY4ej8BaxvIKAaavmjFoqzNsIzr+x5HCpry1ybQYpchtQ==
@@ -10747,6 +10770,19 @@ text-table@0.2.0, text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
+
+theme-ui@^0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/theme-ui/-/theme-ui-0.0.8.tgz#6ac447da552b8e9a7cd35dfb1e68294504139db7"
+  integrity sha512-sT53Ntd/9bpZZyiS+/BGW4fPQ4u9AvNCALKOzor+dLTRYXyhHWD9LULPNb/MhXIszMEwLKTkEqF/BLPTIGytbw==
+  dependencies:
+    "@styled-system/css" "^1.0.3"
+    css-what "^2.1.3"
+    jest-emotion "^10.0.10"
+    lodash.get "^4.4.2"
+    lodash.merge "^4.6.1"
+    styled-system "^4.1.0"
+    typography "^0.16.19"
 
 throat@^4.0.0:
   version "4.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1095,19 +1095,6 @@
   resolved "https://registry.yarnpkg.com/@stefanprobst/lokijs/-/lokijs-1.5.6-b.tgz#6a36a86dbe132e702e6b15ffd3ce4139aebfe942"
   integrity sha512-MNodHp46og+Sdde/LCxTLrxcD5Dimu21R/Fer2raXMG1XtHSV2+vZnkIV87OPAxuf2NiDj1W5hN7Q2MYUfQQ8w==
 
-"@styled-system/css@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@styled-system/css/-/css-1.0.3.tgz#34e24d585707a796b6e8940466c26f5a6761b8c1"
-  integrity sha512-YXT8+00hFo/zk4oZeHxbysNgUc1wEYrTjpRreFIJxF6vgNkqg+fu70jmyP2JQ7f2I9C+Ssvg7GZ+RSp50RfosA==
-  dependencies:
-    lodash.flatten "^4.4.0"
-    lodash.isobject "^3.0.2"
-    lodash.merge "^4.6.1"
-    lodash.omit "^4.5.0"
-    lodash.pick "^4.4.0"
-    lodash.pickby "^4.6.0"
-    styled-system "^4.1.0-0"
-
 "@styled-system/css@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@styled-system/css/-/css-2.0.0.tgz#1cdb89182ddec16fab63d088093917df3745179b"
@@ -7116,7 +7103,7 @@ lodash.filter@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.filter/-/lodash.filter-4.6.0.tgz#668b1d4981603ae1cc5a6fa760143e480b4c4ace"
   integrity sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4=
 
-lodash.flatten@^4.2.0, lodash.flatten@^4.4.0:
+lodash.flatten@^4.2.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
   integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
@@ -7140,11 +7127,6 @@ lodash.isnumber@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
   integrity sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=
-
-lodash.isobject@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash.isobject/-/lodash.isobject-3.0.2.tgz#3c8fb8d5b5bf4bf90ae06e14f2a530a4ed935e1d"
-  integrity sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0=
 
 lodash.kebabcase@^4.1.1:
   version "4.1.1"
@@ -7176,15 +7158,10 @@ lodash.omit@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
   integrity sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=
 
-lodash.pick@^4.2.1, lodash.pick@^4.4.0:
+lodash.pick@^4.2.1:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
   integrity sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=
-
-lodash.pickby@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.pickby/-/lodash.pickby-4.6.0.tgz#7dea21d8c18d7703a27c704c15d3b84a67e33aff"
-  integrity sha1-feoh2MGNdwOifHBMFdO4SmfjOv8=
 
 lodash.reduce@^4.4.0:
   version "4.6.0"
@@ -10624,7 +10601,7 @@ style-to-object@^0.2.1:
   dependencies:
     css "2.2.4"
 
-styled-system@^4.1.0, styled-system@^4.1.0-0:
+styled-system@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/styled-system/-/styled-system-4.1.0.tgz#e5a58be23b89cf8fb7b181c8e425ab107b166693"
   integrity sha512-ioIAJ029tRr6eJhiUrE3VZeahN+GBuJHv/jmckkfikY4ej8BaxvIKAaavmjFoqzNsIzr+x5HCpry1ybQYpchtQ==
@@ -10770,19 +10747,6 @@ text-table@0.2.0, text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
-
-theme-ui@^0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/theme-ui/-/theme-ui-0.0.8.tgz#6ac447da552b8e9a7cd35dfb1e68294504139db7"
-  integrity sha512-sT53Ntd/9bpZZyiS+/BGW4fPQ4u9AvNCALKOzor+dLTRYXyhHWD9LULPNb/MhXIszMEwLKTkEqF/BLPTIGytbw==
-  dependencies:
-    "@styled-system/css" "^1.0.3"
-    css-what "^2.1.3"
-    jest-emotion "^10.0.10"
-    lodash.get "^4.4.2"
-    lodash.merge "^4.6.1"
-    styled-system "^4.1.0"
-    typography "^0.16.19"
 
 throat@^4.0.0:
   version "4.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1112,18 +1112,12 @@
   resolved "https://registry.yarnpkg.com/@stefanprobst/lokijs/-/lokijs-1.5.6-b.tgz#6a36a86dbe132e702e6b15ffd3ce4139aebfe942"
   integrity sha512-MNodHp46og+Sdde/LCxTLrxcD5Dimu21R/Fer2raXMG1XtHSV2+vZnkIV87OPAxuf2NiDj1W5hN7Q2MYUfQQ8w==
 
-"@styled-system/css@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@styled-system/css/-/css-1.0.3.tgz#34e24d585707a796b6e8940466c26f5a6761b8c1"
-  integrity sha512-YXT8+00hFo/zk4oZeHxbysNgUc1wEYrTjpRreFIJxF6vgNkqg+fu70jmyP2JQ7f2I9C+Ssvg7GZ+RSp50RfosA==
+"@styled-system/css@^2.0.0-0":
+  version "2.0.0-0"
+  resolved "https://registry.yarnpkg.com/@styled-system/css/-/css-2.0.0-0.tgz#f4cd62e3d86ef553a7ed34cffa031d559705d2c9"
+  integrity sha512-nVmeJxLqXH7tW8B+0V3IHkLNRET9y1tzIUXo5++HW6BJ8trUhH7V5711iyBBvKy8nK0DgyCZH/GbeHLVCfmOYA==
   dependencies:
-    lodash.flatten "^4.4.0"
-    lodash.isobject "^3.0.2"
-    lodash.merge "^4.6.1"
-    lodash.omit "^4.5.0"
-    lodash.pick "^4.4.0"
-    lodash.pickby "^4.6.0"
-    styled-system "^4.1.0-0"
+    lodash.get "^4.4.2"
 
 "@styled-system/edit@^0.0.4":
   version "0.0.4"
@@ -7134,7 +7128,7 @@ lodash.filter@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.filter/-/lodash.filter-4.6.0.tgz#668b1d4981603ae1cc5a6fa760143e480b4c4ace"
   integrity sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4=
 
-lodash.flatten@^4.2.0, lodash.flatten@^4.4.0:
+lodash.flatten@^4.2.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
   integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
@@ -7158,11 +7152,6 @@ lodash.isnumber@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
   integrity sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=
-
-lodash.isobject@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash.isobject/-/lodash.isobject-3.0.2.tgz#3c8fb8d5b5bf4bf90ae06e14f2a530a4ed935e1d"
-  integrity sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0=
 
 lodash.kebabcase@^4.1.1:
   version "4.1.1"
@@ -7194,15 +7183,10 @@ lodash.omit@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
   integrity sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=
 
-lodash.pick@^4.2.1, lodash.pick@^4.4.0:
+lodash.pick@^4.2.1:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
   integrity sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=
-
-lodash.pickby@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.pickby/-/lodash.pickby-4.6.0.tgz#7dea21d8c18d7703a27c704c15d3b84a67e33aff"
-  integrity sha1-feoh2MGNdwOifHBMFdO4SmfjOv8=
 
 lodash.reduce@^4.4.0:
   version "4.6.0"
@@ -10642,7 +10626,7 @@ style-to-object@^0.2.1:
   dependencies:
     css "2.2.4"
 
-styled-system@^4.1.0, styled-system@^4.1.0-0:
+styled-system@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/styled-system/-/styled-system-4.1.0.tgz#e5a58be23b89cf8fb7b181c8e425ab107b166693"
   integrity sha512-ioIAJ029tRr6eJhiUrE3VZeahN+GBuJHv/jmckkfikY4ej8BaxvIKAaavmjFoqzNsIzr+x5HCpry1ybQYpchtQ==


### PR DESCRIPTION
Uses new implementation of `@styled-system/css` package (see https://github.com/styled-system/extras/pull/17), which doesn't rely on the core styled-system package and *should* generally be faster