### PR TITLE
Use pragma directly

### DIFF
--- a/theme-ui/layout.js
+++ b/theme-ui/layout.js
@@ -1,4 +1,3 @@
-/** @jsx jsx */
 import { jsx } from './index'
 import styled from '@emotion/styled'
 import {
@@ -34,52 +33,52 @@ export const Flex = styled(Box)({
 
 // root/page layout
 export const Layout = props =>
-  <Box
-    {...props}
-    css={{
+  jsx(Box, {
+    ...props,
+    css: {
       minHeight: '100vh',
       display: 'flex',
       flexDirection: 'column',
-    }}
-  />
+    }
+  })
 
 export const Header = props =>
-  <Box
-    as='header'
-    {...props}
-    css={{
+  jsx(Box, {
+    as: 'header'
+    ...props,
+    css: {
       display: 'flex',
-    }}
-  />
+    }
+  })
 
 export const Main = props =>
-  <Box
-    {...props}
-    css={{
+  jsx(Box, {
+    ...props,
+    css: {
       flex: '1 1 auto',
-    }}
-  />
+    }
+  })
 
 export const Container = props =>
-  <Box
-    {...props}
-    css={{
+  jsx(Box, {
+    ...props,
+    css: {
       width: '100%',
       minWidth: 0,
       maxWidth: 1024,
       mx: 'auto',
       p: 4,
-    }}
-  />
+    }
+  })
 
 export const Footer = props =>
-  <Box
-    as='footer'
-    {...props}
-    css={{
+  jsx(Box, {
+    as: 'footer'
+    ...props,
+    css: {
       display: 'flex',
-    }}
-  />
+    }
+  })
 
 // todo
 // export const Sidebar


### PR DESCRIPTION
Current implementations using theme-ui are transpiling
theme-ui directly which causes gatsby-plugin-emotion to
override the jsx pragma. This uses the pragma directly
so that we can ensure this doesn't happen.