### PR TITLE
Add color modes and useColorMode hook

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,4 +15,4 @@ jobs:
           paths:
             - node_modules
           key: v2-dependencies-{{ checksum "package.json" }}
-      - run: yarn test
+      - run: yarn test --coverage

--- a/docs/src/components/button.js
+++ b/docs/src/components/button.js
@@ -1,0 +1,23 @@
+/** @jsx jsx */
+import { jsx } from 'theme-ui'
+
+export default props =>
+  <button
+    {...props}
+    css={{
+      appearance: 'none',
+      fontFamily: 'inherit',
+      fontSize: 1,
+      fontWeight: 'bold',
+      m: 0,
+      px: 2,
+      py: 2,
+      color: 'text',
+      bg: 'muted',
+      border: 0,
+      borderRadius: 2,
+      ':focus': {
+        outline: '2px solid',
+      }
+    }}
+  />

--- a/docs/src/components/header.js
+++ b/docs/src/components/header.js
@@ -15,7 +15,7 @@ const modes = [
 ]
 
 export default props => {
-  const [ mode, setMode ] = useColorMode('light')
+  const [ mode, setMode ] = useColorMode()
 
   const cycleMode = e => {
     const i = modes.indexOf(mode)

--- a/docs/src/components/header.js
+++ b/docs/src/components/header.js
@@ -1,18 +1,44 @@
 /** @jsx jsx */
-import { jsx, Header, Box, Container, } from 'theme-ui'
+import {
+  jsx,
+  Header,
+  Box,
+  Container,
+  useColorMode,
+} from 'theme-ui'
 import NavLink from './nav-link'
 
-export default props =>
-  <Header>
-    <Container
-      css={{
-        display: 'flex',
-        alignItems: 'center',
-      }}>
-      <NavLink to='/'>Theme UI</NavLink>
-      <Box mx='auto' />
-      <NavLink href='https://github.com/system-ui/theme-ui'>GitHub</NavLink>
-      <NavLink to='/demo'>Demo</NavLink>
-      {props.children}
-    </Container>
-  </Header>
+const modes = [
+  'light',
+  'dark',
+]
+
+export default props => {
+  const [ mode, setMode ] = useColorMode('light')
+
+  const cycleMode = e => {
+    const i = modes.indexOf(mode)
+    const next = modes[(i + 1) % modes.length]
+    setMode(next)
+  }
+
+  return (
+    <Header>
+      <Container
+        css={{
+          display: 'flex',
+          alignItems: 'center',
+        }}>
+        <NavLink to='/'>Theme UI</NavLink>
+        <Box mx='auto' />
+        <NavLink href='https://github.com/system-ui/theme-ui'>GitHub</NavLink>
+        <NavLink to='/demo'>Demo</NavLink>
+        {props.children}
+        <button
+          onClick={cycleMode}>
+          {mode}
+        </button>
+      </Container>
+    </Header>
+  )
+}

--- a/docs/src/components/header.js
+++ b/docs/src/components/header.js
@@ -33,7 +33,6 @@ export default props => {
         <NavLink to='/'>Theme UI</NavLink>
         <Box mx='auto' />
         <NavLink href='https://github.com/system-ui/theme-ui'>GitHub</NavLink>
-        <NavLink to='/demo'>Demo</NavLink>
         <Button
           css={{
             ml: 2,

--- a/docs/src/components/header.js
+++ b/docs/src/components/header.js
@@ -2,46 +2,16 @@
 import {
   jsx,
   Header,
-  Box,
   Container,
-  useColorMode,
 } from 'theme-ui'
-import NavLink from './nav-link'
-import Button from './button'
 
-const modes = [
-  'light',
-  'dark',
-]
-
-export default props => {
-  const [ mode, setMode ] = useColorMode()
-
-  const cycleMode = e => {
-    const i = modes.indexOf(mode)
-    const next = modes[(i + 1) % modes.length]
-    setMode(next)
-  }
-
-  return (
-    <Header>
-      <Container
-        css={{
-          display: 'flex',
-          alignItems: 'center',
-        }}>
-        <NavLink to='/'>Theme UI</NavLink>
-        <Box mx='auto' />
-        <NavLink href='https://github.com/system-ui/theme-ui'>GitHub</NavLink>
-        <Button
-          css={{
-            ml: 2,
-          }}
-          onClick={cycleMode}>
-          {mode}
-        </Button>
-        {props.children}
-      </Container>
-    </Header>
-  )
-}
+export default props =>
+  <Header>
+    <Container
+      css={{
+        display: 'flex',
+        alignItems: 'center',
+      }}>
+      {props.children}
+    </Container>
+  </Header>

--- a/docs/src/components/header.js
+++ b/docs/src/components/header.js
@@ -7,6 +7,7 @@ import {
   useColorMode,
 } from 'theme-ui'
 import NavLink from './nav-link'
+import Button from './button'
 
 const modes = [
   'light',
@@ -33,11 +34,14 @@ export default props => {
         <Box mx='auto' />
         <NavLink href='https://github.com/system-ui/theme-ui'>GitHub</NavLink>
         <NavLink to='/demo'>Demo</NavLink>
-        {props.children}
-        <button
+        <Button
+          css={{
+            ml: 2,
+          }}
           onClick={cycleMode}>
           {mode}
-        </button>
+        </Button>
+        {props.children}
       </Container>
     </Header>
   )

--- a/docs/src/components/layout.js
+++ b/docs/src/components/layout.js
@@ -10,6 +10,7 @@ import {
 import { useState } from 'react'
 import { Global } from '@emotion/core'
 
+import SkipLink from './skip-link'
 import Header from './header'
 import Footer from './footer'
 import Sidebar from './sidebar'
@@ -31,6 +32,9 @@ export default ({ header, ...props }) => {
           }
         }}
       />
+      <SkipLink>
+        Skip to content
+      </SkipLink>
       <Layout>
         <Header>
           {header}
@@ -45,16 +49,16 @@ export default ({ header, ...props }) => {
             css={{
               display: 'flex',
             }}>
+            <Box id='content'>
+              {props.children}
+              <Pagination />
+            </Box>
             <Sidebar
               open={menuOpen}
               onClick={e => {
                 setMenuOpen(false)
               }}
             />
-            <Box>
-              {props.children}
-              <Pagination />
-            </Box>
           </Container>
         </Main>
         <Footer />

--- a/docs/src/components/layout.js
+++ b/docs/src/components/layout.js
@@ -6,8 +6,9 @@ import {
   Main,
   Box,
   Container,
+  useColorMode,
 } from 'theme-ui'
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 import { Global } from '@emotion/core'
 
 import SkipLink from './skip-link'
@@ -16,9 +17,24 @@ import Footer from './footer'
 import Sidebar from './sidebar'
 import Pagination from './pagination'
 import MenuButton from './menu-button'
+import NavLink from './nav-link'
+import Button from './button'
 
-export default ({ header, ...props }) => {
+const modes = [
+  'light',
+  'dark',
+]
+
+export default props => {
   const [ menuOpen, setMenuOpen ] = useState(false)
+  const [ mode, setMode ] = useColorMode()
+  const nav = useRef(null)
+
+  const cycleMode = e => {
+    const i = modes.indexOf(mode)
+    const next = modes[(i + 1) % modes.length]
+    setMode(next)
+  }
 
   return (
     <Styled.root>
@@ -37,12 +53,24 @@ export default ({ header, ...props }) => {
       </SkipLink>
       <Layout>
         <Header>
-          {header}
           <MenuButton
             onClick={e => {
               setMenuOpen(!menuOpen)
+              if (!nav.current) return
+              const navLink = nav.current.querySelector('a')
+              if (navLink) navLink.focus()
             }}
           />
+          <NavLink to='/'>Theme UI</NavLink>
+          <Box mx='auto' />
+          <NavLink href='https://github.com/system-ui/theme-ui'>GitHub</NavLink>
+          <Button
+            css={{
+              ml: 2,
+            }}
+            onClick={cycleMode}>
+            {mode}
+          </Button>
         </Header>
         <Main>
           <Container
@@ -51,6 +79,7 @@ export default ({ header, ...props }) => {
               display: 'flex',
             }}>
             <Sidebar
+              ref={nav}
               open={menuOpen}
               onFocus={e => {
                 setMenuOpen(true)

--- a/docs/src/components/layout.js
+++ b/docs/src/components/layout.js
@@ -47,18 +47,25 @@ export default ({ header, ...props }) => {
         <Main>
           <Container
             css={{
+              p: 0,
               display: 'flex',
             }}>
-            <Box id='content'>
-              {props.children}
-              <Pagination />
-            </Box>
             <Sidebar
               open={menuOpen}
+              onFocus={e => {
+                setMenuOpen(true)
+              }}
+              onBlur={e => {
+                setMenuOpen(false)
+              }}
               onClick={e => {
                 setMenuOpen(false)
               }}
             />
+            <Box id='content' px={3}>
+              {props.children}
+              <Pagination />
+            </Box>
           </Container>
         </Main>
         <Footer />

--- a/docs/src/components/menu-button.js
+++ b/docs/src/components/menu-button.js
@@ -17,6 +17,7 @@ const Burger = ({ size = '1em' }) =>
 
 export default props =>
   <button
+    title='Toggle Menu'
     {...props}
     css={{
       fontFamily: 'inherit',

--- a/docs/src/components/menu-button.js
+++ b/docs/src/components/menu-button.js
@@ -26,7 +26,6 @@ export default props =>
       bg: 'transparent',
       p: 0,
       m: 0,
-      ml: 3,
       border: 0,
       appearance: 'none',
       ':focus': {

--- a/docs/src/components/nav-link.js
+++ b/docs/src/components/nav-link.js
@@ -1,18 +1,32 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
 import { Link } from 'gatsby'
+import isAbsoluteURL from 'is-absolute-url'
 
 const styles = {
   display: 'inline-block',
   px: 2,
-  py: 3,
+  py: 2,
   color: 'inherit',
   textDecoration: 'none',
   fontWeight: 'bold',
+  '&.active': {
+    color: 'primary',
+  },
 }
 
-export default props => !!props.to ? (
-  <Link {...props} css={styles} />
-) : (
-  <a {...props} css={styles} />
-)
+export default ({ href, ...props }) => {
+  const isExternal = isAbsoluteURL(href || '')
+  if (isExternal) {
+    return <a {...props} href={href} css={styles} />
+  }
+  const to = props.to || href
+  return (
+    <Link
+      {...props}
+      to={to}
+      css={styles}
+      activeClassName='active'
+    />
+  )
+}

--- a/docs/src/components/pagination.js
+++ b/docs/src/components/pagination.js
@@ -28,9 +28,19 @@ const Pagination = props => {
 
   return (
     <Flex py={4} mx={-2}>
-      {hasPagination && previous && <NavLink {...previous.props} />}
+      {hasPagination && previous && (
+        <NavLink
+          to={previous.props.href}
+          children={previous.props.children}
+        />
+      )}
       <Box mx='auto' />
-      {hasPagination && next && <NavLink {...next.props} />}
+      {hasPagination && next && (
+        <NavLink
+          to={next.props.href}
+          children={next.props.children}
+        />
+      )}
     </Flex>
   )
 }

--- a/docs/src/components/root.js
+++ b/docs/src/components/root.js
@@ -1,14 +1,16 @@
 /** @jsx jsx */
-import { jsx, ThemeProvider } from 'theme-ui'
+import { jsx, ColorModeProvider, ThemeProvider } from 'theme-ui'
 import theme from './theme'
 import components from './mdx-components'
 
 export default props => {
   return (
-    <ThemeProvider
-      components={components}
-      theme={theme}>
-      {props.children}
-    </ThemeProvider>
+    <ColorModeProvider initialColorMode='light'>
+      <ThemeProvider
+        components={components}
+        theme={theme}>
+        {props.children}
+      </ThemeProvider>
+    </ColorModeProvider>
   )
 }

--- a/docs/src/components/sidebar.js
+++ b/docs/src/components/sidebar.js
@@ -1,42 +1,68 @@
 /** @jsx jsx */
+import React from 'react'
 import { jsx, Box } from 'theme-ui'
+import { MDXProvider } from '@mdx-js/react'
+import NavLink from './nav-link'
 import Content from '../sidebar.mdx'
 
-export default props =>
-  <Box {...props}
-    css={{
-      position: 'sticky',
-      top: 0,
-      minWidth: 0,
-      width: [ 256 ],
-      flex: 'none',
-      px: 3,
-      py: 3,
-      maxHeight: '100vh',
-      overflow: 'auto',
-      WebkitOverflowScrolling: 'touch',
-      '@media screen and (max-width: 39.99em)': {
-        bg: 'background',
-        marginLeft: -256,
-        transition: 'transform .2s ease-out',
-        transform: props.open ? 'translateX(100%)' : 'translateX(0)',
-      },
-      ul: {
-        listStyle: 'none',
-        m: 0,
-        p: 0,
-      },
-      a: {
-        display: 'block',
-        px: 2,
-        py: 1,
-        fontWeight: 'bold',
-        color: 'inherit',
-        textDecoration: 'none',
-        '&.active': {
-          color: 'primary',
+const components = {
+  a: NavLink,
+}
+
+export default React.forwardRef((props, ref) =>
+  <>
+    {props.open && (
+      <Box
+        onClick={props.onClick}
+        css={{
+          position: 'fixed',
+          top: 0,
+          right: 0,
+          bottom: 0,
+          left: 0,
+        }}
+      />
+    )}
+    <Box
+      {...props}
+      ref={ref}
+      css={{
+        position: 'sticky',
+        top: 0,
+        minWidth: 0,
+        width: [ 256 ],
+        flex: 'none',
+        px: 3,
+        py: 3,
+        maxHeight: '100vh',
+        overflow: 'auto',
+        WebkitOverflowScrolling: 'touch',
+        '@media screen and (max-width: 39.99em)': {
+          bg: 'background',
+          marginLeft: -256,
+          transition: 'transform .2s ease-out',
+          transform: props.open ? 'translateX(100%)' : 'translateX(0)',
+        },
+        ul: {
+          listStyle: 'none',
+          m: 0,
+          p: 0,
+        },
+        __a: {
+          display: 'block',
+          px: 2,
+          py: 1,
+          fontWeight: 'bold',
+          color: 'inherit',
+          textDecoration: 'none',
+          '&.active': {
+            color: 'primary',
+          }
         }
-      }
-    }}>
-    <Content />
-  </Box>
+      }}>
+      <MDXProvider components={components}>
+        <Content />
+      </MDXProvider>
+    </Box>
+  </>
+)

--- a/docs/src/components/sidebar.js
+++ b/docs/src/components/sidebar.js
@@ -47,17 +47,6 @@ export default React.forwardRef((props, ref) =>
           listStyle: 'none',
           m: 0,
           p: 0,
-        },
-        __a: {
-          display: 'block',
-          px: 2,
-          py: 1,
-          fontWeight: 'bold',
-          color: 'inherit',
-          textDecoration: 'none',
-          '&.active': {
-            color: 'primary',
-          }
         }
       }}>
       <MDXProvider components={components}>

--- a/docs/src/components/sidebar.js
+++ b/docs/src/components/sidebar.js
@@ -31,6 +31,7 @@ const theme = {
 export default props =>
   <Box {...props}
     css={{
+      order: -1,
       position: 'sticky',
       top: 0,
       minWidth: 0,

--- a/docs/src/components/sidebar.js
+++ b/docs/src/components/sidebar.js
@@ -1,6 +1,11 @@
 /** @jsx jsx */
 import { jsx, Box, ThemeProvider } from 'theme-ui'
+import { Link } from 'gatsby'
 import Content from '../sidebar.mdx'
+
+const components = {
+  a: ({ href, ...props }) => <Link {...props} to={href} activeClassName='active' />,
+}
 
 const theme = {
   styles: {
@@ -16,6 +21,9 @@ const theme = {
       fontWeight: 'bold',
       color: 'inherit',
       textDecoration: 'none',
+      '&.active': {
+        color: 'primary',
+      }
     }
   }
 }
@@ -39,7 +47,9 @@ export default props =>
         transform: props.open ? 'translateX(100%)' : 'translateX(0)',
       }
     }}>
-    <ThemeProvider theme={theme}>
+      <ThemeProvider
+        components={components}
+        theme={theme}>
       <Content />
     </ThemeProvider>
   </Box>

--- a/docs/src/components/sidebar.js
+++ b/docs/src/components/sidebar.js
@@ -30,7 +30,7 @@ export default React.forwardRef((props, ref) =>
         position: 'sticky',
         top: 0,
         minWidth: 0,
-        width: [ 256 ],
+        width: 256,
         flex: 'none',
         px: 3,
         py: 3,

--- a/docs/src/components/sidebar.js
+++ b/docs/src/components/sidebar.js
@@ -1,56 +1,42 @@
 /** @jsx jsx */
-import { jsx, Box, ThemeProvider } from 'theme-ui'
-import { Link } from 'gatsby'
+import { jsx, Box } from 'theme-ui'
 import Content from '../sidebar.mdx'
-
-const components = {
-  a: ({ href, ...props }) => <Link {...props} to={href} activeClassName='active' />,
-}
-
-const theme = {
-  styles: {
-    ul: {
-      listStyle: 'none',
-      m: 0,
-      p: 0,
-    },
-    a: {
-      display: 'block',
-      px: 2,
-      py: 1,
-      fontWeight: 'bold',
-      color: 'inherit',
-      textDecoration: 'none',
-      '&.active': {
-        color: 'primary',
-      }
-    }
-  }
-}
 
 export default props =>
   <Box {...props}
     css={{
-      order: -1,
       position: 'sticky',
       top: 0,
       minWidth: 0,
-      width: [ '100%', 256 ],
+      width: [ 256 ],
       flex: 'none',
+      px: 3,
       py: 3,
       maxHeight: '100vh',
       overflow: 'auto',
       WebkitOverflowScrolling: 'touch',
       '@media screen and (max-width: 39.99em)': {
         bg: 'background',
-        marginLeft: '-100%',
+        marginLeft: -256,
         transition: 'transform .2s ease-out',
         transform: props.open ? 'translateX(100%)' : 'translateX(0)',
+      },
+      ul: {
+        listStyle: 'none',
+        m: 0,
+        p: 0,
+      },
+      a: {
+        display: 'block',
+        px: 2,
+        py: 1,
+        fontWeight: 'bold',
+        color: 'inherit',
+        textDecoration: 'none',
+        '&.active': {
+          color: 'primary',
+        }
       }
     }}>
-      <ThemeProvider
-        components={components}
-        theme={theme}>
-      <Content />
-    </ThemeProvider>
+    <Content />
   </Box>

--- a/docs/src/components/skip-link.js
+++ b/docs/src/components/skip-link.js
@@ -1,0 +1,32 @@
+/** @jsx jsx */
+import { jsx } from 'theme-ui'
+
+export default props =>
+  <a
+    children='Skip to content'
+    {...props}
+    href='#content'
+    css={{
+      clip: 'rect(0 0 0 0)',
+      height: 1,
+      width: 1,
+      m: -1,
+      p: 0,
+      overrflow: 'hidden',
+      position: 'absolute',
+      ':focus': {
+        p: 3,
+        position: 'fixed',
+        zIndex: 4,
+        top: 0,
+        left: 0,
+        m: 2,
+        fontWeight: 'bold',
+        color: 'black',
+        bg: 'white',
+        width: 'auto',
+        height: 'auto',
+        clip: 'auto',
+      }
+    }}
+  />

--- a/docs/src/components/theme.js
+++ b/docs/src/components/theme.js
@@ -21,12 +21,12 @@ export default {
     modes: {
       dark: {
         text: '#fff',
-        background: '#111',
-        primary: '#39f',
-        secondary: '#c0f',
+        background: '#060606',
+        primary: '#3cf',
+        secondary: '#e0f',
         muted: '#191919',
         highlight: '#ffffcc',
-        gray: '#777',
+        gray: '#999',
         purple: '#c0f',
       }
     },

--- a/docs/src/components/theme.js
+++ b/docs/src/components/theme.js
@@ -18,6 +18,18 @@ export default {
       text: 'inherit',
       background: 'inherit',
     },
+    modes: {
+      dark: {
+        text: '#fff',
+        background: '#111',
+        primary: '#39f',
+        secondary: '#c0f',
+        muted: '#191919',
+        highlight: '#ffffcc',
+        gray: '#777',
+        purple: '#c0f',
+      }
+    },
   },
   fonts: {
     body: 'system-ui, sans-serif',
@@ -113,7 +125,7 @@ export default {
         py: '4px',
         pr: '4px',
         pl: 0,
-        borderColor: 'inherit',
+        borderColor: 'muted',
         borderBottomStyle: 'solid'
       },
     },

--- a/docs/src/components/typography-layout.js
+++ b/docs/src/components/typography-layout.js
@@ -6,6 +6,7 @@ import merge from 'lodash.merge'
 
 import Layout from './layout'
 import GoogleFonts from './google-fonts'
+import Button from './button'
 import themes from './typography-themes'
 import createTypographyStyles from 'theme-ui/typography'
 import typographyThemes from './typography-themes'
@@ -55,7 +56,9 @@ export default props => {
 
   return (
     <Layout {...props}>
-      <Flex py={4}>
+      <Flex
+        py={4}
+        alignItems='center'>
         <ThemeSelect
           name='theme'
           value={themeName}
@@ -63,13 +66,16 @@ export default props => {
             setTheme(e.target.value)
           }}
         />
-        <button
+        <Button
+          css={{
+            ml: 2,
+          }}
           onClick={e => {
             const i = (themeNames.indexOf(themeName) + 1) % themeNames.length
             setTheme(themeNames[i])
           }}>
           Next
-        </button>
+        </Button>
       </Flex>
       <ThemeProvider theme={theme}>
         <GoogleFonts />

--- a/docs/src/components/typography-layout.js
+++ b/docs/src/components/typography-layout.js
@@ -1,4 +1,5 @@
 /** @jsx jsx */
+import React from 'react'
 import { jsx, ThemeProvider } from 'theme-ui'
 import { useState } from 'react'
 import merge from 'lodash.merge'

--- a/docs/src/components/typography-layout.js
+++ b/docs/src/components/typography-layout.js
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import React from 'react'
-import { jsx, ThemeProvider } from 'theme-ui'
+import { jsx, ThemeProvider, Flex, } from 'theme-ui'
 import { useState } from 'react'
 import merge from 'lodash.merge'
 
@@ -52,35 +52,29 @@ export default props => {
     styles: typography.styles,
     typography
   })
-  const children = (
-    <ThemeProvider theme={theme}>
-      <GoogleFonts />
-      {props.children}
-    </ThemeProvider>
-  )
 
   return (
-    <Layout
-      {...props}
-      children={children}
-      header={(
-        <>
-          <ThemeSelect
-            name='theme'
-            value={themeName}
-            onChange={e => {
-              setTheme(e.target.value)
-            }}
-          />
-          <button
-            onClick={e => {
-              const i = (themeNames.indexOf(themeName) + 1) % themeNames.length
-              setTheme(themeNames[i])
-            }}>
-            Next
-          </button>
-        </>
-      )}
-    />
+    <Layout {...props}>
+      <Flex py={4}>
+        <ThemeSelect
+          name='theme'
+          value={themeName}
+          onChange={e => {
+            setTheme(e.target.value)
+          }}
+        />
+        <button
+          onClick={e => {
+            const i = (themeNames.indexOf(themeName) + 1) % themeNames.length
+            setTheme(themeNames[i])
+          }}>
+          Next
+        </button>
+      </Flex>
+      <ThemeProvider theme={theme}>
+        <GoogleFonts />
+        {props.children}
+      </ThemeProvider>
+    </Layout>
   )
 }

--- a/docs/src/components/typography-layout.js
+++ b/docs/src/components/typography-layout.js
@@ -1,5 +1,4 @@
 /** @jsx jsx */
-import React from 'react'
 import { jsx, ThemeProvider } from 'theme-ui'
 import { useState } from 'react'
 import merge from 'lodash.merge'

--- a/docs/src/pages/color-modes.mdx
+++ b/docs/src/pages/color-modes.mdx
@@ -28,6 +28,28 @@ In the `theme.colors` object, add a nested `modes` object that will contain keys
 }
 ```
 
+## Color mode state
+
+To use color modes, import the `ColorModeProvider` component and wrap it around your outer most `ThemeProvider` component.
+Initialize the state with the `initialColorMode` prop.
+
+```jsx
+import React from 'react'
+import {
+  ColorModeProvider,
+  ThemeProvider,
+} from 'theme-ui'
+import theme from './theme'
+
+export default props =>
+  <ColorModeProvider
+    initialColorMode='light'>
+    <ThemeProvider theme={theme}>
+      {props.children}
+    </ThemeProvider>
+  </ColorModeProvider>
+```
+
 ## Setting the color mode
 
 Use the `useColorMode` hook in your application to change the color mode,

--- a/docs/src/pages/color-modes.mdx
+++ b/docs/src/pages/color-modes.mdx
@@ -52,8 +52,7 @@ export default props =>
 
 ## Setting the color mode
 
-Use the `useColorMode` hook in your application to change the color mode,
-passing the initial color mode as the first argument to the hook.
+Use the `useColorMode` hook in your application to change the color mode.
 This value will be stored in `localStorage` and used whenever the page is loaded.
 
 ```jsx
@@ -61,7 +60,7 @@ import React from 'react'
 import { useColorMode } from 'theme-ui'
 
 export default props => {
-  const [ colorMode, setColorMode ] = useColorMode('light')
+  const [ colorMode, setColorMode ] = useColorMode()
   return (
     <header>
       <button
@@ -75,6 +74,47 @@ export default props => {
     </header>
   )
 }
+```
+
+## Applying colors
+
+The previous steps will enable a color mode state and pass it through context.
+To use the color values, add them to a components styles or use the Emotion `Global` component.
+
+```jsx
+// example using color mode values
+import React from 'react'
+import { css } from 'theme-ui'
+
+export default props =>
+  <div
+    css={css({
+      color: 'text',
+      bg: 'background',
+    })}>
+    {props.children}
+  </div>
+```
+
+```jsx
+// example using Global
+import React from 'react'
+import { css } from 'theme-ui'
+import { Global } from '@emotion/core'
+
+export default props =>
+  <>
+    <Global
+      styles={css({
+        body: {
+          margin: 0,
+          color: 'text',
+          bg: 'background',
+        }
+      })}
+    />
+    {props.children}
+  </>
 ```
 
 ## Caveats

--- a/docs/src/pages/color-modes.mdx
+++ b/docs/src/pages/color-modes.mdx
@@ -117,6 +117,8 @@ export default props =>
   </>
 ```
 
-## Caveats
+## `(prefers-color-scheme: dark)` media query
 
-- This feature does not yet pick up values from the `(prefers-color-scheme: dark)` media query
+This feature will detect the `(prefers-color-scheme: dark)` media query to initialize the state as `dark`.
+Currently it does *not* check for `(prefers-color-scheme: light)`.
+

--- a/docs/src/pages/color-modes.mdx
+++ b/docs/src/pages/color-modes.mdx
@@ -1,30 +1,60 @@
+import Layout from '../components/layout'
+
+export default Layout
 
 # Color Modes
 
-**WIP – not yet implemented**
+Color modes can be used to create a user-configurable dark mode or any number of other color modes.
 
-```jsx
-<ThemeProvider
-  theme={theme}
-  colorMode='dark'>
-  {props.children}
-</ThemeProvider>
+## Defining colors
+
+In the `theme.colors` object, add a nested `modes` object that will contain keys for the non-default color palette mode.
+
+```js
+// example theme colors
+{
+  colors: {
+    text: '#000',
+    background: '#fff',
+    primary: '#07c',
+    modes: {
+      dark: {
+        text: '#fff',
+        background: '#000',
+        primary: '#0cf',
+      }
+    }
+  }
+}
 ```
+
+## Setting the color mode
+
+Use the `useColorMode` hook in your application to change the color mode,
+passing the initial color mode as the first argument to the hook.
+This value will be stored in `localStorage` and used whenever the page is loaded.
 
 ```jsx
 import React from 'react'
 import { useColorMode } from 'theme-ui'
 
 export default props => {
-  const [ mode, setMode ] = useColorMode('light')
-
+  const [ colorMode, setColorMode ] = useColorMode('light')
   return (
-    <button
-      onClick={e => {
-        setMode(mode === 'dark' ? 'light' : 'dark')
-      }}>
-      Toggle color mode
-    </button>
+    <header>
+      <button
+        onClick={e => {
+          setColorMode(colorMode === 'light' ? 'dark' : 'light')
+        }}>
+        Toggle
+        {' '}
+        {colorMode === 'light' ? 'Dark' : 'Light'}
+      </button>
+    </header>
   )
 }
 ```
+
+## Caveats
+
+- This feature does not yet pick up values from the `(prefers-color-scheme: dark)` media query

--- a/docs/src/pages/theming.mdx
+++ b/docs/src/pages/theming.mdx
@@ -43,7 +43,7 @@ colors: {
 }
 ```
 
-**Note:** a mechanism for controlling color modes has not yet been implemented.
+See the [color mode docs](/color-modes) for more information.
 
 ## Typography
 

--- a/docs/src/sidebar.mdx
+++ b/docs/src/sidebar.mdx
@@ -4,5 +4,6 @@
 - [Demo](/demo)
 - [Typography](/typography)
 - [Color](/color)
+- [Color Modes](/color-modes)
 - [Components](/components)
 - [Custom Pragma](/custom-pragma)

--- a/docs/src/sidebar.mdx
+++ b/docs/src/sidebar.mdx
@@ -1,10 +1,10 @@
 
 - [Theming](/theming)
 - [Layout](/layout)
+- [Color Modes](/color-modes)
 - [Demo](/demo)
 - [Typography](/typography)
 - [Color](/color)
-- [Color Modes](/color-modes)
 - [Components](/components)
 - [Custom Pragma](/custom-pragma)
 - [GitHub](https://github.com/system-ui/theme-ui)

--- a/docs/src/sidebar.mdx
+++ b/docs/src/sidebar.mdx
@@ -7,3 +7,4 @@
 - [Color Modes](/color-modes)
 - [Components](/components)
 - [Custom Pragma](/custom-pragma)
+- [GitHub](https://github.com/system-ui/theme-ui)

--- a/theme-ui/package.json
+++ b/theme-ui/package.json
@@ -8,6 +8,7 @@
   "repository": "system-ui/theme-ui",
   "scripts": {
     "prepare": "microbundle --no-compress",
+    "watch": "microbundle watch --no-compress",
     "test": "jest"
   },
   "dependencies": {

--- a/theme-ui/package.json
+++ b/theme-ui/package.json
@@ -40,6 +40,14 @@
     "coverageReporters": [
       "lcov",
       "html"
-    ]
+    ],
+    "coverageThreshold": {
+      "global": {
+        "branches": 90,
+        "functions": 90,
+        "lines": 90,
+        "statements": 90
+      }
+    }
   }
 }

--- a/theme-ui/package.json
+++ b/theme-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "theme-ui",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "author": "Brent Jackson <jxnblk@gmail.com>",

--- a/theme-ui/package.json
+++ b/theme-ui/package.json
@@ -32,6 +32,7 @@
     "jest-emotion": "^10.0.10",
     "microbundle": "^0.11.0",
     "react-test-renderer": "^16.8.6",
+    "react-testing-library": "^7.0.0",
     "typography-theme-wordpress-2016": "^0.16.19"
   },
   "jest": {

--- a/theme-ui/src/context.js
+++ b/theme-ui/src/context.js
@@ -1,0 +1,9 @@
+import { createContext, useContext } from 'react'
+import { components } from './components'
+
+export const Context = createContext({
+  theme: {},
+  components,
+})
+
+export const useThemeUI = () => useContext(Context)

--- a/theme-ui/src/core.js
+++ b/theme-ui/src/core.js
@@ -32,6 +32,7 @@ export const ThemeProvider = ({
       colors: get(modes, context.colorMode, context.theme.colors)
     })
   }
+  console.log(outer, context.components, context.theme)
 
   return (
     jsx(EmotionProvider, { theme: context.theme },

--- a/theme-ui/src/core.js
+++ b/theme-ui/src/core.js
@@ -12,33 +12,8 @@ import merge from 'lodash.merge'
 import get from 'lodash.get'
 import jsx from './jsx'
 import themed from './themed'
-import { components } from './components'
-
-export const Context = createContext({
-  theme: {},
-  components,
-})
-
-export const useThemeUI = () => useContext(Context)
-
-export const useColorMode = (initialMode) => {
-  const { colorMode, setColorMode } = useThemeUI()
-  return [ colorMode, setColorMode ]
-}
-
-const STORAGE_KEY = '__theme-ui-color-mode'
-const useColorModeState = (initialMode, args = []) => {
-  const [ colorMode, setColorMode ] = useState(initialMode)
-  useLayoutEffect(() => {
-    const storedMode = window.localStorage.getItem(STORAGE_KEY)
-    if (storedMode !== colorMode) setColorMode(storedMode)
-  }, [])
-  useEffect(() => {
-    window.localStorage.setItem(STORAGE_KEY, colorMode)
-  }, [colorMode])
-
-  return { colorMode, setColorMode }
-}
+import { useColorState } from './use-color-mode'
+import { Context, useThemeUI } from './context'
 
 const createComponents = (components = {}) => {
   const next = {}
@@ -53,7 +28,7 @@ export const ThemeProvider = ({
   components,
   ...props
 }) => {
-  const { colorMode, setColorMode } = useColorModeState()
+  const [ colorMode, setColorMode ] = useColorState()
   const outer = useThemeUI()
   const context = merge({}, outer, {
     theme,

--- a/theme-ui/src/core.js
+++ b/theme-ui/src/core.js
@@ -32,7 +32,6 @@ export const ThemeProvider = ({
       colors: get(modes, context.colorMode, context.theme.colors)
     })
   }
-  console.log(outer, context.components, context.theme)
 
   return (
     jsx(EmotionProvider, { theme: context.theme },

--- a/theme-ui/src/core.js
+++ b/theme-ui/src/core.js
@@ -1,10 +1,3 @@
-import {
-  createContext,
-  useContext,
-  useState,
-  useEffect,
-  useLayoutEffect
-} from 'react'
 import styled from '@emotion/styled'
 import { ThemeProvider as EmotionProvider } from 'emotion-theming'
 import { MDXProvider } from '@mdx-js/react'

--- a/theme-ui/src/core.js
+++ b/theme-ui/src/core.js
@@ -5,7 +5,6 @@ import merge from 'lodash.merge'
 import get from 'lodash.get'
 import jsx from './jsx'
 import themed from './themed'
-import { useColorState } from './use-color-mode'
 import { Context, useThemeUI } from './context'
 
 const createComponents = (components = {}) => {
@@ -22,19 +21,15 @@ export const ThemeProvider = ({
   ...props
 }) => {
   const outer = useThemeUI()
-  const [ colorMode, setColorMode ] = useColorState(outer.colorMode)
-  const context = merge({
-    colorMode,
-    setColorMode,
-  }, outer, {
+  const context = merge({}, outer, {
     theme,
     components: createComponents(components),
   })
 
-  if (colorMode) {
+  if (context.colorMode) {
     const modes = get(context.theme, 'colors.modes', {})
     context.theme = merge({}, context.theme, {
-      colors: get(modes, colorMode, context.theme.colors)
+      colors: get(modes, context.colorMode, context.theme.colors)
     })
   }
 

--- a/theme-ui/src/core.js
+++ b/theme-ui/src/core.js
@@ -21,18 +21,20 @@ export const ThemeProvider = ({
   components,
   ...props
 }) => {
-  const [ colorMode, setColorMode ] = useColorState()
   const outer = useThemeUI()
-  const context = merge({}, outer, {
-    theme,
-    components: createComponents(components),
+  const [ colorMode, setColorMode ] = useColorState(outer.colorMode)
+  const context = merge({
     colorMode,
     setColorMode,
+  }, outer, {
+    theme,
+    components: createComponents(components),
   })
 
   if (colorMode) {
+    const modes = get(context.theme, 'colors.modes', {})
     context.theme = merge({}, context.theme, {
-      colors: get(context.theme.colors.modes, colorMode, context.theme.colors)
+      colors: get(modes, colorMode, context.theme.colors)
     })
   }
 

--- a/theme-ui/src/core.js
+++ b/theme-ui/src/core.js
@@ -1,8 +1,9 @@
-import { createContext, useContext } from 'react'
+import { createContext, useContext, useState } from 'react'
 import styled from '@emotion/styled'
 import { ThemeProvider as EmotionProvider } from 'emotion-theming'
 import { MDXProvider } from '@mdx-js/react'
 import merge from 'lodash.merge'
+import get from 'lodash.get'
 import jsx from './jsx'
 import themed from './themed'
 import { components } from './components'
@@ -11,6 +12,13 @@ export const Context = createContext({
   theme: {},
   components,
 })
+
+export const useThemeUI = () => useContext(Context)
+
+export const useColorMode = () => {
+  const { colorMode, setColorMode } = useThemeUI()
+  return [ colorMode, setColorMode ]
+}
 
 const createComponents = (components = {}) => {
   const next = {}
@@ -25,11 +33,20 @@ export const ThemeProvider = ({
   components,
   ...props
 }) => {
-  const outer = useContext(Context)
+  const [ colorMode, setColorMode ] = useState()
+  const outer = useThemeUI()
   const context = merge({}, outer, {
     theme,
     components: createComponents(components),
+    colorMode,
+    setColorMode,
   })
+
+  if (colorMode) {
+    context.theme = merge({}, context.theme, {
+      colors: get(context.theme.colors.modes, colorMode, context.theme.colors)
+    })
+  }
 
   return (
     jsx(EmotionProvider, { theme: context.theme },

--- a/theme-ui/src/core.js
+++ b/theme-ui/src/core.js
@@ -1,4 +1,10 @@
-import { createContext, useContext, useState } from 'react'
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useLayoutEffect
+} from 'react'
 import styled from '@emotion/styled'
 import { ThemeProvider as EmotionProvider } from 'emotion-theming'
 import { MDXProvider } from '@mdx-js/react'
@@ -15,9 +21,23 @@ export const Context = createContext({
 
 export const useThemeUI = () => useContext(Context)
 
-export const useColorMode = () => {
+export const useColorMode = (initialMode) => {
   const { colorMode, setColorMode } = useThemeUI()
   return [ colorMode, setColorMode ]
+}
+
+const STORAGE_KEY = '__theme-ui-color-mode'
+const useColorModeState = (initialMode, args = []) => {
+  const [ colorMode, setColorMode ] = useState(initialMode)
+  useLayoutEffect(() => {
+    const storedMode = window.localStorage.getItem(STORAGE_KEY)
+    if (storedMode !== colorMode) setColorMode(storedMode)
+  }, [])
+  useEffect(() => {
+    window.localStorage.setItem(STORAGE_KEY, colorMode)
+  }, [colorMode])
+
+  return { colorMode, setColorMode }
 }
 
 const createComponents = (components = {}) => {
@@ -33,7 +53,7 @@ export const ThemeProvider = ({
   components,
   ...props
 }) => {
-  const [ colorMode, setColorMode ] = useState()
+  const { colorMode, setColorMode } = useColorModeState()
   const outer = useThemeUI()
   const context = merge({}, outer, {
     theme,

--- a/theme-ui/src/index.js
+++ b/theme-ui/src/index.js
@@ -2,7 +2,7 @@ export { css } from '@styled-system/css'
 export { jsx } from './jsx'
 export { ThemeProvider } from './core'
 export { Context, useThemeUI } from './context'
-export { useColorMode } from './use-color-mode'
+export { ColorModeProvider, useColorMode } from './use-color-mode'
 export { Styled } from './components'
 export {
   Box,

--- a/theme-ui/src/index.js
+++ b/theme-ui/src/index.js
@@ -1,6 +1,11 @@
 export { css } from '@styled-system/css'
 export { jsx } from './jsx'
-export { Context, ThemeProvider } from './core'
+export {
+  Context,
+  ThemeProvider,
+  useThemeUI,
+  useColorMode,
+} from './core'
 export { Styled } from './components'
 export {
   Box,

--- a/theme-ui/src/index.js
+++ b/theme-ui/src/index.js
@@ -1,11 +1,8 @@
 export { css } from '@styled-system/css'
 export { jsx } from './jsx'
-export {
-  Context,
-  ThemeProvider,
-  useThemeUI,
-  useColorMode,
-} from './core'
+export { ThemeProvider } from './core'
+export { Context, useThemeUI } from './context'
+export { useColorMode } from './use-color-mode'
 export { Styled } from './components'
 export {
   Box,

--- a/theme-ui/src/use-color-mode.js
+++ b/theme-ui/src/use-color-mode.js
@@ -11,8 +11,8 @@ const STORAGE_KEY = 'theme-ui-color-mode'
 const get = (init) => window.localStorage.getItem(STORAGE_KEY) || init
 const set = (value) => window.localStorage.setItem(STORAGE_KEY, value)
 
-export const useColorState = () => {
-  const [ mode, setMode ] = useState()
+export const useColorState = (initialMode) => {
+  const [ mode, setMode ] = useState(initialMode)
 
   useLayoutEffect(() => {
     const stored = get()
@@ -34,10 +34,10 @@ export const ColorModeProvider = ({
 }) => {
   const outer = useThemeUI()
   const [ colorMode, setColorMode ] = useColorState(initialColorMode)
-  const context = merge({}, outer, {
+  const context = merge({
     colorMode,
     setColorMode,
-  })
+  }, outer)
   return (
     <Context.Provider
       value={context}
@@ -46,7 +46,7 @@ export const ColorModeProvider = ({
   )
 }
 
-export const useColorMode = (initialMode) => {
+export const useColorMode = () => {
   const { colorMode, setColorMode } = useThemeUI()
 
   if (typeof setColorMode !== 'function') {
@@ -59,7 +59,7 @@ export const useColorMode = (initialMode) => {
 
   // initialize
   useEffect(() => {
-    const init = get(initialMode)
+    const init = get()
     if (!init || init === colorMode) return
     setColorMode(init)
   }, [])

--- a/theme-ui/src/use-color-mode.js
+++ b/theme-ui/src/use-color-mode.js
@@ -11,12 +11,24 @@ const STORAGE_KEY = 'theme-ui-color-mode'
 const get = (init) => window.localStorage.getItem(STORAGE_KEY) || init
 const set = (value) => window.localStorage.setItem(STORAGE_KEY, value)
 
+const getMediaQuery = () => {
+  const darkQuery = '(prefers-color-scheme: dark)'
+  const mql = window.matchMedia ? window.matchMedia(darkQuery) : {}
+  const dark = mql.media === darkQuery
+  return dark && mql.matches
+}
+
 export const useColorState = (initialMode) => {
   const [ mode, setMode ] = useState(initialMode)
 
   useLayoutEffect(() => {
     const stored = get()
-    if (!stored  || stored === mode) return
+    const dark = getMediaQuery()
+    if (dark) {
+      setMode('dark')
+      return
+    }
+    if (!stored || stored === mode) return
     setMode(stored)
   }, [])
 

--- a/theme-ui/src/use-color-mode.js
+++ b/theme-ui/src/use-color-mode.js
@@ -3,29 +3,13 @@ import React, {
   useEffect,
   useLayoutEffect,
 } from 'react'
+import merge from 'lodash.merge'
 import { Context, useThemeUI } from './context'
 
 const STORAGE_KEY = 'theme-ui-color-mode'
 
 const get = (init) => window.localStorage.getItem(STORAGE_KEY) || init
 const set = (value) => window.localStorage.setItem(STORAGE_KEY, value)
-
-export const ColorModeProvider = ({
-  initialColorMode,
-  children
-}) => {
-  const [ colorMode, setColorMode ] = useColorState(initialColorMode)
-  const context = {
-    colorMode,
-    setColorMode,
-  }
-  return (
-    <Context.Provider
-      value={context}
-      children={children}
-    />
-  )
-}
 
 export const useColorState = () => {
   const [ mode, setMode ] = useState()
@@ -42,6 +26,24 @@ export const useColorState = () => {
   }, [ mode ])
 
   return [ mode, setMode ]
+}
+
+export const ColorModeProvider = ({
+  initialColorMode,
+  children
+}) => {
+  const outer = useThemeUI()
+  const [ colorMode, setColorMode ] = useColorState(initialColorMode)
+  const context = merge({}, outer, {
+    colorMode,
+    setColorMode,
+  })
+  return (
+    <Context.Provider
+      value={context}
+      children={children}
+    />
+  )
 }
 
 export const useColorMode = (initialMode) => {

--- a/theme-ui/src/use-color-mode.js
+++ b/theme-ui/src/use-color-mode.js
@@ -1,14 +1,31 @@
-import {
+import React, {
   useState,
   useEffect,
   useLayoutEffect,
 } from 'react'
-import { useThemeUI } from './context'
+import { Context, useThemeUI } from './context'
 
 const STORAGE_KEY = 'theme-ui-color-mode'
 
 const get = (init) => window.localStorage.getItem(STORAGE_KEY) || init
 const set = (value) => window.localStorage.setItem(STORAGE_KEY, value)
+
+export const ColorModeProvider = ({
+  initialColorMode,
+  children
+}) => {
+  const [ colorMode, setColorMode ] = useColorState(initialColorMode)
+  const context = {
+    colorMode,
+    setColorMode,
+  }
+  return (
+    <Context.Provider
+      value={context}
+      children={children}
+    />
+  )
+}
 
 export const useColorState = () => {
   const [ mode, setMode ] = useState()
@@ -29,6 +46,14 @@ export const useColorState = () => {
 
 export const useColorMode = (initialMode) => {
   const { colorMode, setColorMode } = useThemeUI()
+
+  if (typeof setColorMode !== 'function') {
+    // todo
+    console.warn(
+      `useColorMode requires the ColorModeProvider`
+    )
+    return []
+  }
 
   // initialize
   useEffect(() => {

--- a/theme-ui/src/use-color-mode.js
+++ b/theme-ui/src/use-color-mode.js
@@ -11,7 +11,7 @@ const get = (init) => window.localStorage.getItem(STORAGE_KEY) || init
 const set = (value) => window.localStorage.setItem(STORAGE_KEY, value)
 
 export const useColorState = () => {
-  const [ mode, setMode ] = useState(get())
+  const [ mode, setMode ] = useState()
 
   useLayoutEffect(() => {
     const stored = get()

--- a/theme-ui/src/use-color-mode.js
+++ b/theme-ui/src/use-color-mode.js
@@ -1,0 +1,43 @@
+import {
+  useState,
+  useEffect,
+  useLayoutEffect,
+} from 'react'
+import { useThemeUI } from './context'
+
+const STORAGE_KEY = 'theme-ui-color-mode'
+
+const get = (init) => window.localStorage.getItem(STORAGE_KEY) || init
+const set = (value) => window.localStorage.setItem(STORAGE_KEY, value)
+
+export const useColorState = () => {
+  const [ mode, setMode ] = useState(get())
+
+  useLayoutEffect(() => {
+    const stored = get()
+    if (!stored  || stored === mode) return
+    setMode(stored)
+  }, [])
+
+  useEffect(() => {
+    if (!mode) return
+    set(mode)
+  }, [ mode ])
+
+  return [ mode, setMode ]
+}
+
+export const useColorMode = (initialMode) => {
+  const { colorMode, setColorMode } = useThemeUI()
+
+  // initialize
+  useEffect(() => {
+    const init = get(initialMode)
+    if (!init || init === colorMode) return
+    setColorMode(init)
+  }, [])
+
+  return [ colorMode, setColorMode ]
+}
+
+export default useColorMode

--- a/theme-ui/src/use-color-mode.js
+++ b/theme-ui/src/use-color-mode.js
@@ -62,9 +62,8 @@ export const useColorMode = () => {
   const { colorMode, setColorMode } = useThemeUI()
 
   if (typeof setColorMode !== 'function') {
-    // todo
-    console.warn(
-      `useColorMode requires the ColorModeProvider`
+    throw new Error(
+      `[useColorMode] requires the ColorModeProvider component`
     )
     return []
   }

--- a/theme-ui/test/__snapshots__/layout.js.snap
+++ b/theme-ui/test/__snapshots__/layout.js.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders Box 1`] = `
+<div
+  className="css-1xi4blx"
+/>
+`;
+
+exports[`renders Container 1`] = `
+<div
+  className="css-1uc3ui9"
+/>
+`;
+
+exports[`renders Flex 1`] = `
+<div
+  className="css-80zs6q"
+/>
+`;
+
+exports[`renders Footer 1`] = `
+<footer
+  className="css-80zs6q"
+/>
+`;
+
+exports[`renders Header 1`] = `
+<header
+  className="css-80zs6q"
+/>
+`;
+
+exports[`renders Layout 1`] = `
+<div
+  className="css-1eiazfv"
+/>
+`;
+
+exports[`renders Main 1`] = `
+<div
+  className="css-3url3g"
+/>
+`;

--- a/theme-ui/test/color-modes.js
+++ b/theme-ui/test/color-modes.js
@@ -187,3 +187,45 @@ test('retains initial context', () => {
   expect(context.components.pre).toBeTruthy()
   expect(context.components.blockquote).toBeTruthy()
 })
+
+test('initializes mode from prefers-color-scheme media query', () => {
+  window.matchMedia = jest.fn().mockImplementation(query => {
+    return {
+      matches: true,
+      media: query,
+    }
+  })
+  let mode
+  const Consumer = props => {
+    const [ colorMode ] = useColorMode()
+    mode = colorMode
+    return false
+  }
+  render(
+    <ColorModeProvider>
+      <Consumer />
+    </ColorModeProvider>
+  )
+  expect(mode).toBe('dark')
+})
+
+test('does not initialize mode from prefers-color-scheme media query', () => {
+  window.matchMedia = jest.fn().mockImplementation(query => {
+    return {
+      matches: false,
+      media: query,
+    }
+  })
+  let mode
+  const Consumer = props => {
+    const [ colorMode ] = useColorMode()
+    mode = colorMode
+    return false
+  }
+  render(
+    <ColorModeProvider>
+      <Consumer />
+    </ColorModeProvider>
+  )
+  expect(mode).toBe(undefined)
+})

--- a/theme-ui/test/color-modes.js
+++ b/theme-ui/test/color-modes.js
@@ -133,6 +133,7 @@ test('initializes mode based on localStorage', () => {
       <Button />
     </ThemeProvider>
   )
-  console.log(window.localStorage.getItem(STORAGE_KEY))
   expect(mode).toBe('dark')
 })
+
+test.todo('inherits color mode state from parent context')

--- a/theme-ui/test/color-modes.js
+++ b/theme-ui/test/color-modes.js
@@ -1,0 +1,138 @@
+/** @jsx jsx */
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { render, fireEvent, cleanup, act } from 'react-testing-library'
+import { matchers } from 'jest-emotion'
+import {
+  jsx,
+  ThemeProvider,
+  useColorMode,
+} from '../src/index'
+
+const STORAGE_KEY = 'theme-ui-color-mode'
+
+afterEach(cleanup)
+beforeEach(() => {
+  localStorage.removeItem(STORAGE_KEY)
+})
+expect.extend(matchers)
+
+test('renders with color modes', () => {
+  let json
+  let mode
+  const Mode = props => {
+    const [ colorMode ] = useColorMode('light')
+    mode = colorMode
+    return (
+      <div>
+        Mode
+      </div>
+    )
+  }
+  renderer.act(() => {
+    renderer.create(
+      <ThemeProvider>
+        <Mode />
+      </ThemeProvider>
+    )
+  })
+  expect(mode).toBe('light')
+})
+
+test('useColorMode updates color mode state', () => {
+  let mode
+  const Button = props => {
+    const [ colorMode, setMode ] = useColorMode('light')
+    mode = colorMode
+    return (
+      <button
+        onClick={e => {
+          setMode('dark')
+        }}
+        children='test'
+      />
+    )
+  }
+  const tree = render(
+    <ThemeProvider>
+      <Button />
+    </ThemeProvider>
+  )
+  const button = tree.getByText('test')
+  fireEvent.click(button)
+  expect(mode).toBe('dark')
+})
+
+test('color mode is passed through theme context', () => {
+  let mode
+  const Button = props => {
+    const [ colorMode, setMode ] = useColorMode('light')
+    mode = colorMode
+    return (
+      <button
+        css={{
+          color: 'text'
+        }}
+        onClick={e => {
+          setMode('dark')
+        }}
+        children='test'
+      />
+    )
+  }
+  const tree = render(
+    <ThemeProvider
+      theme={{
+        colors: {
+          text: '#000',
+          modes: {
+            dark: {
+              text: 'cyan'
+            }
+          }
+        }
+      }}>
+      <Button />
+    </ThemeProvider>
+  )
+  const button = tree.getByText('test')
+  button.click()
+  expect(mode).toBe('dark')
+  expect(tree.getByText('test')).toHaveStyleRule('color', 'cyan')
+})
+
+test('does not initialize mode', () => {
+  let mode
+  const Button = props => {
+    const [ colorMode, setMode ] = useColorMode()
+    mode = colorMode
+    return (
+      <button children='test' />
+    )
+  }
+  const tree = render(
+    <ThemeProvider>
+      <Button />
+    </ThemeProvider>
+  )
+  expect(mode).toBe(undefined)
+})
+
+test('initializes mode based on localStorage', () => {
+  window.localStorage.setItem(STORAGE_KEY, 'dark')
+  let mode
+  const Button = props => {
+    const [ colorMode, setMode ] = useColorMode()
+    mode = colorMode
+    return (
+      <button children='test' />
+    )
+  }
+  const tree = render(
+    <ThemeProvider>
+      <Button />
+    </ThemeProvider>
+  )
+  console.log(window.localStorage.getItem(STORAGE_KEY))
+  expect(mode).toBe('dark')
+})

--- a/theme-ui/test/index.js
+++ b/theme-ui/test/index.js
@@ -1,6 +1,6 @@
 /** @jsx mdx */
 import { mdx } from '@mdx-js/react'
-import { useContext } from 'react'
+import React, { useContext } from 'react'
 import renderer from 'react-test-renderer'
 import { matchers } from 'jest-emotion'
 import {
@@ -8,6 +8,7 @@ import {
   Context,
   Styled,
   jsx,
+  useColorMode,
 } from '../src/index'
 
 expect.extend(matchers)

--- a/theme-ui/test/layout.js
+++ b/theme-ui/test/layout.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import {
+  Box,
+  Flex,
+  Layout,
+  Main,
+  Container,
+  Header,
+  Footer
+} from '../src/layout'
+
+test.each([
+  [ 'Box', Box ],
+  [ 'Flex', Flex ],
+  [ 'Layout', Layout ],
+  [ 'Main', Main ],
+  [ 'Container', Container ],
+  [ 'Header', Header ],
+  [ 'Footer', Footer ],
+])('renders %s', (a, Component) => {
+  const json = renderer.create(
+    <Component />
+  ).toJSON()
+  expect(json).toMatchSnapshot()
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1321,6 +1321,11 @@
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-12.0.12.tgz#45dd1d0638e8c8f153e87d296907659296873916"
   integrity sha512-SOhuU4wNBxhhTHxYaiG5NY4HBhDIDnJF60GU+2LqHAdKKer86//e4yg69aENCtQ04n0ovz+tq2YPME5t5yp4pw==
 
+"@use-it/event-listener@^0.1.2":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@use-it/event-listener/-/event-listener-0.1.3.tgz#a9920b2819d211cf55e68e830997546eec6886d3"
+  integrity sha512-UCHkLOVU+xj3/1R8jXz8GzDTowkzfIDPESOBlVC2ndgwUSBEqiFdwCoUEs2lcGhJOOiEdmWxF+T23C5+60eEew==
+
 "@webassemblyjs/ast@1.7.11":
   version "1.7.11"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.7.11.tgz#b988582cafbb2b095e8b556526f30c90d057cace"
@@ -13196,6 +13201,13 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-persisted-state@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/use-persisted-state/-/use-persisted-state-0.3.0.tgz#f8e3d2fd8eee67e0c86fd596c3ea3e8121c07402"
+  integrity sha512-UlWEq0JYg7NbvcRBZ1g6Bwe4SEbYfr1wr/D5mrmfCzSxXSwsPRYygGLlsxHcW58Rf7gGwRPBT23sNVvyVn4WYg==
+  dependencies:
+    "@use-it/event-listener" "^0.1.2"
 
 use@^3.1.0:
   version "3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1321,11 +1321,6 @@
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-12.0.12.tgz#45dd1d0638e8c8f153e87d296907659296873916"
   integrity sha512-SOhuU4wNBxhhTHxYaiG5NY4HBhDIDnJF60GU+2LqHAdKKer86//e4yg69aENCtQ04n0ovz+tq2YPME5t5yp4pw==
 
-"@use-it/event-listener@^0.1.2":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@use-it/event-listener/-/event-listener-0.1.3.tgz#a9920b2819d211cf55e68e830997546eec6886d3"
-  integrity sha512-UCHkLOVU+xj3/1R8jXz8GzDTowkzfIDPESOBlVC2ndgwUSBEqiFdwCoUEs2lcGhJOOiEdmWxF+T23C5+60eEew==
-
 "@webassemblyjs/ast@1.7.11":
   version "1.7.11"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.7.11.tgz#b988582cafbb2b095e8b556526f30c90d057cace"
@@ -13201,13 +13196,6 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
-
-use-persisted-state@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/use-persisted-state/-/use-persisted-state-0.3.0.tgz#f8e3d2fd8eee67e0c86fd596c3ea3e8121c07402"
-  integrity sha512-UlWEq0JYg7NbvcRBZ1g6Bwe4SEbYfr1wr/D5mrmfCzSxXSwsPRYygGLlsxHcW58Rf7gGwRPBT23sNVvyVn4WYg==
-  dependencies:
-    "@use-it/event-listener" "^0.1.2"
 
 use@^3.1.0:
   version "3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1100,6 +1100,11 @@
     react-lifecycles-compat "^3.0.4"
     warning "^3.0.0"
 
+"@sheerun/mutationobserver-shim@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz#8013f2af54a2b7d735f71560ff360d3a8176a87b"
+  integrity sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==
+
 "@stefanprobst/lokijs@^1.5.6-b":
   version "1.5.6-b"
   resolved "https://registry.yarnpkg.com/@stefanprobst/lokijs/-/lokijs-1.5.6-b.tgz#6a36a86dbe132e702e6b15ffd3ce4139aebfe942"
@@ -4051,6 +4056,16 @@ dom-serializer@0, dom-serializer@~0.1.0:
   dependencies:
     domelementtype "^1.3.0"
     entities "^1.1.1"
+
+dom-testing-library@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/dom-testing-library/-/dom-testing-library-4.1.0.tgz#273264e62e9e63f4e404f7349ddd7b9356aacd23"
+  integrity sha512-654GHd0oPC31S+ll1bJH9NUOBRzcHcrf23/XzJh41o6g67uGUpF9tn23qmbcwjNauoRqKQfAdHCDwr/Ez/Ot7A==
+  dependencies:
+    "@babel/runtime" "^7.4.3"
+    "@sheerun/mutationobserver-shim" "^0.3.2"
+    pretty-format "^24.7.0"
+    wait-for-expect "^1.1.1"
 
 dom-walk@^0.1.0:
   version "0.1.1"
@@ -7184,6 +7199,11 @@ jest-leak-detector@^24.8.0:
   dependencies:
     pretty-format "^24.8.0"
 
+jest-localstorage-mock@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/jest-localstorage-mock/-/jest-localstorage-mock-2.4.0.tgz#c6073810735dd3af74020ea6c3885ec1cc6d0d13"
+  integrity sha512-/mC1JxnMeuIlAaQBsDMilskC/x/BicsQ/BXQxEOw+5b1aGZkkOAqAF3nu8yq449CpzGtp5jJ5wCmDNxLgA2m6A==
+
 jest-matcher-utils@^24.8.0:
   version "24.8.0"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-24.8.0.tgz#2bce42204c9af12bde46f83dc839efe8be832495"
@@ -10164,7 +10184,7 @@ pretty-error@^2.1.1:
     renderkid "^2.0.1"
     utila "~0.4"
 
-pretty-format@^24.8.0:
+pretty-format@^24.7.0, pretty-format@^24.8.0:
   version "24.8.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.8.0.tgz#8dae7044f58db7cb8be245383b565a963e3c27f2"
   integrity sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==
@@ -10532,6 +10552,14 @@ react-test-renderer@^16.8.6:
     prop-types "^15.6.2"
     react-is "^16.8.6"
     scheduler "^0.13.6"
+
+react-testing-library@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/react-testing-library/-/react-testing-library-7.0.0.tgz#d3b535e44de94d7b0a83c56cd2e3cfed752dcec1"
+  integrity sha512-8SHqwG+uhN9VhAgNVkVa3f7VjTw/L5CIaoAxKmy+EZuDQ6O+VsfcpRAyUw3MDL1h8S/gGrEiazmHBVL/uXsftA==
+  dependencies:
+    "@babel/runtime" "^7.4.3"
+    dom-testing-library "^4.0.0"
 
 react@^16.8.0, react@^16.8.6:
   version "16.8.6"
@@ -13316,6 +13344,11 @@ w3c-hr-time@^1.0.1:
   integrity sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=
   dependencies:
     browser-process-hrtime "^0.1.2"
+
+wait-for-expect@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-1.1.1.tgz#9cd10e07d52810af9e0aaf509872e38f3c3d81ae"
+  integrity sha512-vd9JOqqEcBbCDhARWhW85ecjaEcfBLuXgVBqatfS3iw6oU4kzAcs+sCNjF+TC9YHPImCW7ypsuQc+htscIAQCw==
 
 walker@^1.0.7, walker@~1.0.5:
   version "1.0.7"


### PR DESCRIPTION
This adds a color mode state to the ThemeProvider, allowing end users to change this state with the `useColorMode` hook. This is similar to the implementation in `use-dark-mode` but custom built to better support how theme-ui works with Emotion's theme context and its own internal context. This PR also includes updates to the docs

- [x] Add tests for nested ThemeProviders
- [x] Add support for initialization from the `(prefers-color-scheme: dark)` media query