### PR TITLE
Add inherit prop to ThemeProvider

### DIFF
--- a/theme-ui/src/core.js
+++ b/theme-ui/src/core.js
@@ -18,13 +18,16 @@ const createComponents = (components = {}) => {
 export const ThemeProvider = ({
   theme,
   components,
+  inherit,
   ...props
 }) => {
   const outer = useThemeUI()
   const context = merge({}, outer, {
     theme,
     components: createComponents(components),
-  })
+  },
+    inherit ? outer : null
+  )
 
   if (context.colorMode) {
     const modes = get(context.theme, 'colors.modes', {})

--- a/theme-ui/test/index.js
+++ b/theme-ui/test/index.js
@@ -8,6 +8,7 @@ import {
   Context,
   Styled,
   jsx,
+  css,
   useColorMode,
 } from '../src/index'
 
@@ -118,4 +119,30 @@ test('custom pragma adds styles', () => {
   expect(json).toHaveStyleRule('margin-right', 'auto')
   expect(json).toHaveStyleRule('padding', '8px')
   expect(json).toHaveStyleRule('background-color', 'tomato')
+})
+
+test('outer context overrides inner context with inherit prop', () => {
+  const json = renderJSON(
+    <ThemeProvider
+      theme={{
+        colors: {
+          primary: 'tomato'
+        }
+      }}>
+      <ThemeProvider
+        inherit
+        theme={{
+          colors: {
+            primary: 'blue'
+          }
+        }}>
+        {jsx('div', {
+          css: {
+            color: 'primary'
+          }
+        })}
+      </ThemeProvider>
+    </ThemeProvider>
+  )
+  expect(json).toHaveStyleRule('color', 'tomato')
 })


### PR DESCRIPTION
This allows parent ThemeProvider components to override child ThemeProviders' `theme` object – there's probably a better approach for this, but using this for trying out different ways to handle overriding themes