### PR TITLE
Converted bold and italics to aliases

### DIFF
--- a/packages/theme-ui/src/components.js
+++ b/packages/theme-ui/src/components.js
@@ -4,8 +4,6 @@ import themed from './themed'
 
 const tags = [
   'p',
-  'b',
-  'i',
   'a',
   'h1',
   'h2',
@@ -42,6 +40,8 @@ const aliases = {
   inlineCode: 'code',
   thematicBreak: 'hr',
   root: 'div',
+  strong: 'b',
+  em: 'i',
 }
 
 const alias = n => aliases[n] || n

--- a/packages/theme-ui/src/components.js
+++ b/packages/theme-ui/src/components.js
@@ -19,7 +19,6 @@ const tags = [
   'li',
   'blockquote',
   'hr',
-  'em',
   'table',
   'tr',
   'th',


### PR DESCRIPTION
1. Removed bold and italics from individual components array 
2. Created aliases for bold and italics with `strong` and `em` respectively
3. Removed the extra `em` in components array