### PR TITLE
Add hooks to documentation

### DIFF
--- a/packages/docs/src/pages/hooks.mdx
+++ b/packages/docs/src/pages/hooks.mdx
@@ -15,8 +15,9 @@ import React from 'react'
 import { useThemeUI } from 'theme-ui'
 
 export default props => {
-  const { theme } = useTheme
-  ...
+  const { theme } = useThemeUI()
+
+  return <pre>{JSON.stringify(theme, null, 2)}</pre>
 }
 ```
 

--- a/packages/docs/src/pages/hooks.mdx
+++ b/packages/docs/src/pages/hooks.mdx
@@ -1,0 +1,22 @@
+import Layout from '../components/layout'
+
+export default Layout
+
+# Hooks
+
+If you are interested in learning more about how React Hooks work please see the official React docs [here](https://reactjs.org/docs/hooks-intro.html). 
+
+## `useThemeUI`
+
+To access the `theme` object directly in a component, you can use the `useThemeUI` hook.
+
+```jsx
+import React from 'react'
+import { useThemeUI } from 'theme-ui'
+
+export default props => {
+  const { theme } = useTheme
+  ...
+}
+```
+

--- a/packages/docs/src/sidebar.mdx
+++ b/packages/docs/src/sidebar.mdx
@@ -8,6 +8,7 @@
 - [Theme Spec](/theme-spec)
 - [Gatsby Plugin](/gatsby-plugin)
 - [Custom Pragma](/custom-pragma)
+- [Hooks](/hooks)
 - [How it Works](/how-it-works)
 - [Motivation](/motivation)
 - [Demo](/demo)

--- a/packages/theme-ui/README.md
+++ b/packages/theme-ui/README.md
@@ -229,8 +229,9 @@ import React from 'react'
 import { useThemeUI } from 'theme-ui'
 
 export default props => {
-  const { theme } = useTheme
-  ...
+  const { theme } = useThemeUI()
+
+  return <pre>{JSON.stringify(theme, null, 2)}</pre>
 }
 ``
 

--- a/packages/theme-ui/README.md
+++ b/packages/theme-ui/README.md
@@ -233,7 +233,7 @@ export default props => {
 
   return <pre>{JSON.stringify(theme, null, 2)}</pre>
 }
-``
+```
 
 ## Layout Components
 

--- a/packages/theme-ui/README.md
+++ b/packages/theme-ui/README.md
@@ -216,6 +216,24 @@ To change the underlying component in `Styled`, use the `as` prop.
 <Styled.a as={Link} to='/'>Home</Styled.a>
 ```
 
+## Hooks
+
+If you are interested in learning more about how React Hooks work please see the official React docs [here](https://reactjs.org/docs/hooks-intro.html). 
+
+### `useThemeUI`
+
+To access the `theme` object directly in a component, you can use the `useThemeUI` hook.
+
+```jsx
+import React from 'react'
+import { useThemeUI } from 'theme-ui'
+
+export default props => {
+  const { theme } = useTheme
+  ...
+}
+``
+
 ## Layout Components
 
 Theme UI includes several components for creating page layouts.

--- a/packages/theme-ui/README.md
+++ b/packages/theme-ui/README.md
@@ -216,25 +216,6 @@ To change the underlying component in `Styled`, use the `as` prop.
 <Styled.a as={Link} to='/'>Home</Styled.a>
 ```
 
-## Hooks
-
-If you are interested in learning more about how React Hooks work please see the official React docs [here](https://reactjs.org/docs/hooks-intro.html). 
-
-### `useThemeUI`
-
-To access the `theme` object directly in a component, you can use the `useThemeUI` hook.
-
-```jsx
-import React from 'react'
-import { useThemeUI } from 'theme-ui'
-
-export default props => {
-  const { theme } = useThemeUI()
-
-  return <pre>{JSON.stringify(theme, null, 2)}</pre>
-}
-```
-
 ## Layout Components
 
 Theme UI includes several components for creating page layouts.


### PR DESCRIPTION
Hello 👋 Thank you for building this awesome library - I have really been enjoying it so far and look forward to building more things with it in the future. 

One thing that came recently was that I wanted to access the theme object directly... and after poking around the source code I found the `useThemeUI` hook which worked perfectly. I noticed there wasn't any documentation on this so I have created a PR. I've written a little bit on info, but I'm sure you might want to tweak it 👍