### PR TITLE
Add new layout component: Grid

### DIFF
--- a/packages/docs/src/pages/layout.mdx
+++ b/packages/docs/src/pages/layout.mdx
@@ -49,6 +49,23 @@ export default props => (
 )
 ```
 
+## Grid
+
+The `Grid` layout component is similar to the `Flex` component but uses CSS Grid instead of flexbox.
+
+```jsx
+import React from 'react'
+import { Box, Grid } from 'theme-ui'
+
+export default props => (
+  <Grid p="2" gridTemplateColumns="repeat(3, 1fr)" gridGap="2">
+    <Box />
+    <Box />
+    <Box />
+  </Grid>
+)
+```
+
 ## Layout Theming
 
 These page layout components can be styled with the `theme.styles` object, similar to how other MDX components can be styled.

--- a/packages/theme-ui/src/index.js
+++ b/packages/theme-ui/src/index.js
@@ -4,7 +4,16 @@ export { ThemeProvider } from './core'
 export { Context, useThemeUI } from './context'
 export { ColorMode, useColorMode } from './color-modes'
 export { Styled, components } from './components'
-export { Box, Flex, Layout, Header, Main, Container, Footer } from './layout'
+export {
+  Box,
+  Flex,
+  Grid,
+  Layout,
+  Header,
+  Main,
+  Container,
+  Footer,
+} from './layout'
 
 // DEPRECATED
 export {

--- a/packages/theme-ui/src/layout.js
+++ b/packages/theme-ui/src/layout.js
@@ -1,6 +1,6 @@
 import jsx from './jsx'
 import styled from '@emotion/styled'
-import { space, color, layout, flexbox } from 'styled-system'
+import { space, color, layout, flexbox, grid } from 'styled-system'
 import css from '@styled-system/css'
 
 // fallback for missing emotion pragma or for use in MDX
@@ -21,6 +21,17 @@ export const Box = styled('div')(
 export const Flex = styled(Box)({
   display: 'flex',
 })
+
+export const Grid = styled('div')(
+  css({
+    display: 'grid',
+  }),
+  space,
+  color,
+  layout,
+  grid,
+  cssProp
+)
 
 // root/page layout
 export const Layout = props =>

--- a/packages/theme-ui/test/layout.js
+++ b/packages/theme-ui/test/layout.js
@@ -13,6 +13,7 @@ import {
 test.each([
   ['Box', Box],
   ['Flex', Flex],
+  ['Grid', Grid],
   ['Layout', Layout],
   ['Main', Main],
   ['Container', Container],


### PR DESCRIPTION
I've added a new layout component called `Grid` which acts similar to the `Box` and `Flexbox` component but obviously it uses CSS grid. I think this would be handy to a lot of people who are using CSS Grid 👍