### PR TITLE
Fix missing text in typography page option

### DIFF
--- a/packages/docs/src/components/typography-layout.js
+++ b/packages/docs/src/components/typography-layout.js
@@ -37,7 +37,9 @@ const ThemeSelect = props => (
       }}
     >
       {themeNames.map(name => (
-        <option key={name} label={name} value={name} />
+        <option key={name} label={name} value={name}>
+          {name}
+        </option>
       ))}
     </select>
   </div>


### PR DESCRIPTION
Select is missing option text on:
https://theme-ui.com/typography/