### PR TITLE
add support for CSS properties

### DIFF
--- a/packages/docs/src/gatsby-plugin-theme-ui/index.js
+++ b/packages/docs/src/gatsby-plugin-theme-ui/index.js
@@ -5,7 +5,7 @@ const heading = {
 }
 
 export default {
-  includeCSSProperties: true,
+  useCustomProperties: true,
   initialColorMode: 'light',
   colors: {
     text: '#000',

--- a/packages/docs/src/gatsby-plugin-theme-ui/index.js
+++ b/packages/docs/src/gatsby-plugin-theme-ui/index.js
@@ -5,6 +5,7 @@ const heading = {
 }
 
 export default {
+  includeCSSProperties: true,
   initialColorMode: 'light',
   colors: {
     text: '#000',

--- a/packages/docs/src/pages/color-modes.mdx
+++ b/packages/docs/src/pages/color-modes.mdx
@@ -13,9 +13,9 @@ Color modes can be used to create a user-configurable _dark mode_ or any number 
 ## Defining colors
 
 In the `theme.colors` object, add a nested `modes` object that will contain keys for optional color modes.
-Add an `initialColorMode` value to the theme to initialize the default state.
+Add an `initialColorMode` value to the theme to initialize the default state. You can also set the `useCustomProperties` option to `true` to help prevent flash of colors, please ensure you can [support CSS properties](https://caniuse.com/#feat=css-variables) before setting this option.
 
-**Note:** This value is only used as the _name_ of the top-level colors and should not be used to initialize a color mode defined in the `modes` object.
+**Note:** The `initialColorMode` value is only used as the _name_ of the top-level colors and should not be used to initialize a color mode defined in the `modes` object.
 
 ```js
 // example theme colors
@@ -23,6 +23,8 @@ Add an `initialColorMode` value to the theme to initialize the default state.
   // this enables the color modes feature
   // and is used as the name for the top-level colors object
   initialColorMode: 'light',
+  // use CSS custom properties to help avoid flash of colors on initial page load
+  useCustomProperties: true,
   colors: {
     text: '#000',
     background: '#fff',
@@ -86,6 +88,7 @@ export default props => (
 
 For use with Gatsby, install and use `gatsby-plugin-theme-ui` to add the ThemeProvider to the root of your application.
 The plugin will also attempt to prevent the flash of colors that can happen during page load when a user has a non-default color mode set.
+If you support CSS custom properties, we recommend setting `useCustomProperties` in your theme as seen above in [defining colors](#defining-colors).
 
 ```sh
 npm i gatsby-plugin-theme-ui

--- a/packages/theme-ui/src/color-modes.js
+++ b/packages/theme-ui/src/color-modes.js
@@ -54,7 +54,7 @@ const bodyColor = (theme = {}) => {
   const styles = {}
   Object.keys(modes).forEach(mode => {
     const colors = modes[mode]
-    styles[`&.theme-ui-${mode}`] = theme.includeCSSProperties
+    styles[`&.theme-ui-${mode}`] = theme.useCustomProperties
       ? colors
       : { color: colors.text, bg: colors.background }
   })

--- a/packages/theme-ui/src/color-modes.js
+++ b/packages/theme-ui/src/color-modes.js
@@ -54,10 +54,9 @@ const bodyColor = (theme = {}) => {
   const styles = {}
   Object.keys(modes).forEach(mode => {
     const colors = modes[mode]
-    styles[`&.theme-ui-${mode}`] = {
-      color: colors.text,
-      bg: colors.background,
-    }
+    styles[`&.theme-ui-${mode}`] = theme.includeCSSProperties
+      ? colors
+      : { color: colors.text, bg: colors.background }
   })
 
   return css({

--- a/packages/theme-ui/src/provider.js
+++ b/packages/theme-ui/src/provider.js
@@ -52,7 +52,7 @@ const BaseProvider = ({ context, components, children }) => {
   const theme = applyColorMode(context.theme, context.colorMode)
   return jsx(
     EmotionContext.Provider,
-    { value: theme.includeCSSProperties ? applyCSSProperties(theme) : theme },
+    { value: theme.useCustomProperties ? applyCSSProperties(theme) : theme },
     jsx(
       MDXProvider,
       { components },

--- a/packages/theme-ui/src/provider.js
+++ b/packages/theme-ui/src/provider.js
@@ -7,6 +7,39 @@ import { Context, useThemeUI } from './context'
 import { useColorState } from './color-modes'
 import { createComponents } from './components'
 
+const colorModesToCSSProperties = modes => {
+  return Object.keys(modes).reduce((parsedModes, modeKey) => {
+    const colors = modes[modeKey]
+    return {
+      ...parsedModes,
+      [modeKey]: Object.keys(colors).reduce(
+        (parsedColors, colorKey) => ({
+          ...parsedColors,
+          [`--theme-ui-${colorKey}`]: colors[colorKey],
+        }),
+        {}
+      ),
+    }
+  }, {})
+}
+
+const applyCSSProperties = theme => {
+  const { colors } = theme
+  return {
+    ...theme,
+    colors: Object.keys(colors).reduce(
+      (parsedColors, key) => ({
+        ...parsedColors,
+        [key]:
+          key === 'modes'
+            ? colorModesToCSSProperties(colors[key])
+            : `var(--theme-ui-${key}, ${colors[key]})`,
+      }),
+      {}
+    ),
+  }
+}
+
 const applyColorMode = (theme, mode) => {
   if (!mode) return theme
   const modes = get(theme, 'colors.modes', {})
@@ -19,7 +52,7 @@ const BaseProvider = ({ context, components, children }) => {
   const theme = applyColorMode(context.theme, context.colorMode)
   return jsx(
     EmotionContext.Provider,
-    { value: theme },
+    { value: theme.includeCSSProperties ? applyCSSProperties(theme) : theme },
     jsx(
       MDXProvider,
       { components },

--- a/packages/theme-ui/test/color-modes.js
+++ b/packages/theme-ui/test/color-modes.js
@@ -32,8 +32,7 @@ test('renders with color modes', () => {
       <ThemeProvider
         theme={{
           initialColorMode: 'light',
-        }}
-      >
+        }}>
         <Mode />
       </ThemeProvider>
     )
@@ -93,8 +92,7 @@ test('color mode is passed through theme context', () => {
             },
           },
         },
-      }}
-    >
+      }}>
       <Button />
     </ThemeProvider>
   )
@@ -102,6 +100,32 @@ test('color mode is passed through theme context', () => {
   button.click()
   expect(mode).toBe('dark')
   expect(tree.getByText('test')).toHaveStyleRule('color', 'cyan')
+})
+
+test('converts color modes to css properties', () => {
+  const Box = props => (
+    <div
+      sx={{
+        color: 'text',
+      }}
+      children="test"
+    />
+  )
+  const tree = render(
+    <ThemeProvider
+      theme={{
+        includeCSSProperties: true,
+        colors: {
+          text: '#000',
+        },
+      }}>
+      <Box />
+    </ThemeProvider>
+  )
+  expect(tree.getByText('test')).toHaveStyleRule(
+    'color',
+    'var(--theme-ui-text,#000)'
+  )
 })
 
 test('does not initialize mode', () => {
@@ -146,13 +170,11 @@ test('inherits color mode state from parent context', () => {
     <ThemeProvider
       theme={{
         initialColorMode: 'outer',
-      }}
-    >
+      }}>
       <ThemeProvider
         theme={{
           initialColorMode: 'inner',
-        }}
-      >
+        }}>
         <Consumer />
       </ThemeProvider>
     </ThemeProvider>
@@ -244,8 +266,7 @@ test('ColorMode component renders with colors', () => {
             },
           },
         },
-      }}
-    >
+      }}>
       <ColorMode />
     </ThemeProvider>
   )

--- a/packages/theme-ui/test/color-modes.js
+++ b/packages/theme-ui/test/color-modes.js
@@ -114,7 +114,7 @@ test('converts color modes to css properties', () => {
   const tree = render(
     <ThemeProvider
       theme={{
-        includeCSSProperties: true,
+        useCustomProperties: true,
         colors: {
           text: '#000',
         },


### PR DESCRIPTION
Adds support for toggling CSS properties by setting a `includesCSSProperties` key in theme 🎨. I'm not sure if this initial approach is the best since I'm setting a fallback value, but it seems to work nicely when building the theme-ui docs locally. Maybe there's a better way around that I'm just not seeing? I appreciate any feedback 😊.

closes #134 