### PR TITLE
JSX Pragma - In getCSS function, don’t always return a function

### DIFF
--- a/packages/theme-ui/src/jsx.js
+++ b/packages/theme-ui/src/jsx.js
@@ -1,11 +1,13 @@
 import { jsx as emotion } from '@emotion/core'
 import css from '@styled-system/css'
 
-const getCSS = props => theme => {
+const getCSS = props => {
   if (!props.sx && !props.css) return undefined
-  const styles = css(props.sx)(theme)
-  const raw = typeof props.css === 'function' ? props.css(theme) : props.css
-  return [styles, raw]
+  return theme => {
+    const styles = css(props.sx)(theme)
+    const raw = typeof props.css === 'function' ? props.css(theme) : props.css
+    return [styles, raw]
+  }
 }
 
 const parseProps = props => {


### PR DESCRIPTION
I needed to use the `Global` component from `@emotion/core` and I kept getting the following warning:  `It looks like you're using the css prop on Global, did you mean to use the styles prop instead?`

So I was chatting with Mitchell Hamilton (core maintainer of emotion) about this issue and he suggested this was the best fix to get rid of that warning.

But this does not convert the styles in that component to theme values, which I think is expected. 

But I guess this leads to the question, would you be interested in exposing a `Global` component that allows values to be passed to the `sx` prop?
