### PR TITLE
Add default value for theme

### DIFF
--- a/packages/theme-ui/src/provider.js
+++ b/packages/theme-ui/src/provider.js
@@ -40,7 +40,7 @@ const applyCSSProperties = theme => {
   }
 }
 
-const applyColorMode = (theme, mode) => {
+const applyColorMode = (theme = {}, mode) => {
   if (!mode) return theme
   const modes = get(theme, 'colors.modes', {})
   return merge.all({}, theme, {


### PR DESCRIPTION
Prevents errors when `props.theme` is undefined