### PR TITLE
Fix root color mode

### DIFF
--- a/packages/theme-ui/src/provider.js
+++ b/packages/theme-ui/src/provider.js
@@ -52,7 +52,7 @@ const applyColorMode = (theme, mode) => {
 }
 
 const BaseProvider = ({ context, components, children }) => {
-  const theme = applyColorMode(context.theme, context.colorMode)
+  const theme = context.theme
   return jsx(
     EmotionContext.Provider,
     { value: theme.useCustomProperties ? applyCSSProperties(theme) : theme },
@@ -64,18 +64,19 @@ const BaseProvider = ({ context, components, children }) => {
   )
 }
 
-const RootProvider = ({ theme = {}, components, children }) => {
+const RootProvider = ({ theme: propsTheme = {}, components, children }) => {
   // components are provided in the default Context
   const outer = useThemeUI()
-  const [colorMode, setColorMode] = useColorState(theme.initialColorMode)
-  const [themeState, setThemeState] = useReducer(mergeState, theme)
+  const [colorMode, setColorMode] = useColorState(propsTheme.initialColorMode)
+  const [themeState, setThemeState] = useReducer(mergeState, propsTheme)
+  const theme = applyColorMode(themeState, colorMode)
 
   const context = {
     __THEME_UI__: true,
     colorMode,
     setColorMode,
     components: { ...outer.components, ...createComponents(components) },
-    theme: themeState,
+    theme,
     setTheme: setThemeState,
   }
 

--- a/packages/theme-ui/test/color-modes.js
+++ b/packages/theme-ui/test/color-modes.js
@@ -289,3 +289,33 @@ test('useColorMode throws when there is no theme context', () => {
     render(<Consumer />)
   }).toThrow()
 })
+
+test('useThemeUI returns current color mode colors', () => {
+  window.localStorage.setItem(STORAGE_KEY, 'tomato')
+  let colors
+  const GetColors = () => {
+    const { theme } = useThemeUI()
+    colors = theme.colors
+    return false
+  }
+  const root = render(
+    <ThemeProvider
+      theme={{
+        initialColorMode: 'light',
+        colors: {
+          text: 'tomato',
+          background: 'black',
+          modes: {
+            tomato: {
+              text: 'black',
+              background: 'tomato',
+            },
+          },
+        },
+      }}>
+      <GetColors />
+    </ThemeProvider>
+  )
+  expect(colors.text).toBe('black')
+  expect(colors.background).toBe('tomato')
+})


### PR DESCRIPTION
The root-level `ThemeProvider` was not passing the color mode `colors` object through context, as intended. This passes the current color mode through to the Theme UI context as well as Emotion context