### PR TITLE
Override arrays when merging themes

### DIFF
--- a/packages/theme-ui/src/merge.js
+++ b/packages/theme-ui/src/merge.js
@@ -14,11 +14,11 @@ const isMergeableObject = n => {
   )
 }
 
-export const merge = (a, b) =>
-  deepmerge(a, b, {
-    isMergeableObject,
-  })
+const arrayMerge = (destinationArray, sourceArray, options) => sourceArray
 
-merge.all = (...args) => deepmerge.all(args, { isMergeableObject })
+export const merge = (a, b) =>
+  deepmerge(a, b, { isMergeableObject, arrayMerge })
+
+merge.all = (...args) => deepmerge.all(args, { isMergeableObject, arrayMerge })
 
 export default merge

--- a/packages/theme-ui/test/merge.js
+++ b/packages/theme-ui/test/merge.js
@@ -71,3 +71,31 @@ test('primitive types override arrays', () => {
     fontSize: 4,
   })
 })
+
+test('arrays override arrays', () => {
+  const result = merge(
+    {
+      fontSize: [3, 4, 5],
+    },
+    {
+      fontSize: [6, 7],
+    }
+  )
+  expect(result).toEqual({
+    fontSize: [6, 7],
+  })
+})
+
+test('arrays override primitive types', () => {
+  const result = merge(
+    {
+      fontSize: 5,
+    },
+    {
+      fontSize: [6, 7],
+    }
+  )
+  expect(result).toEqual({
+    fontSize: [6, 7],
+  })
+})


### PR DESCRIPTION
When nesting themes with ThemeProvider the arrays are being concatenated.  
Repro: https://codesandbox.io/s/naughty-khayyam-3gu8z

I changed the merge to override the outer theme array.