### PR TITLE
examples/next: fix unstyled flash

### DIFF
--- a/examples/next/components/Header.js
+++ b/examples/next/components/Header.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import { useColorMode } from 'theme-ui'
+
+export default function Header() {
+  const [colorMode, setColorMode] = useColorMode()
+  return (
+    <header>
+      <button
+        onClick={() => setColorMode(colorMode === 'light' ? 'dark' : 'light')}>
+        Toggle {colorMode === 'light' ? 'Dark' : 'Light'}
+      </button>
+    </header>
+  )
+}

--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -11,6 +11,7 @@
     "start": "next start"
   },
   "dependencies": {
+    "@emotion/core": "^10.0.15",
     "@mdx-js/loader": "^1.0.19",
     "@next/mdx": "^9.0.3",
     "next": "^9.0.2",

--- a/examples/next/pages/_app.js
+++ b/examples/next/pages/_app.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import App, { Container } from 'next/app'
-import { ThemeProvider, Styled } from 'theme-ui'
+import { ThemeProvider, Styled, ColorMode } from 'theme-ui'
+
+import Header from '../components/Header'
 import theme from '../src/theme'
 
 class MyApp extends App {
@@ -20,6 +22,8 @@ class MyApp extends App {
     return (
       <Container>
         <ThemeProvider theme={theme}>
+          <ColorMode />
+          <Header />
           <Styled.root>
             <Component {...pageProps} />
           </Styled.root>

--- a/examples/next/pages/_document.js
+++ b/examples/next/pages/_document.js
@@ -1,0 +1,27 @@
+import React from 'react'
+import Document, { Html, Head, Main, NextScript } from 'next/document'
+import { applyColorModeFromLocalStorage } from 'theme-ui'
+
+class MyDocument extends Document {
+  static async getInitialProps(ctx) {
+    const initialProps = await Document.getInitialProps(ctx)
+    return initialProps
+  }
+
+  render() {
+    return (
+      <Html>
+        <Head />
+        <body>
+          <script
+            dangerouslySetInnerHTML={{ __html: applyColorModeFromLocalStorage }}
+          />
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    )
+  }
+}
+
+export default MyDocument

--- a/examples/next/pages/_document.js
+++ b/examples/next/pages/_document.js
@@ -9,7 +9,6 @@ class MyDocument extends Document {
   }
 
   render() {
-    console.log(ApplyColorModeFromLocalStorage)
     return (
       <Html>
         <Head />

--- a/examples/next/pages/_document.js
+++ b/examples/next/pages/_document.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import Document, { Html, Head, Main, NextScript } from 'next/document'
-import { ApplyColorModeFromLocalStorage } from 'theme-ui'
+import { InitializeColorMode } from 'theme-ui'
 
 class MyDocument extends Document {
   static async getInitialProps(ctx) {
@@ -13,7 +13,7 @@ class MyDocument extends Document {
       <Html>
         <Head />
         <body>
-          <ApplyColorModeFromLocalStorage />
+          <InitializeColorMode />
           <Main />
           <NextScript />
         </body>

--- a/examples/next/pages/_document.js
+++ b/examples/next/pages/_document.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import Document, { Html, Head, Main, NextScript } from 'next/document'
-import { applyColorModeFromLocalStorage } from 'theme-ui'
+import { ApplyColorModeFromLocalStorage } from 'theme-ui'
 
 class MyDocument extends Document {
   static async getInitialProps(ctx) {
@@ -9,13 +9,12 @@ class MyDocument extends Document {
   }
 
   render() {
+    console.log(ApplyColorModeFromLocalStorage)
     return (
       <Html>
         <Head />
         <body>
-          <script
-            dangerouslySetInnerHTML={{ __html: applyColorModeFromLocalStorage }}
-          />
+          <ApplyColorModeFromLocalStorage />
           <Main />
           <NextScript />
         </body>

--- a/examples/next/src/theme.js
+++ b/examples/next/src/theme.js
@@ -1,9 +1,18 @@
 export default {
+  useCustomProperties: true,
   colors: {
     text: '#000',
     background: '#fff',
     primary: '#07c',
     secondary: '#609',
+    modes: {
+      dark: {
+        text: '#fff',
+        background: '#222',
+        primary: '#0cf',
+        secondary: '#90c',
+      },
+    },
   },
   fonts: {
     body: 'system-ui, sans-serif',

--- a/packages/gatsby-plugin-theme-ui/gatsby-ssr.js
+++ b/packages/gatsby-plugin-theme-ui/gatsby-ssr.js
@@ -1,13 +1,8 @@
-import { jsx, applyColorModeFromLocalStorage } from 'theme-ui'
+import { ApplyColorModeFromLocalStorage } from 'theme-ui'
 
 export { wrapRootElement } from './src/provider'
 
 export const onRenderBody = ({ setPreBodyComponents }) => {
-  const script = jsx('script', {
-    key: 'theme-ui-noscript',
-    dangerouslySetInnerHTML: {
-      __html: applyColorModeFromLocalStorage,
-    },
-  })
-  setPreBodyComponents([script])
+  console.log(ApplyColorModeFromLocalStorage)
+  setPreBodyComponents([ApplyColorModeFromLocalStorage])
 }

--- a/packages/gatsby-plugin-theme-ui/gatsby-ssr.js
+++ b/packages/gatsby-plugin-theme-ui/gatsby-ssr.js
@@ -1,7 +1,8 @@
+import React from 'react'
 import { ApplyColorModeFromLocalStorage } from 'theme-ui'
 
 export { wrapRootElement } from './src/provider'
 
 export const onRenderBody = ({ setPreBodyComponents }) => {
-  setPreBodyComponents([ApplyColorModeFromLocalStorage])
+  setPreBodyComponents([<ApplyColorModeFromLocalStorage />])
 }

--- a/packages/gatsby-plugin-theme-ui/gatsby-ssr.js
+++ b/packages/gatsby-plugin-theme-ui/gatsby-ssr.js
@@ -3,6 +3,5 @@ import { ApplyColorModeFromLocalStorage } from 'theme-ui'
 export { wrapRootElement } from './src/provider'
 
 export const onRenderBody = ({ setPreBodyComponents }) => {
-  console.log(ApplyColorModeFromLocalStorage)
   setPreBodyComponents([ApplyColorModeFromLocalStorage])
 }

--- a/packages/gatsby-plugin-theme-ui/gatsby-ssr.js
+++ b/packages/gatsby-plugin-theme-ui/gatsby-ssr.js
@@ -1,8 +1,8 @@
 import React from 'react'
-import { ApplyColorModeFromLocalStorage } from 'theme-ui'
+import { InitializeColorMode } from 'theme-ui'
 
 export { wrapRootElement } from './src/provider'
 
 export const onRenderBody = ({ setPreBodyComponents }) => {
-  setPreBodyComponents([<ApplyColorModeFromLocalStorage />])
+  setPreBodyComponents([<InitializeColorMode />])
 }

--- a/packages/gatsby-plugin-theme-ui/gatsby-ssr.js
+++ b/packages/gatsby-plugin-theme-ui/gatsby-ssr.js
@@ -1,22 +1,12 @@
-import { jsx } from 'theme-ui'
+import { jsx, applyColorModeFromLocalStorage } from 'theme-ui'
 
 export { wrapRootElement } from './src/provider'
-
-const noflash = `
-(function() {
-  try {
-    var mode = localStorage.getItem('theme-ui-color-mode');
-    if (!mode) return
-    document.body.classList.add('theme-ui-' + mode);
-  } catch (e) {}
-})();
-`
 
 export const onRenderBody = ({ setPreBodyComponents }) => {
   const script = jsx('script', {
     key: 'theme-ui-noscript',
     dangerouslySetInnerHTML: {
-      __html: noflash,
+      __html: applyColorModeFromLocalStorage,
     },
   })
   setPreBodyComponents([script])

--- a/packages/theme-ui/src/color-modes.js
+++ b/packages/theme-ui/src/color-modes.js
@@ -68,14 +68,19 @@ const bodyColor = theme => ({
 
 export const ColorMode = () => <Global styles={bodyColor} />
 
-export const applyColorModeFromLocalStorage = `
-  (function() {
+export const ApplyColorModeFromLocalStorage = () => (
+  <script
+    key="theme-ui-noscript"
+    dangerouslySetInnerHTML={{
+      __html: `(function() {
     try {
       var mode = localStorage.getItem('theme-ui-color-mode');
       if (!mode) return
       document.body.classList.add('theme-ui-' + mode);
     } catch (e) {}
-  })();
-`
+  })();`,
+    }}
+  />
+)
 
 export default useColorMode

--- a/packages/theme-ui/src/color-modes.js
+++ b/packages/theme-ui/src/color-modes.js
@@ -72,13 +72,11 @@ export const ApplyColorModeFromLocalStorage = () => (
   <script
     key="theme-ui-noscript"
     dangerouslySetInnerHTML={{
-      __html: `(function() {
-    try {
-      var mode = localStorage.getItem('theme-ui-color-mode');
-      if (!mode) return
-      document.body.classList.add('theme-ui-' + mode);
-    } catch (e) {}
-  })();`,
+      __html: `(function() { try {
+        var mode = localStorage.getItem('theme-ui-color-mode');
+        if (!mode) return
+        document.body.classList.add('theme-ui-' + mode);
+      } catch (e) {} })();`,
     }}
   />
 )

--- a/packages/theme-ui/src/color-modes.js
+++ b/packages/theme-ui/src/color-modes.js
@@ -68,7 +68,7 @@ const bodyColor = theme => ({
 
 export const ColorMode = () => <Global styles={bodyColor} />
 
-export const ApplyColorModeFromLocalStorage = () => (
+export const InitializeColorMode = () => (
   <script
     key="theme-ui-noscript"
     dangerouslySetInnerHTML={{

--- a/packages/theme-ui/src/color-modes.js
+++ b/packages/theme-ui/src/color-modes.js
@@ -68,4 +68,14 @@ const bodyColor = theme => ({
 
 export const ColorMode = () => <Global styles={bodyColor} />
 
+export const applyColorModeFromLocalStorage = `
+  (function() {
+    try {
+      var mode = localStorage.getItem('theme-ui-color-mode');
+      if (!mode) return
+      document.body.classList.add('theme-ui-' + mode);
+    } catch (e) {}
+  })();
+`
+
 export default useColorMode

--- a/packages/theme-ui/src/index.js
+++ b/packages/theme-ui/src/index.js
@@ -1,11 +1,7 @@
 export { jsx } from './jsx'
 export { ThemeProvider } from './provider'
 export { Context, useThemeUI } from './context'
-export {
-  ColorMode,
-  useColorMode,
-  ApplyColorModeFromLocalStorage,
-} from './color-modes'
+export { ColorMode, useColorMode, InitializeColorMode } from './color-modes'
 export { Styled, components } from './components'
 export { Box, Flex, Layout, Header, Main, Container, Footer } from './layout'
 export { css, get } from '@styled-system/css'

--- a/packages/theme-ui/src/index.js
+++ b/packages/theme-ui/src/index.js
@@ -4,7 +4,7 @@ export { Context, useThemeUI } from './context'
 export {
   ColorMode,
   useColorMode,
-  applyColorModeFromLocalStorage,
+  ApplyColorModeFromLocalStorage,
 } from './color-modes'
 export { Styled, components } from './components'
 export { Box, Flex, Layout, Header, Main, Container, Footer } from './layout'

--- a/packages/theme-ui/src/index.js
+++ b/packages/theme-ui/src/index.js
@@ -1,7 +1,11 @@
 export { jsx } from './jsx'
 export { ThemeProvider } from './provider'
 export { Context, useThemeUI } from './context'
-export { ColorMode, useColorMode } from './color-modes'
+export {
+  ColorMode,
+  useColorMode,
+  applyColorModeFromLocalStorage,
+} from './color-modes'
 export { Styled, components } from './components'
 export { Box, Flex, Layout, Header, Main, Container, Footer } from './layout'
 export { css, get } from '@styled-system/css'


### PR DESCRIPTION
Hello 👋

This PR attempts to fix #270 

So I don't think it's possible to create a `theme-ui-next` plugin as we have to do things that plugins aren't able to do (like wrapping the App in a ThemeProvider). So instead I have done something else:

1. Extract the `noflash` function in `gatsby-plugin-theme-ui` into its own function that `theme-ui` exports called `applyColorModeFromLocalStorage`. 
2. Update the next example to use light/dark mode and also use the `applyColorModeFromLocalStorage` which prevents the unstyled flash.