### PR TITLE
docs/pages/theming.mdx: update link to base preset

### DIFF
--- a/packages/docs/src/pages/theming.mdx
+++ b/packages/docs/src/pages/theming.mdx
@@ -230,5 +230,5 @@ export const base = {
 
 For more information on the Theme UI `theme` object, see the [Theme Specification docs](/theme-spec).
 
-[example]: https://github.com/system-ui/theme-ui/blob/master/packages/presets/src/base.js
+[example]: https://github.com/system-ui/theme-ui/tree/master/packages/preset-base/src/index.js
 [emotion]: https://emotion.sh


### PR DESCRIPTION
Each preset now has its own package, but the URL on this link needed to be updated. 