### PR TITLE
Correct accidental capitalization of HTML tag

### DIFF
--- a/packages/docs/src/pages/sx-prop.mdx
+++ b/packages/docs/src/pages/sx-prop.mdx
@@ -131,7 +131,7 @@ that accept the prop to their own file.
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
 
-export const Div = props => <Div {...props} />
+export const Div = props => <div {...props} />
 ```
 
 This will allow you to import and use the `Div` component


### PR DESCRIPTION
I spent about 10 minutes trying to hunt down why this was breaking my build. Eventually discovered it was because I copy pasted the following code. `Div` needs to be `div`.