### PR TITLE
fix(preset-tailwind): Match medium breakpoint

### DIFF
--- a/packages/preset-tailwind/src/index.js
+++ b/packages/preset-tailwind/src/index.js
@@ -9,7 +9,7 @@ export const borderWidths = {
   '8': '8px',
 }
 
-export const breakpoints = ['640px', '758px', '1024px', '1280px']
+export const breakpoints = ['640px', '768px', '1024px', '1280px']
 
 export const baseColors = {
   transparent: 'transparent',


### PR DESCRIPTION
Changes the medium breakpoint in preset-tailwind to match the one used by Tailwind CSS. 

Fixes #345 