### PR TITLE
Color mode no media query

### DIFF
--- a/packages/docs/src/pages/color-modes.mdx
+++ b/packages/docs/src/pages/color-modes.mdx
@@ -2,7 +2,6 @@
 title: Color Modes
 ---
 
-import Note from '../components/note'
 
 # Color Modes
 
@@ -101,13 +100,6 @@ module.exports = {
 
 See the [Gatsby plugin docs](/gatsby-plugin) for more info.
 
-<Note>
-
-This feature will detect the `(prefers-color-scheme: dark)` media query to initialize the state as `dark`.
-Currently it does _not_ check for `(prefers-color-scheme: light)`.
-
-</Note>
-
 ## Advanced
 
 There are a few advanced usages of color modes when you need more
@@ -159,6 +151,28 @@ is named `default`. If you'd like to customize it you can do so by setting
         text: '#fff',
         background: '#000',
         primary: '#0cf',
+      }
+    }
+  }
+}
+```
+
+### Initialize dark mode with `prefers-color-scheme: dark`
+
+To initialize a dark color mode based on the `prefers-color-scheme: dark` media query, add the `useColorSchemeMediaQuery` flag to your theme.
+This will set the initial color mode to `dark` when `@media (prefers-color-scheme: dark)` matches.
+If you do not have a color mode named `dark`, this will have no effect.
+
+```js
+{
+  useColorSchemeMediaQuery: true,
+  colors: {
+    text: '#000',
+    background: '#fff',
+    modes: {
+      dark: {
+        text: '#fff',
+        background: '#000',
       }
     }
   }

--- a/packages/theme-ui/src/color-modes.js
+++ b/packages/theme-ui/src/color-modes.js
@@ -28,7 +28,7 @@ export const useColorState = theme => {
     const stored = storage.get()
     document.body.classList.remove('theme-ui-' + stored)
     const dark = getMediaQuery()
-    if (!stored && dark) return setMode('dark')
+    if (!stored && dark && theme.useColorSchemeMediaQuery) return setMode('dark')
     if (!stored || stored === mode) return
     setMode(stored)
   }, [])

--- a/packages/theme-ui/test/color-modes.js
+++ b/packages/theme-ui/test/color-modes.js
@@ -246,7 +246,10 @@ test('initializes mode from prefers-color-scheme media query', () => {
     return false
   }
   render(
-    <ThemeProvider>
+    <ThemeProvider
+      theme={{
+        useColorSchemeMediaQuery: true,
+      }}>
       <Consumer />
     </ThemeProvider>
   )
@@ -257,6 +260,30 @@ test('does not initialize mode from prefers-color-scheme media query', () => {
   window.matchMedia = jest.fn().mockImplementation(query => {
     return {
       matches: false,
+      media: query,
+    }
+  })
+  let mode
+  const Consumer = props => {
+    const [colorMode] = useColorMode()
+    mode = colorMode
+    return false
+  }
+  render(
+    <ThemeProvider
+      theme={{
+        useColorSchemeMediaQuery: true,
+      }}>
+      <Consumer />
+    </ThemeProvider>
+  )
+  expect(mode).toBe('default')
+})
+
+test('does not initialize mode from prefers-color-scheme media query when useColorSchemeMediaQuery is not set', () => {
+  window.matchMedia = jest.fn().mockImplementation(query => {
+    return {
+      matches: true,
       media: query,
     }
   })


### PR DESCRIPTION
Follow-up to #358 that changes the default behavior with the `prefers-color-scheme` media query

Related #246