### PR TITLE
@theme-ui/color convert var to hex when useCustomProperties is true

### DIFF
--- a/packages/color/src/index.js
+++ b/packages/color/src/index.js
@@ -1,7 +1,7 @@
 import * as P from 'polished'
 import { get } from '@styled-system/css'
 
-const g = (t, c) => get(t, `colors.${c}`, c).replace(/var\(--(\w+)(.*?), /,'').replace(/\)/,'')
+const g = (t, c) => get(t, `colors.${c}`, c).replace(/^var\(--(\w+)(.*?), /,'').replace(/\)/,'')
 
 export const darken = (c, n) => t => P.darken(n, g(t, c))
 export const lighten = (c, n) => t => P.lighten(n, g(t, c))

--- a/packages/color/src/index.js
+++ b/packages/color/src/index.js
@@ -1,7 +1,7 @@
 import * as P from 'polished'
 import { get } from '@styled-system/css'
 
-const g = (t, c) => get(t, `colors.${c}`, c)
+const g = (t, c) => get(t, `colors.${c}`, c).replace(/var\(--(\w+)(.*?), /,'').replace(/\)/,'')
 
 export const darken = (c, n) => t => P.darken(n, g(t, c))
 export const lighten = (c, n) => t => P.lighten(n, g(t, c))

--- a/packages/color/test/index.js
+++ b/packages/color/test/index.js
@@ -91,3 +91,102 @@ test('grayscale', () => {
   const n = grayscale('primary')(theme)
   expect(n).toBe('#808080')
 })
+
+const themeCustomProps = {
+  colors: {
+    primary: 'var(--theme-ui-colors-primary, #0cf)',
+    secondary: 'var(--theme-ui-colors-primary, #639)',
+  },
+}
+
+test('desaturateCustomProps', () => {
+  const n = desaturate('primary', 0.5)(themeCustomProps)
+  expect(n).toBe('#40a6bf')
+})
+
+test('saturateCustomProps', () => {
+  const n = saturate('secondary', 1)(themeCustomProps)
+  expect(n).toBe('#60c')
+})
+
+test('darkenCustomProps', () => {
+  const n = darken('primary', 0.25)(themeCustomProps)
+  expect(n).toBe('#006680')
+})
+
+test('lightenCustomProps', () => {
+  const n = lighten('primary', 0.25)(themeCustomProps)
+  expect(n).toBe('#80e5ff')
+})
+
+test('rotateCustomProps', () => {
+  const n = rotate('primary', 30)(themeCustomProps)
+  expect(n).toBe('#004cff')
+})
+
+test('hueCustomProps', () => {
+  const n = hue('primary', 200)(themeCustomProps)
+  expect(n).toBe('#0af')
+})
+
+test('saturationCustomProps', () => {
+  const n = saturation('primary', 0.25)(themeCustomProps)
+  expect(n).toBe('#60939f')
+})
+
+test('lightnessCustomProps', () => {
+  const n = lightness('primary', 0.25)(themeCustomProps)
+  expect(n).toBe('#006680')
+})
+
+test('shadeCustomProps', () => {
+  const n = shade('primary', 0.25)(themeCustomProps)
+  expect(n).toBe('#0099bf')
+})
+
+test('tintCustomProps', () => {
+  const n = tint('primary', 0.25)(themeCustomProps)
+  expect(n).toBe('#3fd8ff')
+})
+
+test('mixCustomProps', () => {
+  const n = mix('primary', 'secondary', 0.25)(themeCustomProps)
+  expect(n).toBe('#4c59b2')
+})
+
+test('complementCustomProps', () => {
+  const n = complement('secondary')(themeCustomProps)
+  expect(n).toBe('#693')
+})
+
+test('invertCustomProps', () => {
+  const n = invert('primary')(themeCustomProps)
+  expect(n).toBe('#f30')
+})
+
+test('grayscaleCustomProps', () => {
+  const n = grayscale('primary')(themeCustomProps)
+  expect(n).toBe('#808080')
+})
+
+const themeTomato = {
+  colors: {
+    primary: 'tomato',
+  },
+}
+
+test('darkenTomato', () => {
+  const n = darken('primary', 0.25)(themeTomato)
+  expect(n).toBe('#c61e00')
+})
+
+const themeTomatoCustomProps = {
+  colors: {
+    primary: 'var(--theme-ui-colors-primary, tomato)',
+  },
+}
+
+test('darkenTomatoCustomProps', () => {
+  const n = darken('primary', 0.25)(themeTomatoCustomProps)
+  expect(n).toBe('#c61e00')
+})


### PR DESCRIPTION
Uses a regex to extract the hex value from the CSS Custom Variable value generated from a theme when useCustomProperties is true. Added test coverage. Verified that CSS Color Names are also processed correctly.