### PR TITLE
fix: edit link to git editor page

### DIFF
--- a/packages/docs/src/components/edit-link.js
+++ b/packages/docs/src/components/edit-link.js
@@ -3,8 +3,19 @@ import { Location } from '@reach/router'
 import { jsx } from 'theme-ui'
 
 const getHREF = (base, location) => {
-  if (location.pathname === '/') return false
-  return base + location.pathname.replace(/\/+$/, '') + '.mdx'
+  if (location.pathname === '/') return
+
+  const sanitizedLocationPathname = location.pathname.replace(/\/+$/, '')
+  const basePagesHref = `${base}/pages` + sanitizedLocationPathname
+
+  if (location.pathname === '/recipes') return `${basePagesHref}/index.js`
+
+  if (location.pathname === '/guides') return `${basePagesHref}/index.mdx`
+
+  if (location.pathname.startsWith('/recipes/') === false)
+    return `${basePagesHref}.mdx`
+
+  return `${base}${sanitizedLocationPathname}.mdx`
 }
 
 export const EditLink = ({ base, children, ...props }) => (
@@ -12,6 +23,7 @@ export const EditLink = ({ base, children, ...props }) => (
     children={({ location }) => {
       const href = getHREF(base, location)
       if (!href) return false
+
       return (
         <a
           {...props}
@@ -30,8 +42,7 @@ export const EditLink = ({ base, children, ...props }) => (
 )
 
 EditLink.defaultProps = {
-  base:
-    'https://github.com/system-ui/theme-ui/edit/master/packages/docs/src/recipes',
+  base: 'https://github.com/system-ui/theme-ui/edit/master/packages/docs/src',
   children: 'Edit the page on GitHub',
 }
 

--- a/packages/docs/src/components/edit-link.js
+++ b/packages/docs/src/components/edit-link.js
@@ -21,8 +21,7 @@ export const EditLink = ({ base, children, ...props }) => (
             color: 'inherit',
             fontSize: 1,
             my: 4,
-          }}
-        >
+          }}>
           {children}
         </a>
       )
@@ -32,7 +31,7 @@ export const EditLink = ({ base, children, ...props }) => (
 
 EditLink.defaultProps = {
   base:
-    'https://github.com/system-ui/theme-ui/edit/master/packages/docs/src/pages',
+    'https://github.com/system-ui/theme-ui/edit/master/packages/docs/src/recipes',
   children: 'Edit the page on GitHub',
 }
 


### PR DESCRIPTION
Hi and thx a lot your work 👋,

When I tried to look at the source code of the doc pages I was redirected to the wrong GitHub URL. This should fix it :)
