### PR TITLE
Update  NextJS example

### DIFF
--- a/examples/next/pages/_app.js
+++ b/examples/next/pages/_app.js
@@ -1,34 +1,33 @@
 import React from 'react'
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import { ThemeProvider, Styled, ColorMode } from 'theme-ui'
 
 import Header from '../components/Header'
 import theme from '../src/theme'
 
 class MyApp extends App {
-  static async getInitialProps({ Component, ctx }) {
-    let pageProps = {}
-
-    if (Component.getInitialProps) {
-      pageProps = await Component.getInitialProps(ctx)
-    }
-
-    return { pageProps }
-  }
+  // Only uncomment this method if you have blocking data requirements for
+  // every single page in your application. This disables the ability to
+  // perform automatic static optimization, causing every page in your app to
+  // be server-side rendered.
+  //
+  // static async getInitialProps(appContext) {
+  //   // calls page's `getInitialProps` and fills `appProps.pageProps`
+  //   const appProps = await App.getInitialProps(appContext);
+  //
+  //   return { ...appProps }
+  // }
 
   render() {
     const { Component, pageProps } = this.props
-
     return (
-      <Container>
-        <ThemeProvider theme={theme}>
-          <ColorMode />
-          <Header />
-          <Styled.root>
-            <Component {...pageProps} />
-          </Styled.root>
-        </ThemeProvider>
-      </Container>
+      <ThemeProvider theme={theme}>
+        <ColorMode />
+        <Header />
+        <Styled.root>
+          <Component {...pageProps} />
+        </Styled.root>
+      </ThemeProvider>
     )
   }
 }

--- a/examples/next/pages/_document.js
+++ b/examples/next/pages/_document.js
@@ -5,7 +5,7 @@ import { InitializeColorMode } from 'theme-ui'
 class MyDocument extends Document {
   static async getInitialProps(ctx) {
     const initialProps = await Document.getInitialProps(ctx)
-    return initialProps
+    return { ...initialProps }
   }
 
   render() {


### PR DESCRIPTION
I've made some optimisations to the NextJS example so its more inline with `create-next-app` defaults. 

This PR removes a deprecation warning and also allows pages to be statically optimised by next.

Closes #379