### PR TITLE
Clean up unused argument

### DIFF
--- a/packages/theme-ui/src/color-modes.js
+++ b/packages/theme-ui/src/color-modes.js
@@ -18,7 +18,8 @@ export const getMediaQuery = () => {
   return dark && mql.matches
 }
 
-const getName = (theme) => theme.initialColorModeName || theme.initialColorMode || 'default'
+const getName = theme =>
+  theme.initialColorModeName || theme.initialColorMode || 'default'
 
 export const useColorState = theme => {
   const [mode, setMode] = useState(getName(theme))
@@ -28,7 +29,8 @@ export const useColorState = theme => {
     const stored = storage.get()
     document.body.classList.remove('theme-ui-' + stored)
     const dark = getMediaQuery()
-    if (!stored && dark && theme.useColorSchemeMediaQuery) return setMode('dark')
+    if (!stored && dark && theme.useColorSchemeMediaQuery)
+      return setMode('dark')
     if (!stored || stored === mode) return
     setMode(stored)
   }, [])
@@ -54,7 +56,7 @@ export const useColorState = theme => {
   return [mode, setMode]
 }
 
-export const useColorMode = initialMode => {
+export const useColorMode = () => {
   const { colorMode, setColorMode } = useThemeUI()
 
   if (typeof setColorMode !== 'function') {


### PR DESCRIPTION
The code for `useColorMode` got changed to make the argument `initialMode` unused. This tripped me up because the typings say it exists, but the code doesn't use it. So I propose to remove it here first and then update the typings at https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/theme-ui/index.d.ts#L222

This PR also includes some formatting done by Prettier on commit.