### PR TITLE
Fix missing key warning

### DIFF
--- a/packages/style-guide/src/ColorPalette.js
+++ b/packages/style-guide/src/ColorPalette.js
@@ -39,6 +39,7 @@ export const ColorRow = ({
           const swatch = (
             <ColorSwatch
               {...props}
+              key={key}
               name={id}
               color={id}
               size={size}
@@ -51,7 +52,6 @@ export const ColorRow = ({
             return render({
               swatch,
               color,
-              key,
               name: id,
             })
           }

--- a/packages/style-guide/src/ColorPalette.js
+++ b/packages/style-guide/src/ColorPalette.js
@@ -52,6 +52,7 @@ export const ColorRow = ({
             return render({
               swatch,
               color,
+              key,
               name: id,
             })
           }


### PR DESCRIPTION
I was seeing

> Warning: Each child in a list should have a unique "key" prop.
> Check the top-level render call using <EmotionCssPropInternal>.

Since `key` is special and isn't passed down in `props`, I moved it directly in `<ColorSwatch>`.