### PR TITLE
Remove ColorModeProvider from Dark-Mode example

### DIFF
--- a/examples/dark-mode/src/index.js
+++ b/examples/dark-mode/src/index.js
@@ -1,11 +1,9 @@
 import React from 'react'
-import { ColorModeProvider, ThemeProvider, Styled } from 'theme-ui'
+import { ThemeProvider, Styled } from 'theme-ui'
 import theme from './theme'
 
 export const wrapRootElement = ({ element }) => (
-  <ColorModeProvider initialColorMode="light">
-    <ThemeProvider theme={theme}>
-      <Styled.root>{element}</Styled.root>
-    </ThemeProvider>
-  </ColorModeProvider>
+  <ThemeProvider theme={theme}>
+    <Styled.root>{element}</Styled.root>
+  </ThemeProvider>
 )


### PR DESCRIPTION
`ColorModeProvider` no longer available in `theme-ui` package so the example will not actually run. Followed the migration instructions and bingo! Back in action 😉 