### PR TITLE
[@theme-ui/colors] Implement alpha color function

### DIFF
--- a/packages/color/README.md
+++ b/packages/color/README.md
@@ -116,6 +116,16 @@ import { tint } from '@theme-ui/color'
 // tint('primary', amount)
 ```
 
+### `alpha`
+
+Set the transparancy of a color to an amount 0-1
+
+```js
+
+import { alpha } from '@theme-ui/color'
+// alpha('primary', amount)
+```
+
 ### `mix`
 
 Mix two colors by a specific ratio

--- a/packages/color/README.md
+++ b/packages/color/README.md
@@ -118,7 +118,7 @@ import { tint } from '@theme-ui/color'
 
 ### `alpha`
 
-Set the transparancy of a color to an amount 0-1
+Set the transparency of a color to an amount 0-1
 
 ```js
 

--- a/packages/color/src/index.js
+++ b/packages/color/src/index.js
@@ -17,8 +17,7 @@ export const saturate = (c, n) => t => P.saturate(n, g(t, c))
 export const shade = (c, n) => t => P.shade(n, g(t, c))
 export const tint = (c, n) => t => P.tint(n, g(t, c))
 
-// maybe not from polished? opacify??
-// export const alpha = (c, n) => t =>
+export const alpha = (c, n) => t => P.rgba(g(t, c), n)
 
 export const mix = (a, b, n = 0.5) => t => P.mix(n, g(t, a), g(t, b))
 

--- a/packages/color/test/index.js
+++ b/packages/color/test/index.js
@@ -75,7 +75,7 @@ test('tint', () => {
 
 test('alpha', () => {
   const n = alpha('primary', 0.25)(theme)
-  expect(n).toBe('rgba(0,204,255,0.5)')
+  expect(n).toBe('rgba(0,204,255,0.25)')
 })
 
 test('mix', () => {
@@ -157,7 +157,7 @@ test('tintCustomProps', () => {
 
 test('alphaCustomProps', () => {
   const n = alpha('primary', 0.25)(themeCustomProps)
-  expect(n).toBe('rgba(0,204,255,0.5)')
+  expect(n).toBe('rgba(0,204,255,0.25)')
 })
 
 test('mixCustomProps', () => {

--- a/packages/color/test/index.js
+++ b/packages/color/test/index.js
@@ -9,6 +9,7 @@ import {
   saturate,
   shade,
   tint,
+  alpha,
   mix,
   complement,
   invert,
@@ -70,6 +71,11 @@ test('shade', () => {
 test('tint', () => {
   const n = tint('primary', 0.25)(theme)
   expect(n).toBe('#3fd8ff')
+})
+
+test('alpha', () => {
+  const n = alpha('primary', 0.25)(theme)
+  expect(n).toBe('rgba(0,204,255,0.5)')
 })
 
 test('mix', () => {
@@ -147,6 +153,11 @@ test('shadeCustomProps', () => {
 test('tintCustomProps', () => {
   const n = tint('primary', 0.25)(themeCustomProps)
   expect(n).toBe('#3fd8ff')
+})
+
+test('alphaCustomProps', () => {
+  const n = alpha('primary', 0.25)(themeCustomProps)
+  expect(n).toBe('rgba(0,204,255,0.5)')
 })
 
 test('mixCustomProps', () => {


### PR DESCRIPTION
I noticed the beginning of an `alpha` color function was commented out so I took a stab at finishing it. The function changes the transparency of a given color using the `rgba` function from Polished. 

**Example:**

```js
const theme = {
  colors: { primary: '#f00' }
}

alpha('primary', 0.5)(theme) // rgba(255, 0, 0, 0.5)
```

Let me know if this is how you intended for the `alpha` function to work 😸 

### To do
- [x] Add documentation
- [x] Write tests