### PR TITLE
[match-media] Add default breakpoint index arg to match-media hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - `@theme-ui/color`: add `alpha` utility #441
+- `@theme-ui/match-media`: Add default breakpoint index argument for SSR
 
 ## v0.2.48 2019-11-07
 

--- a/packages/match-media/README.md
+++ b/packages/match-media/README.md
@@ -58,3 +58,22 @@ const MyComponent = () => {
 }
 ```
 
+Each hook uses `breakpoints[0]` by default, if not specified.
+
+```js
+import { useResponsiveValue, useBreakpointIndex } from '@theme-ui/match-media'
+
+const MyComponent = () => {
+  const color = useResponsiveValue(['red', 'green', 'blue'])
+  const index = useBreakpointIndex()
+
+  return (
+    <div>
+      The current color is: {color}, and the current index is: {index} 
+   // Gatsby will output: 
+   // The current color is: red, and the current index is: 0
+    </div>
+  )
+}
+```
+

--- a/packages/match-media/README.md
+++ b/packages/match-media/README.md
@@ -36,3 +36,23 @@ const MyComponent = () => {
   )
 }
 ```
+
+Each hook also accepts a default breakpoint index to use when rendering on the server.
+
+```js
+import { useResponsiveValue, useBreakpointIndex } from '@theme-ui/match-media'
+
+const MyComponent = () => {
+  const color = useResponsiveValue(['red', 'green', 'blue'], 1)
+  const index = useBreakpointIndex(0)
+
+  return (
+    <div>
+      The current color is: {color}, and the current index is: {index} 
+   // Gatsby will output: 
+   // The current color is: green, and the current index is: 0
+    </div>
+  )
+}
+```
+

--- a/packages/match-media/README.md
+++ b/packages/match-media/README.md
@@ -48,7 +48,7 @@ const MyComponent = () => {
   const color = useResponsiveValue(['red', 'green', 'blue'], {
     defaultIndex: 1
   })
-  const index = useBreakpointIndex({ defaultIndex: 1 })
+  const index = useBreakpointIndex({ defaultIndex: 0 })
 
   return (
     <div>

--- a/packages/match-media/README.md
+++ b/packages/match-media/README.md
@@ -39,14 +39,16 @@ const MyComponent = () => {
 
 ### Server side rendering
 
-Each hook also accepts a default breakpoint index to use when rendering on the server.
+Each hook also accepts an options object, used to set a default breakpoint index when rendering on the server.
 
 ```js
 import { useResponsiveValue, useBreakpointIndex } from '@theme-ui/match-media'
 
 const MyComponent = () => {
-  const color = useResponsiveValue(['red', 'green', 'blue'], 1)
-  const index = useBreakpointIndex(0)
+  const color = useResponsiveValue(['red', 'green', 'blue'], {
+    defaultIndex: 1
+  })
+  const index = useBreakpointIndex({ defaultIndex: 1 })
 
   return (
     <div>

--- a/packages/match-media/README.md
+++ b/packages/match-media/README.md
@@ -37,6 +37,8 @@ const MyComponent = () => {
 }
 ```
 
+### Server side rendering
+
 Each hook also accepts a default breakpoint index to use when rendering on the server.
 
 ```js

--- a/packages/match-media/src/index.js
+++ b/packages/match-media/src/index.js
@@ -4,7 +4,7 @@ import { useThemeUI } from 'theme-ui'
 // Shared with @styled-system/css
 const defaultBreakpoints = [40, 52, 64].map(n => n + 'em')
 
-export const useBreakpointIndex = defaultIndex => {
+export const useBreakpointIndex = (defaultIndex = 0) => {
   const context = useThemeUI()
   const breakpoints =
     (context.theme && context.theme.breakpoints) || defaultBreakpoints
@@ -20,8 +20,7 @@ export const useBreakpointIndex = defaultIndex => {
         return defaultIndex
       }
       throw new TypeError(
-        'To use @theme-ui/match-media hooks on the server, you must pass a default index. Got: ' +
-          defaultIndex
+        `Default breakpoint index should be a number. Got: ${defaultIndex}, ${typeof defaultIndex}`
       )
     }
 

--- a/packages/match-media/src/index.js
+++ b/packages/match-media/src/index.js
@@ -4,8 +4,9 @@ import { useThemeUI } from 'theme-ui'
 // Shared with @styled-system/css
 const defaultBreakpoints = [40, 52, 64].map(n => n + 'em')
 
-export const useBreakpointIndex = (defaultIndex = 0) => {
+export const useBreakpointIndex = (options = {}) => {
   const context = useThemeUI()
+  const { defaultIndex = 0 } = options
   const breakpoints =
     (context.theme && context.theme.breakpoints) || defaultBreakpoints
 

--- a/packages/match-media/src/index.js
+++ b/packages/match-media/src/index.js
@@ -12,7 +12,7 @@ export const useBreakpointIndex = defaultIndex => {
   const getIndex = useCallback(() => {
     if (typeof window === 'undefined') {
       if (typeof defaultIndex === 'number') {
-        if (0 < defaultIndex || defaultIndex > breakpoints.length - 1) {
+        if (defaultIndex < 0 || defaultIndex > breakpoints.length - 1) {
           throw new RangeError(
             `Default breakpoint index out of range. Theme has ${breakpoints.length} breakpoints, got index ${defaultIndex}`
           )

--- a/packages/match-media/src/index.js
+++ b/packages/match-media/src/index.js
@@ -4,19 +4,25 @@ import { useThemeUI } from 'theme-ui'
 // Shared with @styled-system/css
 const defaultBreakpoints = [40, 52, 64].map(n => n + 'em')
 
-export const useBreakpointIndex = () => {
+export const useBreakpointIndex = defaultIndex => {
   const context = useThemeUI()
   const breakpoints =
     (context.theme && context.theme.breakpoints) || defaultBreakpoints
 
-  const getIndex = useCallback(
-    () =>
-      breakpoints.filter(
-        breakpoint =>
-          window.matchMedia(`screen and (min-width: ${breakpoint})`).matches
-      ).length,
-    [breakpoints]
-  )
+  const getIndex = useCallback(() => {
+    if (typeof window === 'undefined') {
+      if (typeof defaultIndex === 'number') return defaultIndex
+      throw new TypeError(
+        'To use @theme-ui/match-media hooks on the server, you must pass a default index. Got: ' +
+          defaultIndex
+      )
+    }
+
+    return breakpoints.filter(
+      breakpoint =>
+        window.matchMedia(`screen and (min-width: ${breakpoint})`).matches
+    ).length
+  }, [breakpoints, defaultIndex])
 
   const [value, setValue] = useState(getIndex)
 
@@ -34,9 +40,9 @@ export const useBreakpointIndex = () => {
   return value
 }
 
-export const useResponsiveValue = values => {
+export const useResponsiveValue = (values, defaultIndex) => {
   const { theme } = useThemeUI()
   const array = typeof values === 'function' ? values(theme) : values
-  const index = useBreakpointIndex()
+  const index = useBreakpointIndex(defaultIndex)
   return array[index >= array.length ? array.length - 1 : index]
 }

--- a/packages/match-media/src/index.js
+++ b/packages/match-media/src/index.js
@@ -47,9 +47,10 @@ export const useBreakpointIndex = (options = {}) => {
   return value
 }
 
-export const useResponsiveValue = (values, defaultIndex) => {
+export const useResponsiveValue = (values, options = {}) => {
   const { theme } = useThemeUI()
+  const { defaultIndex = 0 } = options
   const array = typeof values === 'function' ? values(theme) : values
-  const index = useBreakpointIndex(defaultIndex)
+  const index = useBreakpointIndex({ defaultIndex })
   return array[index >= array.length ? array.length - 1 : index]
 }

--- a/packages/match-media/src/index.js
+++ b/packages/match-media/src/index.js
@@ -11,7 +11,14 @@ export const useBreakpointIndex = defaultIndex => {
 
   const getIndex = useCallback(() => {
     if (typeof window === 'undefined') {
-      if (typeof defaultIndex === 'number') return defaultIndex
+      if (typeof defaultIndex === 'number') {
+        if (0 < defaultIndex || defaultIndex > breakpoints.length - 1) {
+          throw new RangeError(
+            `Default breakpoint index out of range. Theme has ${breakpoints.length} breakpoints, got index ${defaultIndex}`
+          )
+        }
+        return defaultIndex
+      }
       throw new TypeError(
         'To use @theme-ui/match-media hooks on the server, you must pass a default index. Got: ' +
           defaultIndex

--- a/packages/match-media/src/index.js
+++ b/packages/match-media/src/index.js
@@ -47,10 +47,9 @@ export const useBreakpointIndex = (options = {}) => {
   return value
 }
 
-export const useResponsiveValue = (values, options = {}) => {
+export const useResponsiveValue = (values, options) => {
   const { theme } = useThemeUI()
-  const { defaultIndex = 0 } = options
   const array = typeof values === 'function' ? values(theme) : values
-  const index = useBreakpointIndex({ defaultIndex })
+  const index = useBreakpointIndex(options)
   return array[index >= array.length ? array.length - 1 : index]
 }

--- a/packages/match-media/test/ssr.js
+++ b/packages/match-media/test/ssr.js
@@ -1,0 +1,24 @@
+/**
+ * @jest-environment node
+ */
+/**@jsx jsx */
+import { jsx } from 'theme-ui'
+import { Fragment } from 'react'
+import ReactDOMServer from 'react-dom/server'
+import { useResponsiveValue, useBreakpointIndex } from '../src'
+
+test('falls back to default index', () => {
+  const Component = props => {
+    const value = useResponsiveValue(['a', 'b'], 1)
+    const index = useBreakpointIndex(2)
+    return (
+      <Fragment>
+        {value} {index}
+      </Fragment>
+    )
+  }
+
+  const root = ReactDOMServer.renderToStaticMarkup(<Component />)
+
+  expect(root).toEqual('b 2')
+})

--- a/packages/match-media/test/ssr.js
+++ b/packages/match-media/test/ssr.js
@@ -9,8 +9,8 @@ import { useResponsiveValue, useBreakpointIndex } from '../src'
 
 test("falls back to user's default index", () => {
   const Component = props => {
-    const value = useResponsiveValue(['a', 'b'], 1)
-    const index = useBreakpointIndex(2)
+    const value = useResponsiveValue(['a', 'b'], { defaultIndex: 1 })
+    const index = useBreakpointIndex({ defaultIndex: 2 })
     return (
       <Fragment>
         {value} {index}
@@ -39,8 +39,8 @@ test('defaults to first breakpoint without user input', () => {
 
 test('requires default index be in range', () => {
   const Component = props => {
-    const value = useResponsiveValue(['a', 'b'], 4)
-    const index = useBreakpointIndex(4)
+    const value = useResponsiveValue(['a', 'b'], { defaultIndex: 4 })
+    const index = useBreakpointIndex({ defaultIndex: 4 })
     return null
   }
   const Example = () =>
@@ -57,8 +57,8 @@ test('requires default index be in range', () => {
 
 test('requires default index be a number', () => {
   const Component = ({ index }) => {
-    const value = useResponsiveValue(['a', 'b'], index)
-    const themeIndex = useBreakpointIndex(index)
+    const value = useResponsiveValue(['a', 'b'], { defaultIndex: index })
+    const themeIndex = useBreakpointIndex({ defaultIndex: index })
     return null
   }
 

--- a/packages/match-media/test/ssr.js
+++ b/packages/match-media/test/ssr.js
@@ -7,7 +7,7 @@ import { Fragment } from 'react'
 import ReactDOMServer from 'react-dom/server'
 import { useResponsiveValue, useBreakpointIndex } from '../src'
 
-test('falls back to default index', () => {
+test("falls back to user's default index", () => {
   const Component = props => {
     const value = useResponsiveValue(['a', 'b'], 1)
     const index = useBreakpointIndex(2)
@@ -23,16 +23,18 @@ test('falls back to default index', () => {
   expect(root).toEqual('b 2')
 })
 
-test('requires a default index for SSR', () => {
+test('defaults to first breakpoint without user input', () => {
+  let value
+  let index
   const Component = props => {
-    const value = useResponsiveValue(['a', 'b'])
-    const index = useBreakpointIndex()
+    value = useResponsiveValue(['a', 'b'])
+    index = useBreakpointIndex()
     return null
   }
 
-  expect(() => ReactDOMServer.renderToStaticMarkup(<Component />)).toThrowError(
-    TypeError
-  )
+  ReactDOMServer.renderToStaticMarkup(<Component />)
+  expect(value).toEqual('a')
+  expect(index).toEqual(0)
 })
 
 test('requires default index be in range', () => {
@@ -51,4 +53,19 @@ test('requires default index be in range', () => {
       </ThemeProvider>
     )
   expect(Example).toThrowError(RangeError)
+})
+
+test('requires default index be a number', () => {
+  const Component = ({ index }) => {
+    const value = useResponsiveValue(['a', 'b'], index)
+    const themeIndex = useBreakpointIndex(index)
+    return null
+  }
+
+  const createRender = defaultIndex => () =>
+    ReactDOMServer.renderToStaticMarkup(<Component index={defaultIndex} />)
+
+  expect(createRender(() => 2)).toThrowError(TypeError)
+  expect(createRender('2')).toThrowError(TypeError)
+  expect(createRender({ index: 2 })).toThrowError(TypeError)
 })

--- a/packages/match-media/test/ssr.js
+++ b/packages/match-media/test/ssr.js
@@ -2,7 +2,7 @@
  * @jest-environment node
  */
 /**@jsx jsx */
-import { jsx } from 'theme-ui'
+import { jsx, ThemeProvider } from 'theme-ui'
 import { Fragment } from 'react'
 import ReactDOMServer from 'react-dom/server'
 import { useResponsiveValue, useBreakpointIndex } from '../src'
@@ -21,4 +21,34 @@ test('falls back to default index', () => {
   const root = ReactDOMServer.renderToStaticMarkup(<Component />)
 
   expect(root).toEqual('b 2')
+})
+
+test('requires a default index for SSR', () => {
+  const Component = props => {
+    const value = useResponsiveValue(['a', 'b'])
+    const index = useBreakpointIndex()
+    return null
+  }
+
+  expect(() => ReactDOMServer.renderToStaticMarkup(<Component />)).toThrowError(
+    TypeError
+  )
+})
+
+test('requires default index be in range', () => {
+  const Component = props => {
+    const value = useResponsiveValue(['a', 'b'], 4)
+    const index = useBreakpointIndex(4)
+    return null
+  }
+  const Example = () =>
+    ReactDOMServer.renderToStaticMarkup(
+      <ThemeProvider
+        theme={{
+          breakpoints: ['30em', '45em', '55em'],
+        }}>
+        <Component />
+      </ThemeProvider>
+    )
+  expect(Example).toThrowError(RangeError)
 })


### PR DESCRIPTION
Closes #438 

Should it also throw if the `defaultIndex` is not in range of the breakpoints array?