### PR TITLE
docs: update prism usage

### DIFF
--- a/packages/prism/README.md
+++ b/packages/prism/README.md
@@ -65,7 +65,7 @@ import nightOwl from '@theme-ui/prism/presets/night-owl.json'
 export default {
   // ...theme
   styles: {
-    pre: {
+    code: {
       ...nightOwl,
     }
   }
@@ -117,7 +117,7 @@ export default {
     gray: '#666',
   },
   styles: {
-    pre: {
+    code: {
       ...prism,
     }
   }


### PR DESCRIPTION
In the copy it says add to `theme.styles.code` but the examples use `theme.styles.pre`