### PR TITLE
Make dependencies with context peer deps

### DIFF
--- a/packages/style-guide/package.json
+++ b/packages/style-guide/package.json
@@ -9,13 +9,15 @@
     "prepare": "microbundle --no-compress",
     "watch": "microbundle watch --no-compress"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@emotion/core": "^10.0.10",
-    "@theme-ui/presets": "^0.2.44",
-    "color": "^3.1.2",
-    "lodash.get": "^4.4.2",
     "react": "^16.8.6",
     "theme-ui": "^0.2.52"
+  },
+  "dependencies": {
+    "@theme-ui/presets": "^0.2.44",
+    "color": "^3.1.2",
+    "lodash.get": "^4.4.2"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
When using the style guide package it's likely that
theme-ui and emotion are already installed. This also
protects against multiple versions of theme-ui ending
up on the page which can result in the components
throwing exceptions because the theme context for
the style-guide's version of theme-ui is null.