### PR TITLE
Fix overflow error in LiveError component

### DIFF
--- a/packages/docs/src/components/code.js
+++ b/packages/docs/src/components/code.js
@@ -96,6 +96,7 @@ export const LiveCode = ({ children, preview, xray }) => {
             fontSize: 0,
             color: 'secondary',
             bg: 'highlight',
+            overflow: 'auto'
           }}
         />
       </div>


### PR DESCRIPTION
Signed-off-by: isamrish <askmaurya48@gmail.com>

This commit will fix overflow error in LiveError component
in docs package

--

I was playing with code in theme-ui and I got this overflow issue in LiveError components

Before:

![overflow-issue](https://user-images.githubusercontent.com/6524419/71320264-d98d4b00-24ce-11ea-8df7-e73302a199ac.png)


After being fixed:

![overflow-solution](https://user-images.githubusercontent.com/6524419/71320275-f4f85600-24ce-11ea-8a8b-1aa00448e161.png)



