### PR TITLE
Typo in the skip link component

### DIFF
--- a/packages/docs/src/components/skip-link.js
+++ b/packages/docs/src/components/skip-link.js
@@ -12,7 +12,7 @@ export default props => (
       width: 1,
       m: -1,
       p: 0,
-      overrflow: 'hidden',
+      overflow: 'hidden',
       position: 'absolute',
       top: -9999,
       ':focus': {


### PR DESCRIPTION
Changed `overrflow` to `overflow`.