### PR TITLE
Add Styled.article

### DIFF
--- a/packages/theme-ui/src/components.js
+++ b/packages/theme-ui/src/components.js
@@ -33,6 +33,7 @@ const tags = [
   'thematicBreak',
   // other
   'div',
+  'article',
   // theme-ui
   'root',
 ]


### PR DESCRIPTION
I feel like this might be incredibly dumb, so apologies if so. But I'd love a simple way to style text content (possibly user-generated, like Markdown in comments, but not MDX) in Theme UI, separately from application/`root` styles.

The article tag here (I hope) would allow doing `<Styled.article>` & having `theme.styles.article` give those styles, keeping the code (as you can see) super concise. Thoughts?