### PR TITLE
Add support for combining multiple variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Adjust media query sort logic #600
 - Fixed link to Gatsby Plugin page in `getting-started` page. Issue #602
+- Adds support for combining multiple variants (pass `variants` an array in `sx` or as a prop on components)
 
 ## v0.3.0 2019-01-22
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -14,6 +14,7 @@
     "@styled-system/color": "^5.1.2",
     "@styled-system/should-forward-prop": "^5.1.2",
     "@styled-system/space": "^5.1.2",
+    "@theme-ui/core": "^0.3.1",
     "@theme-ui/css": "^0.3.1"
   },
   "peerDependencies": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -14,8 +14,8 @@
     "@styled-system/color": "^5.1.2",
     "@styled-system/should-forward-prop": "^5.1.2",
     "@styled-system/space": "^5.1.2",
-    "@theme-ui/core": "^0.3.1",
-    "@theme-ui/css": "^0.3.1"
+    "@theme-ui/css": "^0.3.1",
+    "deepmerge": "^4.2.2"
   },
   "peerDependencies": {
     "react": "^16.8.0"

--- a/packages/components/src/Box.js
+++ b/packages/components/src/Box.js
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled'
 import { css, get } from '@theme-ui/css'
-import { merge } from '@theme-ui/core'
 import { createShouldForwardProp } from '@styled-system/should-forward-prop'
 import space from '@styled-system/space'
 import color from '@styled-system/color'
+import deepmerge from 'deepmerge'
 
 const shouldForwardProp = createShouldForwardProp([
   ...space.propNames,
@@ -12,10 +12,17 @@ const shouldForwardProp = createShouldForwardProp([
 
 const sx = props => css(props.sx)(props.theme)
 const base = props => css(props.__css)(props.theme)
+
 const variant = ({ theme, variant, __themeKey = 'variants' }) =>
   css(get(theme, __themeKey + '.' + variant, get(theme, variant)))
-const variants = ({ theme, variants = [], __themeKey = 'variants' }) =>
-  css(merge(variants.map(v => get(theme, __themeKey + '.' + v, get(theme, v)))))
+const variants = ({ theme, variants = [], __themeKey = 'variants' }) => {
+  if (!Array.isArray(variants)) return {}
+  return css(
+    deepmerge.all(
+      variants.map(v => get(theme, __themeKey + '.' + v, get(theme, v)))
+    )
+  )
+}
 
 export const Box = styled('div', {
   shouldForwardProp,

--- a/packages/components/src/Box.js
+++ b/packages/components/src/Box.js
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled'
 import { css, get } from '@theme-ui/css'
+import { merge } from '@theme-ui/core'
 import { createShouldForwardProp } from '@styled-system/should-forward-prop'
 import space from '@styled-system/space'
 import color from '@styled-system/color'
@@ -13,6 +14,8 @@ const sx = props => css(props.sx)(props.theme)
 const base = props => css(props.__css)(props.theme)
 const variant = ({ theme, variant, __themeKey = 'variants' }) =>
   css(get(theme, __themeKey + '.' + variant, get(theme, variant)))
+const variants = ({ theme, variants = [], __themeKey = 'variants' }) =>
+  css(merge(variants.map(v => get(theme, __themeKey + '.' + v, get(theme, v)))))
 
 export const Box = styled('div', {
   shouldForwardProp,
@@ -23,6 +26,7 @@ export const Box = styled('div', {
     minWidth: 0,
   },
   base,
+  variants,
   variant,
   space,
   color,

--- a/packages/components/test/__snapshots__/index.js.snap
+++ b/packages/components/test/__snapshots__/index.js.snap
@@ -180,6 +180,18 @@ exports[`Box renders 1`] = `
 </div>
 `;
 
+exports[`Box renders with incorrect type of variants prop 1`] = `
+.emotion-0 {
+  box-sizing: border-box;
+  margin: 0;
+  min-width: 0;
+}
+
+<div
+  className="emotion-0"
+/>
+`;
+
 exports[`Button renders 1`] = `
 .emotion-0 {
   box-sizing: border-box;

--- a/packages/components/test/index.js
+++ b/packages/components/test/index.js
@@ -147,6 +147,27 @@ describe('Box', () => {
     expect(json).toHaveStyleRule('color', 'white')
   })
 
+  test('renders with variant and variants prop', () => {
+    const json = renderJSON(
+      <ThemeProvider theme={theme}>
+        <Box variant="text.heading" variants={['boxes.beep', 'boxes.boop']} />
+      </ThemeProvider>
+    )
+    expect(json).toHaveStyleRule('font-size', '32px')
+    expect(json).toHaveStyleRule('padding', '32px')
+    expect(json).toHaveStyleRule('background-color', 'tomato')
+    expect(json).toHaveStyleRule('color', 'white')
+  })
+
+  test('renders with incorrect type of variants prop', () => {
+    const json = renderJSON(
+      <ThemeProvider theme={theme}>
+        <Box variants="boxes.beep" />
+      </ThemeProvider>
+    )
+    expect(json).toMatchSnapshot()
+  })
+
   test('renders with base styles', () => {
     const json = renderJSON(
       <Box

--- a/packages/components/test/index.js
+++ b/packages/components/test/index.js
@@ -48,6 +48,10 @@ const theme = {
       p: 4,
       bg: 'highlight',
     },
+    boop: {
+      bg: 'tomato',
+      color: 'white',
+    },
   },
   cards: {
     primary: {
@@ -130,6 +134,17 @@ describe('Box', () => {
     )
     expect(json).toHaveStyleRule('background-color', 'highlight')
     expect(json).toHaveStyleRule('padding', '32px')
+  })
+
+  test('renders with variants prop', () => {
+    const json = renderJSON(
+      <ThemeProvider theme={theme}>
+        <Box variants={['boxes.beep', 'boxes.boop']} />
+      </ThemeProvider>
+    )
+    expect(json).toHaveStyleRule('padding', '32px')
+    expect(json).toHaveStyleRule('background-color', 'tomato')
+    expect(json).toHaveStyleRule('color', 'white')
   })
 
   test('renders with base styles', () => {

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -8,6 +8,9 @@
     "prepare": "microbundle --no-compress",
     "watch": "microbundle watch --no-compress"
   },
+  "dependencies": {
+    "deepmerge": "^4.2.2"
+  },
   "author": "Brent Jackson",
   "license": "MIT",
   "publishConfig": {

--- a/packages/css/src/index.js
+++ b/packages/css/src/index.js
@@ -1,3 +1,5 @@
+import { all } from 'deepmerge'
+
 export const get = (obj, key, def, p, undef) => {
   key = key && key.split ? key.split('.') : [key]
   for (p = 0; p < key.length; p++) {
@@ -188,6 +190,12 @@ export const css = args => (props = {}) => {
     if (key === 'variant') {
       const variant = css(get(theme, val))(theme)
       result = { ...result, ...variant }
+      continue
+    }
+
+    if (key === 'variants' && typeof val === 'array') {
+      const variants = css(all(val.map(v => get(theme, v))(theme)))
+      result = { ...result, ...variants }
       continue
     }
 

--- a/packages/css/src/index.js
+++ b/packages/css/src/index.js
@@ -193,8 +193,8 @@ export const css = args => (props = {}) => {
       continue
     }
 
-    if (key === 'variants' && typeof val === 'array') {
-      const variants = css(all(val.map(v => get(theme, v))(theme)))
+    if (key === 'variants') {
+      const variants = css(get(theme, val))(theme)
       result = { ...result, ...variants }
       continue
     }

--- a/packages/css/test/index.js
+++ b/packages/css/test/index.js
@@ -230,6 +230,21 @@ test('handles responsive variants', () => {
   })
 })
 
+test('returns multiple variants from theme', () => {
+  const result = css({
+    variants: ['text.caps', 'text.title'],
+  })(theme)
+  expect(result).toEqual({
+    fontSize: 16,
+    letterSpacing: '-0.01em',
+    textTransform: 'uppercase',
+    '@media screen and (min-width: 40em)': {
+      fontSize: 16,
+      letterSpacing: '-0.02em',
+    },
+  })
+})
+
 test('handles negative margins from scale', () => {
   const result = css({
     mt: -3,

--- a/packages/docs/src/pages/components/variants.mdx
+++ b/packages/docs/src/pages/components/variants.mdx
@@ -64,6 +64,17 @@ For example, a secondary button style can be added to `theme.buttons.secondary` 
 </Button>
 ```
 
+## Combining Multiple Variants
+
+If you want to combine multiple variants on the same element, pass an array of variants with the `variants` prop.
+If styles conflict, those of the variant passed later will render.
+
+```jsx live=true
+<Text variants={['caps', 'heading']}>
+  Title text
+</Text>
+```
+
 ## Example Theme
 
 ```js

--- a/packages/docs/src/pages/guides/variants.mdx
+++ b/packages/docs/src/pages/guides/variants.mdx
@@ -29,6 +29,9 @@ For example, you can define `primary` and `secondary` variants for buttons and u
       color: 'white',
       bg: 'secondary',
     },
+    small: {
+      fontSize: 1
+    }
   },
 }
 ```
@@ -50,6 +53,15 @@ When using the built-in [`Button` component](/components/button), you can set th
 Variants can use any name you choose, and deeply nested objects can be accessed with dot notation.
 
 </Note>
+
+## Combining Multiple Variants
+
+If you want to combine multiple variants on the same element, pass an array to `variants` in the `sx` prop.
+If styles conflict, those of the variant passed later will render.
+
+```jsx
+<button sx={{ variants: ['buttons.primary', 'buttons.small'] }} />
+```
 
 ## Color Modes
 


### PR DESCRIPTION
Inspired by #403, I've added support for combining multiple variants by passing `variants` an array. It's a new prop on components, or a property inside `sx`.

- Docs & tests are included for both `components` & `css`.
- The new test on `css` is failing because something about my implementation in `css` doesn't work—to be honest, I have no idea what's wrong & would super appreciate some assistance there.
- Targeting v0.3 because I don't want to create more work with upgrading this :)
- Added to changelog