### PR TITLE
[docs] Fix components variants example

### DIFF
--- a/packages/docs/src/pages/components/index.mdx
+++ b/packages/docs/src/pages/components/index.mdx
@@ -33,11 +33,11 @@ Each component accepts a `variant` prop to quickly
 change custom stylistic variations that you define.
 
 ```js
-// example theme
 {
-  // base theme...
+  // ...base theme...
+  // After the base theme, define the variants:
   buttons: {
-    primary: {
+    secondary: {
       fontWeight: 'bold',
       color: 'white',
       bg: 'primary',

--- a/packages/docs/src/pages/components/variants.mdx
+++ b/packages/docs/src/pages/components/variants.mdx
@@ -69,9 +69,10 @@ For example, a secondary button style can be added to `theme.buttons.secondary` 
 ```js
 // example theme
 {
-  // base theme...
+  // ...base theme...
+  // After the base theme, define the variants:
   buttons: {
-    primary: {
+    secondary: {
       fontWeight: 'bold',
       color: 'white',
       bg: 'primary',


### PR DESCRIPTION
The displayed example component is a secondary button, yet the specified example theme doesn't have a secondary variant for buttons defined, which is incongruent.

This fixes it by renaming the variant defined in the example theme