### PR TITLE
Update theme scales in documentation

### DIFF
--- a/packages/css/src/index.js
+++ b/packages/css/src/index.js
@@ -31,7 +31,7 @@ const aliases = {
   py: 'paddingY',
 }
 
-const multiples = {
+export const multiples = {
   marginX: ['marginLeft', 'marginRight'],
   marginY: ['marginTop', 'marginBottom'],
   paddingX: ['paddingLeft', 'paddingRight'],
@@ -39,7 +39,7 @@ const multiples = {
   size: ['width', 'height'],
 }
 
-const scales = {
+export const scales = {
   color: 'colors',
   backgroundColor: 'colors',
   borderColor: 'colors',

--- a/packages/docs/src/components/theme-scales.js
+++ b/packages/docs/src/components/theme-scales.js
@@ -1,0 +1,56 @@
+/** @jsx jsx */
+import { jsx } from 'theme-ui'
+import { scales, multiples } from '../../../css/src'
+import { Styled } from 'theme-ui'
+
+const camelDash = string =>
+  string.replace(/([A-Z])/g, g => `-${g[0].toLowerCase()}`)
+
+const alphabeticSort = (a, b) =>
+  a.localeCompare(b, undefined, {
+    sensitivity: 'base',
+  })
+
+export default props => {
+  const exclude = Object.keys(multiples)
+  const table = Object.keys(scales).reduce((acc, curr) => {
+    if (!Array.isArray(acc[scales[curr]])) {
+      acc[scales[curr]] = []
+    }
+    // Exclude `multiples` as they're not real CSS properties
+    if (!exclude.includes(curr)) {
+      acc[scales[curr]].push(camelDash(curr))
+    }
+    return acc
+  }, {})
+
+  return (
+    <Styled.table>
+      <thead>
+        <tr>
+          <th>Theme Key</th>
+          <th>CSS Properties</th>
+        </tr>
+      </thead>
+      <tbody>
+        {Object.keys(table)
+          .sort(alphabeticSort)
+          .map(key => (
+            <tr>
+              <td>
+                <Styled.inlineCode>{key}</Styled.inlineCode>
+              </td>
+              <td>
+                {table[key].map((property, index) => (
+                  <Styled.inlineCode>
+                    {!!index && ', '}
+                    {property}
+                  </Styled.inlineCode>
+                ))}
+              </td>
+            </tr>
+          ))}
+      </tbody>
+    </Styled.table>
+  )
+}

--- a/packages/docs/src/pages/theme-spec.mdx
+++ b/packages/docs/src/pages/theme-spec.mdx
@@ -3,6 +3,7 @@ title: Theme Spec
 ---
 
 import Note from '../components/note'
+import ThemeScales from '../components/theme-scales'
 
 # Theme Specification
 
@@ -22,22 +23,7 @@ The theme object is made up of the following data types:
 
 The `theme` object is made up of the following scales (i.e. property-specific objects) for use in CSS styles.
 
-| Theme Key        | CSS Properties                                                                                                                                                                                     |
-| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `colors`         | `color`, `background-color`, `border-color`                                                                                                                                                        |
-| `fonts`          | `font-family`                                                                                                                                                                                      |
-| `fontSizes`      | `font-size`                                                                                                                                                                                        |
-| `fontWeights`    | `font-weight`                                                                                                                                                                                      |
-| `lineHeights`    | `line-height`                                                                                                                                                                                      |
-| `space`          | `margin`, `margin-top`, `margin-right`, `margin-bottom`, `margin-left`, `padding`, `padding-top`, `padding-right`, `padding-bottom`, `padding-left`, `grid-gap`, `grid-column-gap`, `grid-row-gap` |
-| `letterSpacings` | `letter-spacing`                                                                                                                                                                                   |
-| `sizes`          | `width`, `height`, `min-width`, `max-width`, `min-height`, `max-height`                                                                                                                            |
-| `borders`        | `border`, `border-top`, `border-right`, `border-bottom`, `border-left`                                                                                                                             |
-| `borderWidths`   | `border-width`                                                                                                                                                                                     |
-| `borderStyles`   | `border-style`                                                                                                                                                                                     |
-| `radii`          | `border-radius`                                                                                                                                                                                    |
-| `shadows`        | `box-shadow`, `text-shadow`                                                                                                                                                                        |
-| `zIndices`       | `z-index`                                                                                                                                                                                          |
+<ThemeScales />
 
 <Note>
 


### PR DESCRIPTION
As discussed in #416, this PR adds a `ThemeScales` component which generates a table directly from the scales defined in the css package.