### PR TITLE
Clarify Gatsby link imports in docs

### DIFF
--- a/packages/docs/src/recipes/gatsby-link.mdx
+++ b/packages/docs/src/recipes/gatsby-link.mdx
@@ -4,8 +4,25 @@ name: 'Gatsby Link'
 
 # Gatsby Link
 
-Add an active style to Gatsby Link or other React router link components.
-Import the [custom JSX pragma](/guides/jsx-pragma) for styling the router link components without wrappers.
+Add an active style to [Gatsby Link] or other React router link components.
+Import the Theme UI [custom JSX pragma](/guides/jsx-pragma) for styling
+the router link components directly, without using wrapper components.
+
+```jsx live
+<Link
+  to='/recipes/gatsby-link/'
+  activeClassName='active'
+  sx={{
+    color: 'inherit',
+    '&.active': {
+      color: 'primary',
+    }
+  }}>
+  Link
+</Link>
+```
+
+Full code for this example:
 
 ```jsx
 /** @jsx jsx */
@@ -25,16 +42,4 @@ export default props =>
   />
 ```
 
-```jsx live
-<Link
-  to='/recipes/gatsby-link/'
-  activeClassName='active'
-  sx={{
-    color: 'inherit',
-    '&.active': {
-      color: 'primary',
-    }
-  }}>
-  Link
-</Link>
-```
+[Gatsby Link]: https://www.gatsbyjs.org/docs/linking-between-pages/

--- a/packages/docs/src/recipes/gatsby-link.mdx
+++ b/packages/docs/src/recipes/gatsby-link.mdx
@@ -5,20 +5,7 @@ name: 'Gatsby Link'
 # Gatsby Link
 
 Add an active style to Gatsby Link or other React router link components.
-
-```jsx live
-<Link
-  to='/recipes/gatsby-link/'
-  activeClassName='active'
-  sx={{
-    color: 'inherit',
-    '&.active': {
-      color: 'primary',
-    }
-  }}>
-  Link
-</Link>
-```
+Import the [custom JSX pragma](/guides/jsx-pragma) for styling the router link components without wrappers.
 
 ```jsx
 /** @jsx jsx */
@@ -36,4 +23,18 @@ export default props =>
       }
     }}
   />
+```
+
+```jsx live
+<Link
+  to='/recipes/gatsby-link/'
+  activeClassName='active'
+  sx={{
+    color: 'inherit',
+    '&.active': {
+      color: 'primary',
+    }
+  }}>
+  Link
+</Link>
 ```


### PR DESCRIPTION
Not super ideal that (I don’t think) we can include the imports directly in the live example, but I think this is a bit clearer about what to import & then giving a playground for changing the design.

Closes #597