### PR TITLE
Accept object fontSize values for style guide

### DIFF
--- a/packages/style-guide/src/TypeScale.js
+++ b/packages/style-guide/src/TypeScale.js
@@ -11,6 +11,7 @@ const getValue = (fontSizes, key) => {
 
 export const TypeScale = ({ reverse = true, ...props }) => {
   const { fontSizes = [] } = useTheme()
+  const fontSizesArray = Object.values(fontSizes)
 
   return (
     <div
@@ -20,8 +21,8 @@ export const TypeScale = ({ reverse = true, ...props }) => {
         alignItems: 'baseline',
       }}
     >
-      {fontSizes.map((n, i) => {
-        const key = reverse ? fontSizes.length - 1 - i : i
+      {fontSizesArray.map((n, i) => {
+        const key = reverse ? fontSizesArray.length - 1 - i : i
         return (
           <TypeStyle
             key={i}
@@ -29,7 +30,7 @@ export const TypeScale = ({ reverse = true, ...props }) => {
             sx={{
               mr: 3,
             }}
-            children={getValue(fontSizes, key)}
+            children={getValue(fontSizesArray, key)}
             {...props}
           />
         )


### PR DESCRIPTION
As outlined [in the docs](https://theme-ui.com/theme-spec#font-sizes-typographic-scale), the `fontSizes` scale may be defined as an object instead of an array. To avoid an error being thrown, `Object.values(fontSizes)` should be used instead of `fontSizes` when mapping through values.