### PR TITLE
Export types from @theme-ui/core

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,8 @@ import deepmerge from 'deepmerge'
 import { version as __EMOTION_VERSION__ } from '@emotion/core/package.json'
 import { Theme } from './theme'
 
+export * from './theme'
+
 const getCSS = props => {
   if (!props.sx && !props.css) return undefined
   return theme => {


### PR DESCRIPTION
### Before

Theme can be imported from `@theme-ui/core/dist/theme`
```ts
import { Theme } from '@theme-ui/core/dist/theme'
```

### After

Theme, and all types originally defined in `@types/theme-ui` can be imported from `@theme-ui/core`
```ts
import { Theme } from '@theme-ui/core'
```

I listed exported types below:

- ColorMode
- SxStyleProp
- SxProps
- IntrinsicSxElements
- Theme