### PR TITLE
(@theme-ui/css) adopt TypeScript

### DIFF
--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -12,5 +12,14 @@
   "license": "MIT",
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "csstype": "^2.5.7"
+  },
+  "devDependencies": {
+    "@theme-ui/core": "0.3.1"
+  },
+  "peerDependencies": {
+    "@theme-ui/core": "0.3.1"
   }
 }

--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -1,7 +1,13 @@
-export const get = (obj, key, def, p, undef) => {
-  key = key && key.split ? key.split('.') : [key]
-  for (p = 0; p < key.length; p++) {
-    obj = obj ? obj[key[p]] : undef
+export const get = (
+  obj: object,
+  key: string | number,
+  def?: unknown,
+  p: unknown,
+  undef: unknown
+) => {
+  const path = key && typeof key === 'string' ? key.split('.') : [key]
+  for (p = 0; p < path.length; p++) {
+    obj = obj ? obj[path[p]] : undef
   }
   return obj === undef ? def : obj
 }

--- a/packages/css/src/types.ts
+++ b/packages/css/src/types.ts
@@ -1,0 +1,390 @@
+/**
+ * Copied and adapted from @types/styled-system__css
+ * https://github.com/DefinitelyTyped/DefinitelyTyped/blob/028c46f833ffbbb0328a28ae6177923998fcf0cc/types/styled-system__css/index.d.ts
+ */
+
+import * as CSS from 'csstype'
+
+type StandardCSSProperties = CSS.PropertiesFallback<number | string>
+
+/**
+ * The `css` function accepts arrays as values for mobile-first responsive styles.
+ * Note that this extends to non-theme values also. For example `display=['none', 'block']`
+ * will also works.
+ *
+ * For more information see: https://styled-system.com/responsive-styles
+ */
+export type ResponsiveStyleValue<T> = T | Array<T | null>
+
+/**
+ * All non-vendor-prefixed CSS properties. (Allow `number` to support CSS-in-JS libs,
+ * since they are converted to pixels)
+ */
+export interface CSSProperties
+  extends CSS.StandardProperties<number | string>,
+    CSS.SvgProperties<number | string> {}
+
+/**
+ * Map of all CSS pseudo selectors (`:hover`, `:focus`, ...)
+ */
+export type CSSPseudoSelectorProps = { [K in CSS.Pseudos]?: SystemStyleObject }
+
+/**
+ * CSS as POJO that is compatible with CSS-in-JS libaries.
+ * Copied directly from [emotion](https://github.com/emotion-js/emotion/blob/ca3ad1c1dcabf78a95b55cc2dc94cad1998a3196/packages/serialize/types/index.d.ts#L45) types
+ */
+export interface CSSObject
+  extends CSSPropertiesWithMultiValues,
+    CSSPseudosForCSSObject,
+    CSSOthersObjectForCSSObject {}
+
+type CSSPropertiesWithMultiValues = {
+  [K in keyof CSSProperties]: CSSProperties[K]
+}
+type CSSPseudosForCSSObject = { [K in CSS.Pseudos]?: CSSObject }
+type CSSInterpolation = undefined | number | string | CSSObject
+interface CSSOthersObjectForCSSObject {
+  [propertiesName: string]: CSSInterpolation
+}
+
+/**
+ * Map all nested selectors
+ */
+interface CSSSelectorObject {
+  [cssSelector: string]: SystemStyleObject
+}
+
+interface AliasesCSSProperties {
+  /**
+   * The **`background-color`** CSS property sets the background color of an element.
+   *
+   * **Initial value**: `transparent`
+   *
+   * | Chrome | Firefox | Safari |  Edge  |  IE   |
+   * | :----: | :-----: | :----: | :----: | :---: |
+   * | **1**  |  **1**  | **1**  | **12** | **4** |
+   *
+   * @see https://developer.mozilla.org/docs/Web/CSS/background-color
+   */
+  bg?: StandardCSSProperties['backgroundColor']
+  /**
+   * The **`margin`** CSS property sets the margin area on all four sides of an element. It is a shorthand for `margin-top`, `margin-right`, `margin-bottom`, and `margin-left`.
+   *
+   * | Chrome | Firefox | Safari |  Edge  |  IE   |
+   * | :----: | :-----: | :----: | :----: | :---: |
+   * | **1**  |  **1**  | **1**  | **12** | **3** |
+   *
+   * @see https://developer.mozilla.org/docs/Web/CSS/margin
+   */
+  m?: StandardCSSProperties['margin']
+  /**
+   * The **`margin-top`** CSS property sets the margin area on the top of an element. A positive value places it farther from its neighbors, while a negative value places it closer.
+   *
+   * **Initial value**: `0`
+   *
+   * | Chrome | Firefox | Safari |  Edge  |  IE   |
+   * | :----: | :-----: | :----: | :----: | :---: |
+   * | **1**  |  **1**  | **1**  | **12** | **3** |
+   *
+   * @see https://developer.mozilla.org/docs/Web/CSS/margin-top
+   */
+  mt?: StandardCSSProperties['marginTop']
+  /**
+   * The **`margin-right`** CSS property sets the margin area on the right side of an element. A positive value places it farther from its neighbors, while a negative value places it closer.
+   *
+   * **Initial value**: `0`
+   *
+   * | Chrome | Firefox | Safari |  Edge  |  IE   |
+   * | :----: | :-----: | :----: | :----: | :---: |
+   * | **1**  |  **1**  | **1**  | **12** | **3** |
+   *
+   * @see https://developer.mozilla.org/docs/Web/CSS/margin-right
+   */
+  mr?: StandardCSSProperties['marginRight']
+  /**
+   * The **`margin-bottom`** CSS property sets the margin area on the bottom of an element. A positive value places it farther from its neighbors, while a negative value places it closer.
+   *
+   * **Initial value**: `0`
+   *
+   * | Chrome | Firefox | Safari |  Edge  |  IE   |
+   * | :----: | :-----: | :----: | :----: | :---: |
+   * | **1**  |  **1**  | **1**  | **12** | **3** |
+   *
+   * @see https://developer.mozilla.org/docs/Web/CSS/margin-bottom
+   */
+  mb?: StandardCSSProperties['marginBottom']
+  /**
+   * The **`margin-left`** CSS property sets the margin area on the left side of an element. A positive value places it farther from its neighbors, while a negative value places it closer.
+   *
+   * **Initial value**: `0`
+   *
+   * | Chrome | Firefox | Safari |  Edge  |  IE   |
+   * | :----: | :-----: | :----: | :----: | :---: |
+   * | **1**  |  **1**  | **1**  | **12** | **3** |
+   *
+   * @see https://developer.mozilla.org/docs/Web/CSS/margin-left
+   */
+  ml?: StandardCSSProperties['marginLeft']
+  /**
+   * The **`mx`** is shorthand for using both **`margin-left`** and **`margin-right`** CSS properties. They set the margin area on the left and right side of an element. A positive value placesit
+   * farther from its neighbors, while a negative value places it closer.
+   *
+   * **Initial value**: `0`
+   *
+   * | Chrome | Firefox | Safari |  Edge  |  IE   |
+   * | :----: | :-----: | :----: | :----: | :---: |
+   * | **1**  |  **1**  | **1**  | **12** | **3** |
+   *
+   * @see https://styled-system.com/#margin-props
+   * @see https://developer.mozilla.org/docs/Web/CSS/margin-left
+   * @see https://developer.mozilla.org/docs/Web/CSS/margin-right
+   */
+  mx?: StandardCSSProperties['marginLeft']
+  /**
+   * The **`marginX`** is shorthand for using both **`margin-left`** and **`margin-right`** CSS properties. They set the margin area on the left and right side of an element. A positive value
+   * places it farther from its neighbors, while a negative value places it closer.
+   *
+   * **Initial value**: `0`
+   *
+   * | Chrome | Firefox | Safari |  Edge  |  IE   |
+   * | :----: | :-----: | :----: | :----: | :---: |
+   * | **1**  |  **1**  | **1**  | **12** | **3** |
+   *
+   * @see https://styled-system.com/#margin-props
+   * @see https://developer.mozilla.org/docs/Web/CSS/margin-left
+   * @see https://developer.mozilla.org/docs/Web/CSS/margin-right
+   */
+  marginX?: StandardCSSProperties['marginLeft']
+  /**
+   * The **`my`** is shorthard for using both **`margin-top`** and **`margin-bottom`** CSS properties. They set the margin area on the top and bottom of an element. A positive value places it
+   * farther from its neighbors, while a negative value places it closer.
+   *
+   * **Initial value**: `0`
+   *
+   * | Chrome | Firefox | Safari |  Edge  |  IE   |
+   * | :----: | :-----: | :----: | :----: | :---: |
+   * | **1**  |  **1**  | **1**  | **12** | **3** |
+   *
+   * @see https://styled-system.com/#margin-props
+   * @see https://developer.mozilla.org/docs/Web/CSS/margin-top
+   * @see https://developer.mozilla.org/docs/Web/CSS/margin-bottom
+   */
+  my?: StandardCSSProperties['marginTop']
+  /**
+   * The **`marginY`** is shorthard for using both **`margin-top`** and **`margin-bottom`** CSS properties. They set the margin area on the top and bottom of an element. A positive value places
+   * it farther from its neighbors, while a negative value places it closer.
+   *
+   * **Initial value**: `0`
+   *
+   * | Chrome | Firefox | Safari |  Edge  |  IE   |
+   * | :----: | :-----: | :----: | :----: | :---: |
+   * | **1**  |  **1**  | **1**  | **12** | **3** |
+   *
+   * @see https://styled-system.com/#margin-props
+   * @see https://developer.mozilla.org/docs/Web/CSS/margin-top
+   * @see https://developer.mozilla.org/docs/Web/CSS/margin-bottom
+   */
+  marginY?: StandardCSSProperties['marginTop']
+  /**
+   * The **`padding`** CSS property sets the padding area on all four sides of an element. It is a shorthand for `padding-top`, `padding-right`, `padding-bottom`, and `padding-left`.
+   *
+   * | Chrome | Firefox | Safari |  Edge  |  IE   |
+   * | :----: | :-----: | :----: | :----: | :---: |
+   * | **1**  |  **1**  | **1**  | **12** | **4** |
+   *
+   * @see https://developer.mozilla.org/docs/Web/CSS/padding
+   */
+  p?: StandardCSSProperties['padding']
+  /**
+   * The **`padding-top`** padding area on the top of an element.
+   *
+   * **Initial value**: `0`
+   *
+   * | Chrome | Firefox | Safari |  Edge  |  IE   |
+   * | :----: | :-----: | :----: | :----: | :---: |
+   * | **1**  |  **1**  | **1**  | **12** | **4** |
+   *
+   * @see https://developer.mozilla.org/docs/Web/CSS/padding-top
+   */
+  pt?: StandardCSSProperties['paddingTop']
+  /**
+   * The **`padding-right`** CSS property sets the width of the padding area on the right side of an element.
+   *
+   * **Initial value**: `0`
+   *
+   * | Chrome | Firefox | Safari |  Edge  |  IE   |
+   * | :----: | :-----: | :----: | :----: | :---: |
+   * | **1**  |  **1**  | **1**  | **12** | **4** |
+   *
+   * @see https://developer.mozilla.org/docs/Web/CSS/padding-right
+   */
+  pr?: StandardCSSProperties['paddingRight']
+  /**
+   * The **`padding-bottom`** CSS property sets the height of the padding area on the bottom of an element.
+   *
+   * **Initial value**: `0`
+   *
+   * | Chrome | Firefox | Safari |  Edge  |  IE   |
+   * | :----: | :-----: | :----: | :----: | :---: |
+   * | **1**  |  **1**  | **1**  | **12** | **4** |
+   *
+   * @see https://developer.mozilla.org/docs/Web/CSS/padding-bottom
+   */
+  pb?: StandardCSSProperties['paddingBottom']
+  /**
+   * The **`padding-left`** CSS property sets the width of the padding area on the left side of an element.
+   *
+   * **Initial value**: `0`
+   *
+   * | Chrome | Firefox | Safari |  Edge  |  IE   |
+   * | :----: | :-----: | :----: | :----: | :---: |
+   * | **1**  |  **1**  | **1**  | **12** | **4** |
+   *
+   * @see https://developer.mozilla.org/docs/Web/CSS/padding-left
+   */
+  pl?: StandardCSSProperties['paddingLeft']
+  /**
+   * The **`px`** is shorthand property for CSS properties **`padding-left`** and **`padding-right`**. They set the width of the padding area on the left and right side of an element.
+   *
+   * **Initial value**: `0`
+   *
+   * | Chrome | Firefox | Safari |  Edge  |  IE   |
+   * | :----: | :-----: | :----: | :----: | :---: |
+   * | **1**  |  **1**  | **1**  | **12** | **4** |
+   *
+   * @see https://styled-system.com/#padding-props
+   * @see https://developer.mozilla.org/docs/Web/CSS/padding-left
+   * @see https://developer.mozilla.org/docs/Web/CSS/padding-right
+   */
+  px?: StandardCSSProperties['paddingLeft']
+  /**
+   * The **`paddingX`** is shorthand property for CSS properties **`padding-left`** and **`padding-right`**. They set the width of the padding area on the left and right side of an element.
+   *
+   * **Initial value**: `0`
+   *
+   * | Chrome | Firefox | Safari |  Edge  |  IE   |
+   * | :----: | :-----: | :----: | :----: | :---: |
+   * | **1**  |  **1**  | **1**  | **12** | **4** |
+   *
+   * @see https://styled-system.com/#padding-props
+   * @see https://developer.mozilla.org/docs/Web/CSS/padding-left
+   * @see https://developer.mozilla.org/docs/Web/CSS/padding-right
+   */
+  paddingX?: StandardCSSProperties['paddingLeft']
+  /**
+   * The **`py`** is shorthand property for CSS properties **`padding-top`** and **`padding-bottom`**. They set the width of the padding area on the top and bottom of an element.
+   *
+   * **Initial value**: `0`
+   *
+   * | Chrome | Firefox | Safari |  Edge  |  IE   |
+   * | :----: | :-----: | :----: | :----: | :---: |
+   * | **1**  |  **1**  | **1**  | **12** | **4** |
+   *
+   * @see https://styled-system.com/#padding-props
+   * @see https://developer.mozilla.org/docs/Web/CSS/padding-top
+   * @see https://developer.mozilla.org/docs/Web/CSS/padding-bottom
+   */
+  py?: StandardCSSProperties['paddingTop']
+  /**
+   * The **`paddingY`** is shorthand property for CSS properties **`padding-top`** and **`padding-bottom`**. They set the width of the padding area on the top and bottom of an element.
+   *
+   * **Initial value**: `0`
+   *
+   * | Chrome | Firefox | Safari |  Edge  |  IE   |
+   * | :----: | :-----: | :----: | :----: | :---: |
+   * | **1**  |  **1**  | **1**  | **12** | **4** |
+   *
+   * @see https://styled-system.com/#padding-props
+   * @see https://developer.mozilla.org/docs/Web/CSS/padding-top
+   * @see https://developer.mozilla.org/docs/Web/CSS/padding-bottom
+   */
+  paddingY?: StandardCSSProperties['paddingTop']
+}
+
+interface OverwriteCSSProperties {
+  /**
+   * The **`box-shadow`** CSS property adds shadow effects around an element's frame. You can set multiple effects separated by commas. A box shadow is described by X and Y offsets relative to the
+   * element, blur and spread radii, and color.
+   *
+   * **Initial value**: `none`
+   *
+   * | Chrome  | Firefox | Safari  |  Edge  |  IE   |
+   * | :-----: | :-----: | :-----: | :----: | :---: |
+   * | **10**  |  **4**  | **5.1** | **12** | **9** |
+   * | 1 _-x-_ |         | 3 _-x-_ |        |       |
+   *
+   * @see https://developer.mozilla.org/docs/Web/CSS/box-shadow
+   */
+  boxShadow?: CSS.BoxShadowProperty | number
+  /**
+   * The **`font-weight`** CSS property specifies the weight (or boldness) of the font. The font weights available to you will depend on the `font-family` you are using. Some fonts are only
+   * available in `normal` and `bold`.
+   *
+   * **Initial value**: `normal`
+   *
+   * | Chrome | Firefox | Safari |  Edge  |  IE   |
+   * | :----: | :-----: | :----: | :----: | :---: |
+   * | **2**  |  **1**  | **1**  | **12** | **3** |
+   *
+   * @see https://developer.mozilla.org/docs/Web/CSS/font-weight
+   */
+  fontWeight?: CSS.FontWeightProperty | string
+}
+
+/**
+ * Map of all available CSS properties (including aliases) and their raw value.
+ * Only used internally to map CCS properties to input types (responsive value,
+ * theme function or nested) in `SystemCssProperties`.
+ */
+interface AllSystemCSSProperties
+  extends Omit<CSSProperties, 'boxShadow' | 'fontWeight'>,
+    AliasesCSSProperties,
+    OverwriteCSSProperties {}
+
+export type SystemCssProperties = {
+  [K in keyof AllSystemCSSProperties]:
+    | ResponsiveStyleValue<AllSystemCSSProperties[K]>
+    | ((theme: any) => ResponsiveStyleValue<AllSystemCSSProperties[K]>)
+    | SystemStyleObject
+}
+
+interface VariantProperty {
+  /**
+   * **`Variants`** can be useful for applying complex styles to a component based on a single prop.
+   *
+   * @example
+   * const theme = {
+   *   buttons: {
+   *     primary: {
+   *       p: 3,
+   *       fontWeight: 'bold',
+   *       color: 'white',
+   *       bg: 'primary',
+   *       borderRadius: 2,
+   *     },
+   *   },
+   * }
+   * const result = css({
+   *   variant: 'buttons.primary',
+   * })(theme)
+   *
+   * @see https://styled-system.com/variants
+   */
+  variant: string
+}
+
+export interface UseThemeFunction {
+  (theme: any): Exclude<SystemStyleObject, UseThemeFunction>
+}
+
+/**
+ * The `SystemStyleObject` extends [style props](https://emotion.sh/docs/object-styles)
+ * such that properties that are part of the `Theme` will be transformed to
+ * their corresponding values. Other valid CSS properties are also allowed.
+ */
+export type SystemStyleObject =
+  | SystemCssProperties
+  | CSSPseudoSelectorProps
+  | CSSSelectorObject
+  | VariantProperty
+  | UseThemeFunction

--- a/packages/css/tsconfig.json
+++ b/packages/css/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../core/tsconfig.json",
+  "compilerOptions": {
+    // "strict": true
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1377,7 +1377,7 @@
     "@babel/parser" "^7.8.3"
     "@babel/types" "^7.8.3"
 
-"@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.4.3", "@babel/traverse@^7.4.4", "@babel/traverse@^7.6.0", "@babel/traverse@^7.7.2", "@babel/traverse@^7.7.4", "@babel/traverse@^7.8.0", "@babel/traverse@^7.8.4":
+"@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.4.3", "@babel/traverse@^7.4.4", "@babel/traverse@^7.6.0", "@babel/traverse@^7.7.2", "@babel/traverse@^7.7.4", "@babel/traverse@^7.8.0", "@babel/traverse@^7.8.3", "@babel/traverse@^7.8.4":
   version "7.8.4"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.8.4.tgz#f0845822365f9d5b0e312ed3959d3f827f869e3c"
   integrity sha512-NGLJPZwnVEyBPLI+bl9y9aSnxMhsKz42so7ApAv9D+b4vAFPpY013FTS9LdKxcABoIYFU52HcYga1pPlx454mg==
@@ -8182,6 +8182,11 @@ csstype@^2.2.0, csstype@^2.5.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.7.tgz#20b0024c20b6718f4eda3853a1f5a1cce7f5e4a5"
   integrity sha512-9Mcn9sFbGBAdmimWb2gLVDtFJzeKtDGIr76TUqmjZrw9LFXBMSU70lcs+C0/7fyCd6iBDqmksUcCOUIkisPHsQ==
+
+csstype@^2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.9.tgz#05141d0cd557a56b8891394c1911c40c8a98d098"
+  integrity sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"


### PR DESCRIPTION
Part of https://github.com/system-ui/theme-ui/issues/668

This is by no means a finished PR. I just wanted to push work on it a bit forward.
This may be the one of the trickiest packages in the repository to type.
`get` is the hardest part. Its namesake's types in @types/lodash don't look pretty.

I arrived at this `index.d.ts`
```ts
import { Theme } from '@theme-ui/core';
import * as CSS from 'csstype';
import { SystemStyleObject } from './types';
export * from './types';
export declare const get: (obj: object, key: string | number, def?: unknown, p?: number, undef?: unknown) => unknown;
export declare const multiples: {
    marginX: string[];
    marginY: string[];
    paddingX: string[];
    paddingY: string[];
    size: string[];
};
export declare const scales: {
    readonly color: "colors";
    // redacted
    readonly fill: "colors";
    readonly stroke: "colors";
};
interface CssPropsArg {
    theme?: Theme;
    [key: string]: unknown;
}
export declare const css: (args: SystemStyleObject) => (props?: CssPropsArg) => CSS.Properties<string | 0>;
```