### PR TITLE
@theme-ui/color - remove number arg as it's not used

### DIFF
--- a/packages/color/src/index.js
+++ b/packages/color/src/index.js
@@ -28,4 +28,4 @@ export const mix = (a, b, n = 0.5) => t => P.mix(n, g(t, a), g(t, b))
 export const complement = c => t => P.complement(g(t, c))
 export const invert = c => t => P.invert(g(t, c))
 
-export const grayscale = (c, n) => desaturate(c, 1)
+export const grayscale = c => desaturate(c, 1)


### PR DESCRIPTION
Removed number argument as it's not being used in `grayscale` function.
As I understand it, the value has to be 1 for the color to be greyscaled.
