### PR TITLE
fix combobox overriding property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Removes overriding property on editor combobox
 - Adjust media query sort logic #600
 - Fixed link to Gatsby Plugin page in `getting-started` page. Issue #602
 

--- a/packages/editor/src/Combobox.js
+++ b/packages/editor/src/Combobox.js
@@ -119,7 +119,6 @@ export default ({
       }}
       sx={{
         zIndex: 2,
-        color: 'black',
       }}>
       <Label htmlFor={name}>
         {label || name}

--- a/packages/editor/test/__snapshots__/Combobox.js.snap
+++ b/packages/editor/test/__snapshots__/Combobox.js.snap
@@ -3,7 +3,6 @@
 exports[`renders 1`] = `
 .emotion-6 {
   z-index: 2;
-  color: black;
 }
 
 .emotion-0 {


### PR DESCRIPTION
i just stumble upon that page: https://theme-ui.com/customize and realize that combobox have a ```color: black``` that make it unreadable on black and deep theme