### PR TITLE
fix readme for preset-tailwind

### DIFF
--- a/packages/preset-tailwind/README.md
+++ b/packages/preset-tailwind/README.md
@@ -13,9 +13,10 @@ import theme from '@theme-ui/preset-tailwind'
 
 export default {
   ...theme,
-  styles: {
-    ...theme,
-  },
+  // You can extend the default theme like:
+  // styles: {
+  //   ...theme.presets,
+  //}
 }
 ```
 

--- a/packages/preset-tailwind/README.md
+++ b/packages/preset-tailwind/README.md
@@ -15,7 +15,7 @@ export default {
   ...theme,
   // You can extend the default theme like:
   // styles: {
-  //   ...theme.presets,
+  //   ...theme.styles,
   //}
 }
 ```


### PR DESCRIPTION
As styles is part of `theme` already, I guess the README is wrong. This should correct the docs :)


See: https://github.com/system-ui/theme-ui/blob/master/packages/preset-tailwind/src/index.ts#L552