### PR TITLE
task: add root tsconfig

### DIFF
--- a/packages/color/tsconfig.json
+++ b/packages/color/tsconfig.json
@@ -1,10 +1,4 @@
 {
-  "compilerOptions": {
-    "strict": true,
-
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "moduleResolution": "node"
-  },
+  "extends": "../../tsconfig.json",
   "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.d.ts"]
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,9 +1,8 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "moduleResolution": "node",
-    "jsx": "react"
+    "jsx": "react",
+    "strict": false
   },
   "include": ["./src/**/*.ts", "./src/**/*.tsx"]
 }

--- a/packages/css/tsconfig.json
+++ b/packages/css/tsconfig.json
@@ -1,5 +1,7 @@
 {
-  "extends": "../core/tsconfig.json",
-  "compilerOptions": {},
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "strict": false
+  },
   "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.d.ts"]
 }

--- a/packages/custom-properties/tsconfig.json
+++ b/packages/custom-properties/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "compilerOptions": {
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "moduleResolution": "node",
-    "strict": true
-  }
+  "extends": "../../tsconfig.json"
 }

--- a/packages/match-media/tsconfig.json
+++ b/packages/match-media/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "compilerOptions": {
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "moduleResolution": "node",
-    "strict": true
-  }
+  "extends": "../../tsconfig.json"
 }

--- a/packages/preset-base/tsconfig.json
+++ b/packages/preset-base/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "compilerOptions": {
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "moduleResolution": "node",
-    "strict": true
-  }
+  "extends": "../../tsconfig.json"
 }

--- a/packages/preset-bootstrap/tsconfig.json
+++ b/packages/preset-bootstrap/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "compilerOptions": {
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "moduleResolution": "node",
-    "strict": true
-  }
+  "extends": "../../tsconfig.json"
 }

--- a/packages/preset-bulma/tsconfig.json
+++ b/packages/preset-bulma/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "compilerOptions": {
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "moduleResolution": "node",
-    "strict": true
-  }
+  "extends": "../../tsconfig.json"
 }

--- a/packages/preset-dark/tsconfig.json
+++ b/packages/preset-dark/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "compilerOptions": {
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "moduleResolution": "node",
-    "strict": true
-  }
+  "extends": "../../tsconfig.json"
 }

--- a/packages/preset-deep/tsconfig.json
+++ b/packages/preset-deep/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "compilerOptions": {
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "moduleResolution": "node",
-    "strict": true
-  }
+  "extends": "../../tsconfig.json"
 }

--- a/packages/preset-funk/tsconfig.json
+++ b/packages/preset-funk/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "compilerOptions": {
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "moduleResolution": "node",
-    "strict": true
-  }
+  "extends": "../../tsconfig.json"
 }

--- a/packages/preset-future/tsconfig.json
+++ b/packages/preset-future/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "compilerOptions": {
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "moduleResolution": "node",
-    "strict": true
-  }
+  "extends": "../../tsconfig.json"
 }

--- a/packages/preset-polaris/tsconfig.json
+++ b/packages/preset-polaris/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "compilerOptions": {
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "moduleResolution": "node",
-    "strict": true
-  }
+  "extends": "../../tsconfig.json"
 }

--- a/packages/preset-roboto/tsconfig.json
+++ b/packages/preset-roboto/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "compilerOptions": {
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "moduleResolution": "node",
-    "strict": true
-  }
+  "extends": "../../tsconfig.json"
 }

--- a/packages/preset-swiss/tsconfig.json
+++ b/packages/preset-swiss/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "compilerOptions": {
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "moduleResolution": "node",
-    "strict": true
-  }
+  "extends": "../../tsconfig.json"
 }

--- a/packages/preset-system/tsconfig.json
+++ b/packages/preset-system/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "compilerOptions": {
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "moduleResolution": "node",
-    "strict": true
-  }
+  "extends": "../../tsconfig.json"
 }

--- a/packages/preset-tailwind/tsconfig.json
+++ b/packages/preset-tailwind/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "compilerOptions": {
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "moduleResolution": "node",
-    "strict": true
-  }
+  "extends": "../../tsconfig.json"
 }

--- a/packages/preset-tosh/tsconfig.json
+++ b/packages/preset-tosh/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "compilerOptions": {
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "moduleResolution": "node",
-    "strict": true
-  }
+  "extends": "../../tsconfig.json"
 }

--- a/packages/presets/tsconfig.json
+++ b/packages/presets/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "compilerOptions": {
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "moduleResolution": "node",
-    "strict": true
-  }
+  "extends": "../../tsconfig.json"
 }

--- a/packages/tachyons/tsconfig.json
+++ b/packages/tachyons/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "compilerOptions": {
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "moduleResolution": "node",
-    "strict": true
-  }
+  "extends": "../../tsconfig.json"
 }

--- a/packages/tailwind/tsconfig.json
+++ b/packages/tailwind/tsconfig.json
@@ -1,9 +1,4 @@
 {
-  "compilerOptions": {
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "moduleResolution": "node",
-    "strict": true
-  },
+  "extends": "../../tsconfig.json",
   "exclude": ["test"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "strict": true
+  }
+}


### PR DESCRIPTION
As mentioned in [this comment](https://github.com/system-ui/theme-ui/issues/668#issuecomment-588326836) as part of #668 it would be better to extend a core tsconfig file than duplicate the settings in every package. 

This PR introduces that change placing the core settings in a new `tsconfig.json` at the root level and then extended everywhere else. 

As strict mode was set in most packages I've included it in the root settings and disabled it the two places (core & css) which previously didn't have it set. You'll probably want to fix these packages in separate PRs.  

I wasn't clear if the intent was to have to root file called `.tsconfig.json` as mentioned in the comment, it didn't feel like the convention so it's currently `tsconfig.json` happy to change it if you'd like. 

I wasn't sure how to test this, test don't seem to be working, so I executed `yarn prepare` which passes in all packages. 