### PR TITLE
@theme-ui/match-media : Type variable

### DIFF
--- a/packages/match-media/src/index.ts
+++ b/packages/match-media/src/index.ts
@@ -52,9 +52,12 @@ export const useBreakpointIndex = (options: defaultOptions = {}) => {
   return value
 }
 
-type Values = ((theme: Theme | null) => string[]) | string[]
+type Values<T> = ((theme: Theme | null) => T[]) | T[]
 
-export const useResponsiveValue = (values: Values, options: defaultOptions = {}) => {
+export function useResponsiveValue<T>(
+  values: Values<T>,
+  options: defaultOptions = {}
+): T {
   const { theme } = useThemeUI()
   const array = typeof values === 'function' ? values(theme) : values
   const index = useBreakpointIndex(options)


### PR DESCRIPTION
This is an addition to https://github.com/system-ui/theme-ui/pull/696

**Motivation**
Initially I wanted to work on adding typescript support for `useResponsiveValue` but saw today that I was too late 😄. This change allows to either pass or in most cases infer the type of the array. The uses cases range from a straight forward condition
```ts
 const isNarrow = useResponsiveValue([true, false]); // -> boolean
```
to more complex configurations
```ts
const layoutOptions = useResponsiveValue<LayoutOptions>( // inferred in most cases
[
  {columns: 1, ...},
  {columns: 2, ...},
]); // -> LayoutOptions 
```
all within one call.
