### PR TITLE
fix(@theme-ui/prism): Fix code block line height bug in Safari

### DIFF
--- a/packages/prism/src/index.js
+++ b/packages/prism/src/index.js
@@ -24,15 +24,12 @@ export default ({ children, className: outerClassName, title, ...props }) => {
         <Styled.pre className={`${outerClassName} ${className}`} style={style}>
           {tokens.map((line, i) => (
             <div {...getLineProps({ line, key: i })}>
-              {line.map((token, key) => {
-                const tokenProps = getTokenProps({ token, key })
-
-                if (line.length === 1 && !tokenProps.children) {
-                  tokenProps.sx = { display: 'inline-block' }
-                }
-
-                return <span {...tokenProps} />
-              })}
+              {line.map((token, key) => (
+                <span
+                  {...getTokenProps({ token, key })}
+                  sx={token.empty ? { display: 'inline-block' } : undefined}
+                />
+              ))}
             </div>
           ))}
         </Styled.pre>

--- a/packages/prism/src/index.js
+++ b/packages/prism/src/index.js
@@ -24,12 +24,15 @@ export default ({ children, className: outerClassName, title, ...props }) => {
         <Styled.pre className={`${outerClassName} ${className}`} style={style}>
           {tokens.map((line, i) => (
             <div {...getLineProps({ line, key: i })}>
-              {line.map((token, key) => (
-                <span
-                  {...getTokenProps({ token, key })}
-                  sx={{ display: 'inline-block' }}
-                />
-              ))}
+              {line.map((token, key) => {
+                const tokenProps = getTokenProps({ token, key })
+
+                if (line.length === 1 && !tokenProps.children) {
+                  tokenProps.sx = { display: 'inline-block' }
+                }
+
+                return <span {...tokenProps} />
+              })}
             </div>
           ))}
         </Styled.pre>


### PR DESCRIPTION
Safari renders a small space between inline-block elements, resulting in a variable height of lines which cause a scroll overflow depending on their width.

On iOS this results in the font size of each token being scaled up individually depending on the width of the token element. On desktop Safari the font size stays consistent and the text causes a line break.

This PR fixes that issue by removing `display: inline-block;` from all tokens except single empty elements in a line in order to preserve empty lines.

Screenshot desktop Safari:

<img width="1511" alt="Screenshot 2020-02-25 at 04 20 15" src="https://user-images.githubusercontent.com/31006608/75212282-be68e100-5786-11ea-8185-4e014153975f.png">

Screenshot iPhone:

![IMG_A6C3791072A9-1](https://user-images.githubusercontent.com/31006608/75212311-cf195700-5786-11ea-87ec-9921ab7613c7.jpeg)
