### PR TITLE
Link fix in docs.

### DIFF
--- a/packages/docs/src/pages/styling-mdx.mdx
+++ b/packages/docs/src/pages/styling-mdx.mdx
@@ -87,7 +87,7 @@ colors and other styles can be added to `theme.styles.pre` to target child eleme
 Prism.js adds `<span>` elements with class names that can be used as child selectors.
 
 
-To enable syntax highlighting in MDX, see the [`@theme-ui/prism`](/prism) package.
+To enable syntax highlighting in MDX, see the [`@theme-ui/prism`](/packages/prism) package.
 
 [prism.js]: https://github.com/PrismJS/prism
 


### PR DESCRIPTION
Fixed the link to `@theme-ui/prism` from [Styling MDX Content](https://theme-ui.com/styling-mdx#syntax-highlighting). The redirect works only if you open it in a new tab.