### PR TITLE
Add Gatsby doc to side bar

### DIFF
--- a/packages/docs/src/sidebar.mdx
+++ b/packages/docs/src/sidebar.mdx
@@ -1,5 +1,4 @@
-- Getting Started
-  - [Getting Started](/getting-started)
+- [Getting Started](/getting-started)
   - [Getting Started with Gatsby](/getting-started/gatsby)
 - [Theming](/theming)
 - [The `sx` Prop](/sx-prop)

--- a/packages/docs/src/sidebar.mdx
+++ b/packages/docs/src/sidebar.mdx
@@ -1,4 +1,6 @@
-- [Getting Started](/getting-started)
+- Getting Started
+  - [Getting Started](/getting-started)
+  - [Getting Started with Gatsby](/getting-started/gatsby)
 - [Theming](/theming)
 - [The `sx` Prop](/sx-prop)
 - [Styling MDX](/styling-mdx)
@@ -9,7 +11,6 @@
 - [API](/api)
 - [Theme Specification](/theme-spec)
 - [Customize](/customize)
-- [Theme UI and Gatsby](/getting-started/gatsby)
 - [Demo](/demo)
 - [Components](/components)
   - [Variants](/components/variants)

--- a/packages/docs/src/sidebar.mdx
+++ b/packages/docs/src/sidebar.mdx
@@ -9,6 +9,7 @@
 - [API](/api)
 - [Theme Specification](/theme-spec)
 - [Customize](/customize)
+- [Theme UI and Gatsby](/getting-started/gatsby)
 - [Demo](/demo)
 - [Components](/components)
   - [Variants](/components/variants)


### PR DESCRIPTION
In the long term, we should probably add more specifics to this doc so we can link from .org. However, first step is to make it more discoverable.