### PR TITLE
+ example filename to mdx-layout-components.mdx

### DIFF
--- a/packages/docs/src/pages/guides/mdx-layout-components.mdx
+++ b/packages/docs/src/pages/guides/mdx-layout-components.mdx
@@ -27,6 +27,7 @@ export default props => (
 To add styles to this component, add a `theme` prop to the `ThemeProvider` and an `sx` prop to the `div`.
 
 ```jsx
+// nile name: MyLayout.js
 /** @jsx jsx */
 import { jsx, ThemeProvider } from 'theme-ui'
 


### PR DESCRIPTION
Your documentation is very good, but I personally find it hard to link 2 examples together if there is no file name mentioned in the first.
My poor brain was looking for `export const MyLayout ...`.