### PR TITLE
Run CI on pull_request event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
Hey @mxstbr, I'm not sure if it's what you meant to and if it's correct (I didn't work at GitHub :P)

This should run the CI on new PRs.
Found the problem in https://github.com/system-ui/theme-ui/pull/754.