### PR TITLE
Discussion: Add `typecheck` scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "serve": "yarn workspace docs serve --port 8000",
     "clean": "lerna run clean",
     "format": "prettier --write \"**/*.js{,on}\" \"**/*.md\"  \"**/*.mdx\"",
-    "test": "lerna run typecheck && jest",
+    "typecheck": "lerna run typecheck",
+    "test": "yarn typecheck && jest",
     "logo": "yarn workspace docs logo",
     "dev:chrome": "yarn workspace @theme-ui/chrome dev",
     "dev:editor": "yarn workspace @theme-ui/editor dev"
@@ -39,7 +40,9 @@
     "react-test-renderer": "^16.8.6",
     "ts-jest": "^25.2.0"
   },
-  "resolutions": {},
+  "resolutions": {
+    "@types/vfile-message": "1.0.1"
+  },
   "jest": {
     "testMatch": [
       "**/packages/**/test/*.{js,ts,tsx}"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "serve": "yarn workspace docs serve --port 8000",
     "clean": "lerna run clean",
     "format": "prettier --write \"**/*.js{,on}\" \"**/*.md\"  \"**/*.mdx\"",
-    "test": "jest",
+    "test": "lerna run typecheck && jest",
     "logo": "yarn workspace docs logo",
     "dev:chrome": "yarn workspace @theme-ui/chrome dev",
     "dev:editor": "yarn workspace @theme-ui/editor dev"
@@ -41,21 +41,6 @@
   },
   "resolutions": {},
   "jest": {
-    "preset": "ts-jest/presets/js-with-babel",
-    "globals": {
-      "ts-jest": {
-        "tsConfig": {
-          "module": "commonjs",
-          "esModuleInterop": true,
-          "resolveJsonModule": true,
-          "jsx": "react",
-          "alwaysStrict": true,
-          "noImplicitThis": true,
-          "noImplicitAny": false,
-          "strictBindCallApply": false
-        }
-      }
-    },
     "testMatch": [
       "**/packages/**/test/*.{js,ts,tsx}"
     ],

--- a/packages/color/package.json
+++ b/packages/color/package.json
@@ -7,7 +7,8 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "prepare": "microbundle --no-compress",
-    "watch": "microbundle watch --no-compress"
+    "watch": "microbundle watch --no-compress",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@theme-ui/css": "^0.3.1",

--- a/packages/components/index.d.ts
+++ b/packages/components/index.d.ts
@@ -1,0 +1,335 @@
+import * as React from 'react';
+import { StyledComponent } from '@emotion/styled';
+import { InterpolationWithTheme } from '@emotion/core';
+import { SxStyleProp } from 'theme-ui';
+import { SpaceProps, ColorProps, MarginProps } from 'styled-system';
+import { ResponsiveStyleValue } from '@theme-ui/css';
+
+type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
+
+type Assign<T, U> = {
+    [P in keyof (T & U)]: P extends keyof T ? T[P] : P extends keyof U ? U[P] : never;
+};
+
+type ForwardRef<T, P> = React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<T>>;
+
+export interface BoxOwnProps extends SpaceProps, ColorProps {
+    as?: React.ElementType;
+    variant?: string;
+    css?: InterpolationWithTheme<any>;
+}
+export interface BoxProps extends Assign<React.ComponentProps<'div'>, BoxOwnProps> {}
+/**
+ * Use the Box component as a layout primitive to add margin, padding, and colors to content.
+ * @see https://theme-ui.com/components/box
+ */
+export const Box: StyledComponent<React.ComponentProps<'div'>, BoxOwnProps, {}>;
+
+export type FlexStyleProps = BoxOwnProps;
+export type FlexProps = BoxProps;
+/**
+ * Use the Flex component to create flexbox layouts.
+ * @see https://theme-ui.com/components/flex
+ */
+export const Flex: StyledComponent<React.ComponentProps<'div'>, FlexStyleProps, {}>;
+
+export interface GridProps extends BoxProps {
+    /**
+     * Minimum width of child elements
+     */
+    width?: ResponsiveStyleValue<string | number>;
+    /**
+     * 	Number of columns to use for the layout (cannot be used in conjunction with the width prop)
+     */
+    columns?: ResponsiveStyleValue<number>;
+    /**
+     * Space between child elements
+     */
+    gap?: ResponsiveStyleValue<string | number>;
+}
+/**
+ * CSS grid layout component to arrange direct child elements in a tiled grid layout.
+ * @see https://theme-ui.com/components/grid
+ */
+export const Grid: ForwardRef<HTMLDivElement, GridProps>;
+
+export interface ButtonProps extends Assign<React.ComponentPropsWithRef<'button'>, BoxOwnProps> {}
+/**
+ * Primitive button component with variants
+ * @see https://theme-ui.com/components/button
+ */
+export const Button: ForwardRef<HTMLButtonElement, ButtonProps>;
+
+export interface LinkProps extends Assign<React.ComponentPropsWithRef<'a'>, BoxOwnProps> {}
+/**
+ * Link variants can be defined in the `theme.links` object.
+ * By default the Link component will use styles defined in `theme.styles.a`.
+ * @see https://theme-ui.com/components/link
+ */
+export const Link: ForwardRef<HTMLAnchorElement, LinkProps>;
+
+export type TextProps = BoxProps;
+/**
+ * Primitive typographic component.
+ *
+ * Text style variants can be defined in the theme.text object.
+ * @see https://theme-ui.com/components/text
+ */
+export const Text: ForwardRef<HTMLDivElement, BoxProps>;
+
+export interface HeadingProps extends Assign<React.ComponentPropsWithRef<'h2'>, BoxOwnProps> {}
+/**
+ * Primitive heading component, defaults to <h2>.
+ *
+ * Text style variants can be defined in the theme.text object.
+ * The Heading component uses theme.text.heading as its default variant style.
+ * @see https://theme-ui.com/components/heading
+ */
+export const Heading: ForwardRef<HTMLHeadingElement, HeadingProps>;
+
+export interface ImageProps extends Assign<React.ComponentProps<'img'>, BoxOwnProps> {}
+/**
+ * Image style variants can be defined in the theme.images object.
+ * @see https://theme-ui.com/components/image/
+ */
+export const Image: ForwardRef<HTMLImageElement, ImageProps>;
+
+export type CardProps = BoxProps;
+/**
+ * Card style variants can be defined in the `theme.cards` object.
+ * By default the Card component uses the `theme.cards.primary` variant.
+ * @see https://theme-ui.com/components/card
+ */
+export const Card: ForwardRef<HTMLDivElement, CardProps>;
+
+export interface LabelProps extends Assign<React.ComponentProps<'label'>, BoxOwnProps> {}
+/**
+ * Label variants can be defined in `theme.forms`
+ * and the component uses the `theme.forms.label` variant by default.
+ * @see https://theme-ui.com/components/label/
+ */
+export const Label: ForwardRef<HTMLLabelElement, LabelProps>;
+
+export interface InputProps extends Assign<React.ComponentProps<'input'>, BoxOwnProps> {}
+/**
+ * Input variants can be defined in `theme.forms`
+ * and the component uses the `theme.forms.input` variant by default.
+ * @see https://theme-ui.com/components/input/
+ */
+export const Input: ForwardRef<HTMLInputElement, InputProps>;
+
+export interface SelectProps extends Assign<React.ComponentProps<'select'>, BoxOwnProps> {}
+/**
+ * Select variants can be defined in `theme.forms`
+ * and the component uses the `theme.forms.select` variant by default.
+ * @see https://theme-ui.com/components/select/
+ */
+export const Select: ForwardRef<HTMLSelectElement, SelectProps>;
+
+export interface TextareaProps extends Assign<React.ComponentProps<'textarea'>, BoxOwnProps> {}
+/**
+ * Form textarea component
+ *
+ * Textarea variants can be defined in `theme.forms`
+ * and the component uses the `theme.forms.textarea` variant by default.
+ * @see https://theme-ui.com/components/textarea/
+ */
+export const Textarea: ForwardRef<HTMLTextAreaElement, TextareaProps>;
+
+export interface RadioProps extends Assign<React.ComponentProps<'input'>, BoxOwnProps> {}
+/**
+ * Form radio input component
+ *
+ * Radio variants can be defined in `theme.forms` and the
+ * component uses the `theme.forms.radio variant` by default.
+ * @see https://theme-ui.com/components/radio/
+ */
+export const Radio: ForwardRef<HTMLInputElement, RadioProps>;
+
+export interface CheckboxProps extends Assign<React.ComponentProps<'input'>, BoxOwnProps> {}
+/**
+ * Form checkbox input component
+ *
+ * Checkbox variants can be defined in `theme.forms` and the
+ * component uses the `theme.forms.checkbox` variant by default.
+ * @see https://theme-ui.com/components/checkbox/
+ */
+export const Checkbox: ForwardRef<HTMLInputElement, CheckboxProps>;
+
+export interface SliderProps extends Assign<React.ComponentProps<'input'>, BoxOwnProps> {}
+/**
+ * Range input element
+ *
+ * Slider variants can be defined in the `theme.forms` object.
+ * The Slider component uses `theme.forms.slider` as its default variant style.
+ * @see https://theme-ui.com/components/slider/
+ */
+export const Slider: ForwardRef<HTMLInputElement, SliderProps>;
+
+export interface FieldOwnProps extends MarginProps {
+    /**
+     * Text for Label component
+     */
+    label: string;
+    /**
+     * Used for the for, id, and name attributes
+     */
+    name: string;
+}
+export type FieldProps<T extends React.ElementType> = FieldOwnProps &
+    Omit<React.ComponentProps<T>, 'as' | keyof FieldOwnProps> & {
+        /**
+         * form control to render, default Input
+         */
+        as?: T;
+    };
+
+// `T` is far from unnecessary. We derive component props from it.
+// tslint:disable-next-line no-unnecessary-generics
+export function Field<T extends React.ElementType = React.ElementType<InputProps>>(props: FieldProps<T>): JSX.Element;
+
+export interface ProgressProps extends Assign<React.ComponentProps<'progress'>, BoxOwnProps> {}
+/**
+ * @see https://theme-ui.com/components/progress/
+ */
+export const Progress: ForwardRef<HTMLProgressElement, ProgressProps>;
+
+export interface DonutProps
+    extends Omit<React.SVGProps<SVGSVGElement>, 'opacity' | 'color' | 'css' | 'sx' | 'max' | 'min'>,
+        BoxOwnProps {
+    value: number;
+    min?: number;
+    max?: number;
+    title?: string;
+    size?: string | number;
+}
+/**
+ * Single value SVG donut chart
+ * @see https://theme-ui.com/components/donut/
+ */
+export const Donut: ForwardRef<SVGSVGElement, DonutProps>;
+
+export interface SpinnerProps
+    extends Omit<React.SVGProps<SVGSVGElement>, 'opacity' | 'color' | 'css' | 'sx'>,
+        BoxOwnProps {
+    size?: number | string;
+}
+export const Spinner: ForwardRef<SVGSVGElement, SpinnerProps>;
+
+export interface AvatarProps extends ImageProps {
+    size?: number | string;
+}
+export const Avatar: ForwardRef<HTMLImageElement, AvatarProps>;
+
+export type BadgeProps = BoxProps;
+export const Badge: ForwardRef<HTMLDivElement, BadgeProps>;
+
+interface CloseProps extends Omit<IconButtonProps, 'children'> {}
+/**
+ * Button with close (×) icon.
+ *
+ * The Close component renders as a <button> element by default.
+ * Pass any button attributes as props to the component.
+ *
+ * Close component variants can be defined in the theme.buttons object.
+ * The Close component uses theme.buttons.close as its default variant style.
+ */
+export const Close: ForwardRef<HTMLButtonElement, CloseProps>;
+
+export type AlertProps = BoxProps;
+/**
+ * Component for displaying messages, notifications, or other application state.
+ *
+ * Alert variants can be defined in `theme.alerts`.
+ * The Alert component uses `theme.alerts.primary` as its default variant.
+ */
+export const Alert: ForwardRef<HTMLDivElement, AlertProps>;
+
+export type DividerProps = BoxProps;
+/**
+ * The Divider component reuses styles from `theme.styles.hr` as its default variant.
+ */
+export const Divider: ForwardRef<HTMLDivElement, DividerProps>;
+
+export interface EmbedProps extends BoxProps {
+    ratio?: number;
+    src?: React.IframeHTMLAttributes<any>['src'];
+    frameBorder?: React.IframeHTMLAttributes<any>['frameBorder'];
+    allowFullScreen?: React.IframeHTMLAttributes<any>['allowFullScreen'];
+    allow?: React.IframeHTMLAttributes<any>['allow'];
+}
+/**
+ * Responsive iframe for video embeds.
+ *
+ * Embed variants can be defined anywhere in the theme object.
+ *
+ * @see https://theme-ui.com/components/embed
+ */
+export const Embed: ForwardRef<HTMLIFrameElement, EmbedProps>;
+
+export interface AspectRatioProps extends BoxProps {
+    ratio?: number;
+}
+/**
+ * Component for maintaining a fluid-width aspect ratio
+ * @see https://theme-ui.com/components/aspect-ratio
+ */
+export const AspectRatio: ForwardRef<HTMLDivElement, AspectRatioProps>;
+
+export interface AspectImageProps extends ImageProps {
+    ratio?: number;
+}
+/**
+ * Image component constrained by as aspect ratio.
+ * @see https://theme-ui.com/components/aspect-image
+ */
+export const AspectImage: ForwardRef<HTMLImageElement, AspectImageProps>;
+
+export type ContainerProps = BoxProps;
+/**
+ * Centered, max-width layout component
+ *
+ * Container variants can be defined in the `theme.layout` object.
+ * The Container component uses `theme.layout.container` as its default variant style.
+ * @see https://theme-ui.com/components/container
+ */
+export const Container: ForwardRef<HTMLDivElement, ContainerProps>;
+
+export type NavLinkProps = LinkProps;
+/**
+ * Link component for use in navigation
+ *
+ * NavLink variants can be defined in the `theme.links` object.
+ * By default the NavLink component will use styles defined in `theme.links.nav`.
+ * @see https://theme-ui.com/components/nav-link
+ */
+export const NavLink: ForwardRef<HTMLAnchorElement, NavLinkProps>;
+
+export type MessageProps = BoxProps;
+/**
+ * Styled Box component for callouts and inline messages
+ *
+ * Message variants can be defined in the theme.messages object.
+ * @see https://theme-ui.com/components/message
+ */
+export const Message: ForwardRef<HTMLDivElement, MessageProps>;
+
+export interface IconButtonProps extends Assign<React.ComponentPropsWithRef<'button'>, BoxOwnProps> {}
+/**
+ * Transparent button for SVG icons
+ *
+ * IconButton variants can be defined in the `theme.buttons` object.
+ * By default the IconButton component will use styles defined in `theme.buttons.icon`.
+ *
+ * @see https://theme-ui.com/components/icon-button
+ */
+export const IconButton: ForwardRef<HTMLButtonElement, BoxProps>;
+
+export type MenuButtonProps = IconButtonProps;
+/**
+ * MenuButton variants can be defined in the `theme.buttons` object.
+ * By default the MenuButton component will use styles defined in `theme.buttons.menu`.
+ *
+ * @see https://theme-ui.com/components/menu-button
+ */
+export const MenuButton: ForwardRef<HTMLButtonElement, MenuButtonProps>;

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -3,10 +3,12 @@
   "version": "0.3.1",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
+  "types": "index.d.ts",
   "sideEffects": false,
   "scripts": {
     "prepare": "microbundle --no-compress --jsx React.createElement",
-    "watch": "microbundle watch --no-compress --jsx React.createElement"
+    "watch": "microbundle watch --no-compress --jsx React.createElement",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@emotion/core": "^10.0.0",
@@ -14,6 +16,7 @@
     "@styled-system/color": "^5.1.2",
     "@styled-system/should-forward-prop": "^5.1.2",
     "@styled-system/space": "^5.1.2",
+    "@types/styled-system": "^5.1.9",
     "@theme-ui/css": "^0.3.1"
   },
   "peerDependencies": {

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    // needs `theme-ui`, which lacks many types
+    "noImplicitAny": false
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "index.d.ts"]
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,7 +8,8 @@
   "sideEffects": false,
   "scripts": {
     "prepare": "microbundle --no-compress --tsconfig tsconfig.json",
-    "watch": "microbundle watch --no-compress --tsconfig tsconfig.json"
+    "watch": "microbundle watch --no-compress --tsconfig tsconfig.json",
+    "typecheck": "tsc --noEmit"
   },
   "repository": "system-ui/theme-ui",
   "author": "Brent Jackson",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,7 +26,6 @@
     "react": "^16.11.0"
   },
   "devDependencies": {
-    "@types/react": "^16.9.19",
     "react": "^16.11.0"
   }
 }

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -8,7 +8,8 @@
   "sideEffects": false,
   "scripts": {
     "prepare": "microbundle --no-compress",
-    "watch": "microbundle watch --no-compress"
+    "watch": "microbundle watch --no-compress",
+    "typecheck": "tsc --noEmit"
   },
   "author": "Brent Jackson",
   "license": "MIT",

--- a/packages/custom-properties/package.json
+++ b/packages/custom-properties/package.json
@@ -10,7 +10,8 @@
   "license": "MIT",
   "scripts": {
     "prepare": "microbundle --no-compress --tsconfig tsconfig.json",
-    "watch": "microbundle watch --no-compress --tsconfig tsconfig.json"
+    "watch": "microbundle watch --no-compress --tsconfig tsconfig.json",
+    "typecheck": "tsc --noEmit"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/match-media/package.json
+++ b/packages/match-media/package.json
@@ -11,7 +11,8 @@
   "repository": "system-ui/theme-ui",
   "scripts": {
     "prepare": "microbundle --no-compress --tsconfig tsconfig.json",
-    "watch": "microbundle watch --no-compress --tsconfig tsconfig.json"
+    "watch": "microbundle watch --no-compress --tsconfig tsconfig.json",
+    "typecheck": "tsc --noEmit"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/preset-base/package.json
+++ b/packages/preset-base/package.json
@@ -8,7 +8,8 @@
   "repository": "system-ui/theme-ui",
   "scripts": {
     "prepare": "microbundle --no-compress --tsconfig tsconfig.json",
-    "watch": "microbundle watch --no-compress --tsconfig tsconfig.json"
+    "watch": "microbundle watch --no-compress --tsconfig tsconfig.json",
+    "typecheck": "tsc --noEmit"
   },
   "types": "dist/index.d.ts",
   "source": "src/index.ts",

--- a/packages/preset-bootstrap/package.json
+++ b/packages/preset-bootstrap/package.json
@@ -9,7 +9,8 @@
   "license": "MIT",
   "scripts": {
     "prepare": "microbundle --no-compress",
-    "watch": "microbundle watch --no-compress"
+    "watch": "microbundle watch --no-compress",
+    "typecheck": "tsc --noEmit"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/preset-bulma/package.json
+++ b/packages/preset-bulma/package.json
@@ -9,7 +9,8 @@
   "license": "MIT",
   "scripts": {
     "prepare": "microbundle --no-compress",
-    "watch": "microbundle watch --no-compress"
+    "watch": "microbundle watch --no-compress",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@theme-ui/preset-base": "^0.3.0"

--- a/packages/preset-dark/package.json
+++ b/packages/preset-dark/package.json
@@ -9,7 +9,8 @@
   "license": "MIT",
   "scripts": {
     "prepare": "microbundle --no-compress",
-    "watch": "microbundle watch --no-compress"
+    "watch": "microbundle watch --no-compress",
+    "typecheck": "tsc --noEmit"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/preset-deep/package.json
+++ b/packages/preset-deep/package.json
@@ -9,7 +9,8 @@
   "license": "MIT",
   "scripts": {
     "prepare": "microbundle --no-compress",
-    "watch": "microbundle watch --no-compress"
+    "watch": "microbundle watch --no-compress",
+    "typecheck": "tsc --noEmit"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/preset-funk/package.json
+++ b/packages/preset-funk/package.json
@@ -9,7 +9,8 @@
   "license": "MIT",
   "scripts": {
     "prepare": "microbundle --no-compress",
-    "watch": "microbundle watch --no-compress"
+    "watch": "microbundle watch --no-compress",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@theme-ui/preset-base": "^0.3.0"

--- a/packages/preset-future/package.json
+++ b/packages/preset-future/package.json
@@ -9,7 +9,8 @@
   "license": "MIT",
   "scripts": {
     "prepare": "microbundle --no-compress",
-    "watch": "microbundle watch --no-compress"
+    "watch": "microbundle watch --no-compress",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@theme-ui/preset-base": "^0.3.0"

--- a/packages/preset-polaris/package.json
+++ b/packages/preset-polaris/package.json
@@ -9,7 +9,8 @@
   "license": "MIT",
   "scripts": {
     "prepare": "microbundle --no-compress",
-    "watch": "microbundle watch --no-compress"
+    "watch": "microbundle watch --no-compress",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@theme-ui/preset-base": "^0.3.0"

--- a/packages/preset-roboto/package.json
+++ b/packages/preset-roboto/package.json
@@ -9,7 +9,8 @@
   "license": "MIT",
   "scripts": {
     "prepare": "microbundle --no-compress",
-    "watch": "microbundle watch --no-compress"
+    "watch": "microbundle watch --no-compress",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@theme-ui/preset-base": "^0.3.0"

--- a/packages/preset-swiss/package.json
+++ b/packages/preset-swiss/package.json
@@ -9,7 +9,8 @@
   "license": "MIT",
   "scripts": {
     "prepare": "microbundle --no-compress",
-    "watch": "microbundle watch --no-compress"
+    "watch": "microbundle watch --no-compress",
+    "typecheck": "tsc --noEmit"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/preset-system/package.json
+++ b/packages/preset-system/package.json
@@ -9,7 +9,8 @@
   "license": "MIT",
   "scripts": {
     "prepare": "microbundle --no-compress",
-    "watch": "microbundle watch --no-compress"
+    "watch": "microbundle watch --no-compress",
+    "typecheck": "tsc --noEmit"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/preset-tailwind/package.json
+++ b/packages/preset-tailwind/package.json
@@ -9,7 +9,8 @@
   "license": "MIT",
   "scripts": {
     "prepare": "microbundle --no-compress",
-    "watch": "microbundle watch --no-compress"
+    "watch": "microbundle watch --no-compress",
+    "typecheck": "tsc --noEmit"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/preset-tosh/package.json
+++ b/packages/preset-tosh/package.json
@@ -10,7 +10,8 @@
   "repository": "system-ui/theme-ui",
   "scripts": {
     "prepare": "microbundle --no-compress",
-    "watch": "microbundle watch --no-compress"
+    "watch": "microbundle watch --no-compress",
+    "typecheck": "tsc --noEmit"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/presets/package.json
+++ b/packages/presets/package.json
@@ -9,7 +9,8 @@
   "license": "MIT",
   "scripts": {
     "prepare": "microbundle --no-compress",
-    "watch": "microbundle watch --no-compress"
+    "watch": "microbundle watch --no-compress",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@theme-ui/preset-base": "^0.3.0",

--- a/packages/tachyons/package.json
+++ b/packages/tachyons/package.json
@@ -10,7 +10,8 @@
   "license": "MIT",
   "scripts": {
     "prepare": "microbundle --no-compress --tsconfig tsconfig.json",
-    "watch": "microbundle watch --no-compress --tsconfig tsconfig.json"
+    "watch": "microbundle watch --no-compress --tsconfig tsconfig.json",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "babel-polyfill": "^6.26.0",

--- a/packages/tailwind/package.json
+++ b/packages/tailwind/package.json
@@ -10,7 +10,8 @@
   "license": "MIT",
   "scripts": {
     "prepare": "microbundle --no-compress --tsconfig tsconfig.json",
-    "watch": "microbundle watch --no-compress --tsconfig tsconfig.json"
+    "watch": "microbundle watch --no-compress --tsconfig tsconfig.json",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "babel-polyfill": "^6.26.0",

--- a/packages/theme-provider/package.json
+++ b/packages/theme-provider/package.json
@@ -6,7 +6,8 @@
   "sideEffects": false,
   "scripts": {
     "prepare": "microbundle --no-compress",
-    "watch": "microbundle watch --no-compress"
+    "watch": "microbundle watch --no-compress",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@emotion/core": "^10.0.0",

--- a/packages/theme-provider/package.json
+++ b/packages/theme-provider/package.json
@@ -6,8 +6,7 @@
   "sideEffects": false,
   "scripts": {
     "prepare": "microbundle --no-compress",
-    "watch": "microbundle watch --no-compress",
-    "typecheck": "tsc --noEmit"
+    "watch": "microbundle watch --no-compress"
   },
   "dependencies": {
     "@emotion/core": "^10.0.0",

--- a/packages/theme-ui/package.json
+++ b/packages/theme-ui/package.json
@@ -20,8 +20,7 @@
     "@theme-ui/core": "^0.3.1",
     "@theme-ui/css": "^0.3.1",
     "@theme-ui/mdx": "^0.3.0",
-    "@theme-ui/theme-provider": "^0.3.1",
-    "@types/theme-ui__components": "^0.2.3"
+    "@theme-ui/theme-provider": "^0.3.1"
   },
   "keywords": [
     "theme-ui",

--- a/packages/theme-ui/package.json
+++ b/packages/theme-ui/package.json
@@ -11,7 +11,8 @@
   "repository": "system-ui/theme-ui",
   "scripts": {
     "prepare": "microbundle --no-compress",
-    "watch": "microbundle watch --no-compress"
+    "watch": "microbundle watch --no-compress",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@theme-ui/color-modes": "^0.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3486,10 +3486,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.9.19":
-  version "16.9.23"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.23.tgz#1a66c6d468ba11a8943ad958a8cb3e737568271c"
-  integrity sha512-SsGVT4E7L2wLN3tPYLiF20hmZTPGuzaayVunfgXzUn1x4uHVsKH6QDJQ/TdpHqwsTLd4CwrmQ2vOgxN7gE24gw==
+"@types/react@*":
+  version "16.9.16"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.16.tgz#4f12515707148b1f53a8eaa4341dae5dfefb066d"
+  integrity sha512-dQ3wlehuBbYlfvRXfF5G+5TbZF3xqgkikK7DWAsQXe2KnzV+kjD4W2ea+ThCrKASZn9h98bjjPzoTYzfRqyBkw==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
@@ -3519,19 +3519,12 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
-"@types/styled-system@*":
-  version "5.1.7"
-  resolved "https://registry.yarnpkg.com/@types/styled-system/-/styled-system-5.1.7.tgz#b5aeb6efea499103a497da762516cdf38efd9e02"
-  integrity sha512-0zMxF/B5Z4T6ZhCP8CKtxe8wBmH7sqDjK3lOMByNQ6gG/Qf6RDnBp1aZwkReS1uDVhrsPx9J+IbLigpAdYBkrQ==
+"@types/styled-system@^5.1.9":
+  version "5.1.9"
+  resolved "https://registry.yarnpkg.com/@types/styled-system/-/styled-system-5.1.9.tgz#8baac8f6eca9e0bd5768c175ca5ce1f2d6f61ade"
+  integrity sha512-QlWv6tmQV8dqk8s+LSLb9QAtmuQEnfv4f8lKKZkMgDqRFVmxJDBwEw0u4zhpxp56u0hdR+TCIk9dGfOw3TkCoQ==
   dependencies:
     csstype "^2.6.9"
-
-"@types/styled-system__css@*":
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/@types/styled-system__css/-/styled-system__css-5.0.5.tgz#f3c8036e551fbf603f1ad39cf317fd0e6ad1e431"
-  integrity sha512-JaKYusiRtP3osDx+PhTPP7Ki68mMKoImv/bhr7lK4UFAxeXvveARD5v5rUY0Oy0pfbNkky/nVgHlgGaPbG/JBQ==
-  dependencies:
-    csstype "^2.6.6"
 
 "@types/testing-library__dom@*", "@types/testing-library__dom@^6.0.0":
   version "6.10.0"
@@ -3548,29 +3541,6 @@
     "@types/react-dom" "*"
     "@types/testing-library__dom" "*"
 
-"@types/theme-ui@*":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@types/theme-ui/-/theme-ui-0.3.0.tgz#5a8972b1e6060a4699885ea6c91f9d17a957661a"
-  integrity sha512-3PJw/As8C1HeLJXZytGf5Gfz7HBKskbtyOabPsHSNRTr+jLZvIWpFKF9hgDWYp7io35UcLDS5TLcFwiCGGxAzg==
-  dependencies:
-    "@emotion/serialize" "^0.11.15"
-    "@types/react" "*"
-    "@types/styled-system" "*"
-    "@types/styled-system__css" "*"
-    "@types/theme-ui__components" "*"
-    csstype "^2.6.6"
-
-"@types/theme-ui__components@*", "@types/theme-ui__components@^0.2.3":
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/@types/theme-ui__components/-/theme-ui__components-0.2.3.tgz#470c286375f5177d2607f34da4b38c315e66907c"
-  integrity sha512-g0q3IpJxDXPQvWhaVSXJroB74dxD6HAHAfCbb3unV7iaoovrLact1Yxan5cDRMqHf8d7ub3JAvpSmGSdlNJ5OQ==
-  dependencies:
-    "@emotion/core" "^10.0.0"
-    "@emotion/styled" "^10.0.0"
-    "@types/react" "*"
-    "@types/styled-system" "*"
-    "@types/theme-ui" "*"
-
 "@types/tmp@^0.0.32":
   version "0.0.32"
   resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.0.32.tgz#0d3cb31022f8427ea58c008af32b80da126ca4e3"
@@ -3581,12 +3551,13 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
 
-"@types/vfile-message@*":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@types/vfile-message/-/vfile-message-2.0.0.tgz#690e46af0fdfc1f9faae00cd049cc888957927d5"
-  integrity sha512-GpTIuDpb9u4zIO165fUy9+fXcULdD8HFRNli04GehoMVbeNq7D6OBnqSmg3lxZnC+UvgUhEWKxdKiwYUkGltIw==
+"@types/vfile-message@*", "@types/vfile-message@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/vfile-message/-/vfile-message-1.0.1.tgz#e1e9895cc6b36c462d4244e64e6d0b6eaf65355a"
+  integrity sha512-mlGER3Aqmq7bqR1tTTIVHq8KSAFFRyGbrxuM8C/H82g6k7r2fS+IMEkIu3D7JHzG10NvPdR8DNx0jr0pwpp4dA==
   dependencies:
-    vfile-message "*"
+    "@types/node" "*"
+    "@types/unist" "*"
 
 "@types/vfile@^3.0.0":
   version "3.0.2"
@@ -8181,7 +8152,12 @@ cssstyle@^1.0.0, cssstyle@^1.1.1:
   dependencies:
     cssom "0.3.x"
 
-csstype@^2.2.0, csstype@^2.5.7, csstype@^2.6.6, csstype@^2.6.9:
+csstype@^2.2.0, csstype@^2.5.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.7.tgz#20b0024c20b6718f4eda3853a1f5a1cce7f5e4a5"
+  integrity sha512-9Mcn9sFbGBAdmimWb2gLVDtFJzeKtDGIr76TUqmjZrw9LFXBMSU70lcs+C0/7fyCd6iBDqmksUcCOUIkisPHsQ==
+
+csstype@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.9.tgz#05141d0cd557a56b8891394c1911c40c8a98d098"
   integrity sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q==
@@ -24351,20 +24327,20 @@ vfile-location@^2.0.0:
   resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-2.0.6.tgz#8a274f39411b8719ea5728802e10d9e0dff1519e"
   integrity sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA==
 
-vfile-message@*, vfile-message@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-2.0.2.tgz#75ba05090ec758fa8420f2c11ce049bcddd8cf3e"
-  integrity sha512-gNV2Y2fDvDOOqq8bEe7cF3DXU6QgV4uA9zMR2P8tix11l1r7zju3zry3wZ8sx+BEfuO6WQ7z2QzfWTvqHQiwsA==
-  dependencies:
-    "@types/unist" "^2.0.0"
-    unist-util-stringify-position "^2.0.0"
-
 vfile-message@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-1.1.1.tgz#5833ae078a1dfa2d96e9647886cd32993ab313e1"
   integrity sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==
   dependencies:
     unist-util-stringify-position "^1.1.1"
+
+vfile-message@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-2.0.2.tgz#75ba05090ec758fa8420f2c11ce049bcddd8cf3e"
+  integrity sha512-gNV2Y2fDvDOOqq8bEe7cF3DXU6QgV4uA9zMR2P8tix11l1r7zju3zry3wZ8sx+BEfuO6WQ7z2QzfWTvqHQiwsA==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-stringify-position "^2.0.0"
 
 vfile@^2.0.0:
   version "2.3.0"


### PR DESCRIPTION
This PR moves typechecking out of test to a separate package.json script.
This is to ensure package tsconfigs are respected instead of typechecking everything with one config.

---

Hey @jxnblk, this is what I meant in https://github.com/system-ui/theme-ui/issues/668#issuecomment-598341799 and https://github.com/system-ui/theme-ui/issues/668#issuecomment-598352395.

Feel free to close and totally disregard this.
I'm totally cool with splitting this into separate PRs / commits.

In the meantime, I encountered two problems, which might be worth merging.
I'll elaborate in comments.
