### PR TITLE
fix(@theme-ui/css): add `size` to AliasesCSSProperties

### DIFF
--- a/packages/css/src/types.ts
+++ b/packages/css/src/types.ts
@@ -299,6 +299,16 @@ interface AliasesCSSProperties {
    * @see https://developer.mozilla.org/docs/Web/CSS/padding-bottom
    */
   paddingY?: StandardCSSProperties['paddingTop']
+  // TODO: Move me to `MultiplesCSSProperties type and colocate it with the
+  // multiples object possibly.
+  /**
+   * The **`size`** is a shorthand property for CSS properties **`width`** and **`height`**.
+   *
+   * @see https://theme-ui.com/sx-prop#theme-aware-properties
+   * @see https://developer.mozilla.org/docs/Web/CSS/width
+   * @see https://developer.mozilla.org/docs/Web/CSS/height
+   */
+  size?: StandardCSSProperties['width']
 }
 
 interface OverwriteCSSProperties {


### PR DESCRIPTION
Defined in https://github.com/system-ui/theme-ui/blob/ca9c2261d8a1168233933682769b038f59396896/packages/css/src/index.ts#L52

Missing from https://github.com/system-ui/theme-ui/blob/6b93a303bb622e01044e692c8ec845fe35d89359/packages/css/src/types.ts#L57

---

![](https://user-images.githubusercontent.com/15332326/76743148-7714b580-6772-11ea-8ed2-0c6b5e52c45d.gif)