### PR TITLE
Remove non-existent export

### DIFF
--- a/packages/theme-ui/src/index.ts
+++ b/packages/theme-ui/src/index.ts
@@ -17,7 +17,6 @@ export * from '@theme-ui/components'
 export {
   css,
   get,
-  ColorMode,
   CSSObject,
   CSSProperties,
   CSSPseudoSelectorProps,


### PR DESCRIPTION
Looks like this was removed at some point already but had accidentally returned.