### PR TITLE
Option to not use localStorage to persist the color mode

### DIFF
--- a/packages/color-modes/src/custom-properties.js
+++ b/packages/color-modes/src/custom-properties.js
@@ -13,6 +13,7 @@ const reservedKeys = {
   useCustomProperties: true,
   initialColorModeName: true,
   initialColorMode: true,
+  useLocalStorage: true,
 }
 
 const toPixel = (key, value) => {
@@ -86,6 +87,6 @@ export const createColorStyles = (theme = {}) => {
       ...styles,
       color: 'text',
       bg: 'background',
-    }
+    },
   })(theme)
 }

--- a/packages/color-modes/src/index.js
+++ b/packages/color-modes/src/index.js
@@ -50,17 +50,14 @@ const useColorModeState = (theme = {}) => {
 
   // initialize state
   React.useEffect(() => {
-    const stored = storage.get()
+    const stored = !theme.noLocalStorageForColorMode && storage.get()
     document.body.classList.remove('theme-ui-' + stored)
-    if (
-      (!stored || theme.noLocalStorageForColorMode) &&
-      theme.useColorSchemeMediaQuery
-    ) {
+    if (!stored && theme.useColorSchemeMediaQuery) {
       const query = getMediaQuery()
       setMode(query)
       return
     }
-    if (!stored || theme.noLocalStorageForColorMode || stored === mode) return
+    if (!stored || stored === mode) return
     setMode(stored)
   }, [])
 

--- a/packages/color-modes/src/index.js
+++ b/packages/color-modes/src/index.js
@@ -52,17 +52,20 @@ const useColorModeState = (theme = {}) => {
   React.useEffect(() => {
     const stored = storage.get()
     document.body.classList.remove('theme-ui-' + stored)
-    if (!stored && theme.useColorSchemeMediaQuery) {
+    if (
+      (!stored || theme.noLocalStorageForColorMode) &&
+      theme.useColorSchemeMediaQuery
+    ) {
       const query = getMediaQuery()
       setMode(query)
       return
     }
-    if (!stored || stored === mode) return
+    if (!stored || theme.noLocalStorageForColorMode || stored === mode) return
     setMode(stored)
   }, [])
 
   React.useEffect(() => {
-    if (!mode) return
+    if (!mode || theme.noLocalStorageForColorMode) return
     storage.set(mode)
   }, [mode])
 

--- a/packages/color-modes/src/index.js
+++ b/packages/color-modes/src/index.js
@@ -50,7 +50,7 @@ const useColorModeState = (theme = {}) => {
 
   // initialize state
   React.useEffect(() => {
-    const stored = !theme.noLocalStorageForColorMode && storage.get()
+    const stored = theme.useLocalStorage !== false && storage.get()
     document.body.classList.remove('theme-ui-' + stored)
     if (!stored && theme.useColorSchemeMediaQuery) {
       const query = getMediaQuery()
@@ -62,7 +62,7 @@ const useColorModeState = (theme = {}) => {
   }, [])
 
   React.useEffect(() => {
-    if (!mode || theme.noLocalStorageForColorMode) return
+    if (!mode || theme.useLocalStorage === false) return
     storage.set(mode)
   }, [mode])
 

--- a/packages/color-modes/test/index.js
+++ b/packages/color-modes/test/index.js
@@ -209,7 +209,7 @@ test('initializes mode based on localStorage', () => {
   expect(mode).toBe('dark')
 })
 
-test('does not initialize mode based on localStorage if noLocalStorageForColorMode is set', () => {
+test('does not initialize mode based on localStorage if useLocalStorage is set to false', () => {
   window.localStorage.setItem(STORAGE_KEY, 'dark')
   let mode
   const Button = props => {
@@ -220,7 +220,7 @@ test('does not initialize mode based on localStorage if noLocalStorageForColorMo
   const tree = render(
     <ThemeProvider
       theme={{
-        noLocalStorageForColorMode: true,
+        useLocalStorage: false,
       }}>
       <ColorModeProvider>
         <Button />

--- a/packages/color-modes/test/index.js
+++ b/packages/color-modes/test/index.js
@@ -209,6 +209,27 @@ test('initializes mode based on localStorage', () => {
   expect(mode).toBe('dark')
 })
 
+test('does not initialize mode based on localStorage if noLocalStorageForColorMode is set', () => {
+  window.localStorage.setItem(STORAGE_KEY, 'dark')
+  let mode
+  const Button = props => {
+    const [colorMode, setMode] = useColorMode()
+    mode = colorMode
+    return <button children="test" />
+  }
+  const tree = render(
+    <ThemeProvider
+      theme={{
+        noLocalStorageForColorMode: true,
+      }}>
+      <ColorModeProvider>
+        <Button />
+      </ColorModeProvider>
+    </ThemeProvider>
+  )
+  expect(mode).toBe('default')
+})
+
 test('retains initial context', () => {
   let context
   const Consumer = props => {

--- a/packages/css/src/types.ts
+++ b/packages/css/src/types.ts
@@ -559,6 +559,11 @@ export interface Theme {
   useBorderBox?: boolean
 
   /**
+   * If true, does not save color mode as a localStorage value.
+   */
+  noLocalStorageForColorMode?: boolean
+
+  /**
    * Define the colors that are available through this theme
    */
   colors?: ColorMode & {

--- a/packages/css/src/types.ts
+++ b/packages/css/src/types.ts
@@ -559,9 +559,9 @@ export interface Theme {
   useBorderBox?: boolean
 
   /**
-   * If true, does not save color mode as a localStorage value.
+   * If false, does not save color mode as a localStorage value.
    */
-  noLocalStorageForColorMode?: boolean
+  useLocalStorage?: boolean
 
   /**
    * Define the colors that are available through this theme

--- a/packages/docs/src/pages/color-modes.mdx
+++ b/packages/docs/src/pages/color-modes.mdx
@@ -156,7 +156,7 @@ modes on the same domain.
 
 ```js
 {
-  noLocalStorageForColorMode: true,
+  useLocalStorage: false,
   colors: {
     text: '#000',
     background: '#fff',

--- a/packages/docs/src/pages/color-modes.mdx
+++ b/packages/docs/src/pages/color-modes.mdx
@@ -148,7 +148,7 @@ If you do not have a color mode named `dark` or `light`, this will have no effec
 }
 ```
 
-### Disable setting color mode on `localStorage`
+### Disable persisting color mode on `localStorage`
 
 In some cases, it is not desirable to have the color mode set as a `localStorage` value. 
 The common use-case being that disconnected slices of your app use different color 

--- a/packages/docs/src/pages/color-modes.mdx
+++ b/packages/docs/src/pages/color-modes.mdx
@@ -148,3 +148,25 @@ If you do not have a color mode named `dark` or `light`, this will have no effec
 }
 ```
 
+### Disable setting color mode on `localStorage`
+
+In some cases, it is not desirable to have the color mode set as a `localStorage` value. 
+The common use-case being that disconnected slices of your app use different color 
+modes on the same domain.
+
+```js
+{
+  noLocalStorageForColorMode: true,
+  colors: {
+    text: '#000',
+    background: '#fff',
+    modes: {
+      dark: {
+        text: '#fff',
+        background: '#000',
+      }
+    }
+  }
+}
+```
+

--- a/packages/docs/src/pages/color-modes.mdx
+++ b/packages/docs/src/pages/color-modes.mdx
@@ -150,9 +150,7 @@ If you do not have a color mode named `dark` or `light`, this will have no effec
 
 ### Disable persisting color mode on `localStorage`
 
-In some cases, it is not desirable to have the color mode set as a `localStorage` value. 
-The common use-case being that disconnected slices of your app use different color 
-modes on the same domain.
+To disable `localStorage` add the `useLocalStorage: false` flag to your theme.
 
 ```js
 {
@@ -169,4 +167,3 @@ modes on the same domain.
   }
 }
 ```
-

--- a/packages/docs/src/pages/theming.mdx
+++ b/packages/docs/src/pages/theming.mdx
@@ -181,7 +181,7 @@ Flag | Default | Description
 `initialColorModeName` | `'default'` | The key used for the top-level color palette in `theme.colors`
 `useColorSchemeMediaQuery` | `false` | Initializes the color mode based on the `prefers-color-scheme` media query
 `useBorderBox` | `true` | Adds a global `box-sizing: border-box` style
-`noLocalStorageForColorMode` | `false` | Disables the color mode being loaded from `localStorage`
+`useLocalStorage` | `true` | Persists the color mode in `localStorage`
 
 ## Example Theme
 

--- a/packages/docs/src/pages/theming.mdx
+++ b/packages/docs/src/pages/theming.mdx
@@ -181,7 +181,7 @@ Flag | Default | Description
 `initialColorModeName` | `'default'` | The key used for the top-level color palette in `theme.colors`
 `useColorSchemeMediaQuery` | `false` | Initializes the color mode based on the `prefers-color-scheme` media query
 `useBorderBox` | `true` | Adds a global `box-sizing: border-box` style
-`noLocalStorageForColorMode` | `false` | Disables the color mode being saved in `localStorage`
+`noLocalStorageForColorMode` | `false` | Disables the color mode being loaded from `localStorage`
 
 ## Example Theme
 

--- a/packages/docs/src/pages/theming.mdx
+++ b/packages/docs/src/pages/theming.mdx
@@ -181,6 +181,7 @@ Flag | Default | Description
 `initialColorModeName` | `'default'` | The key used for the top-level color palette in `theme.colors`
 `useColorSchemeMediaQuery` | `false` | Initializes the color mode based on the `prefers-color-scheme` media query
 `useBorderBox` | `true` | Adds a global `box-sizing: border-box` style
+`noLocalStorageForColorMode` | `false` | Disables the color mode being saved in `localStorage`
 
 ## Example Theme
 


### PR DESCRIPTION
Addresses the concerns brought up in https://github.com/system-ui/theme-ui/issues/702.

By default, `localStorage` is still used to persist the color mode. 

Adding a `useLocalStorage` option to the theme config could disable this persistence. Very useful for folks migrating disconnected pieces of an app to `theme-ui`, and stops the notorious color mode switching.

I have also added a test + updated the docs.