### PR TITLE
Fix dropdown appearing under other combo boxes.

### DIFF
--- a/packages/editor/src/Sx/Typography.js
+++ b/packages/editor/src/Sx/Typography.js
@@ -32,6 +32,7 @@ export const SxTypography = ({
           onChange({ fontFamily })
         }}
         options={['inherit', ...Object.keys(fonts)]}
+        sx={{ zIndex: 3 }}
       />
       <div
         sx={{


### PR DESCRIPTION
Because all comboboxes are set to `z-index: 2`, the dropdown from the top combobox (font family) appears under the other two comboboxes (font weight and line height).