### PR TITLE
feat(@theme-ui/components) Add a Stack component

### DIFF
--- a/packages/components/src/Stack.js
+++ b/packages/components/src/Stack.js
@@ -1,19 +1,25 @@
 import React from 'react'
-import Box from './Box'
+import { Box } from './Box'
 
 export const Stack = React.forwardRef(
-  ({ gap = 2, flow = 'row', ...props }, ref) => {
+  ({ gap = 2, children, ...props }, ref) => {
+    /** Make a copy of the children so we can pass the styles as props instead of using brittle CSS selectors */
+    const elements = React.Children.map(children, (element, index) => {
+      if (index === 0) {
+        return element
+      }
+
+      const newProps = {
+        marginTop: gap,
+      }
+
+      return React.cloneElement(element, newProps)
+    })
+
     return (
-      <Box
-        ref={ref}
-        {...props}
-        __themeKey="stacks"
-        __css={{
-          display: 'grid',
-          gridGap: gap,
-          gridAutoFlow: flow,
-        }}
-      />
+      <Box ref={ref} {...props} __themeKey="stacks">
+        {elements}
+      </Box>
     )
   }
 )

--- a/packages/components/src/Stack.js
+++ b/packages/components/src/Stack.js
@@ -2,24 +2,16 @@ import React from 'react'
 import { Box } from './Box'
 
 export const Stack = React.forwardRef(
-  ({ gap = 2, children, ...props }, ref) => {
-    /** Make a copy of the children so we can pass the styles as props instead of using brittle CSS selectors */
-    const elements = React.Children.map(children, (element, index) => {
-      if (index === 0) {
-        return element
-      }
-
-      const newProps = {
-        marginTop: gap,
-      }
-
-      return React.cloneElement(element, newProps)
-    })
-
-    return (
-      <Box ref={ref} {...props} __themeKey="stacks">
-        {elements}
-      </Box>
-    )
-  }
+  ({ gap = 2, children, ...props }, ref) => (
+    <Box
+      ref={ref}
+      {...props}
+      __themeKey="stacks"
+      __css={{
+        display: 'grid',
+        gridGap: gap,
+      }}>
+      {children}
+    </Box>
+  )
 )

--- a/packages/components/src/Stack.js
+++ b/packages/components/src/Stack.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import Box from './Box'
+
+export const Stack = React.forwardRef(
+  ({ gap = 2, flow = 'row', ...props }, ref) => {
+    return (
+      <Box
+        ref={ref}
+        {...props}
+        __themeKey="stacks"
+        __css={{
+          display: 'grid',
+          gridGap: gap,
+          gridAutoFlow: flow,
+        }}
+      />
+    )
+  }
+)

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -1,6 +1,7 @@
 export { Box } from './Box'
 export { Flex } from './Flex'
 export { Grid } from './Grid'
+export { Stack } from './Stack'
 export { Button } from './Button'
 export { Link } from './Link'
 export { Text } from './Text'

--- a/packages/components/test/index.js
+++ b/packages/components/test/index.js
@@ -8,6 +8,7 @@ import {
   Card,
   Flex,
   Grid,
+  Stack,
   Heading,
   Image,
   Link,

--- a/packages/docs/src/pages/components/stack.mdx
+++ b/packages/docs/src/pages/components/stack.mdx
@@ -1,0 +1,71 @@
+---
+title: Stack
+---
+
+# Stack
+
+Use the `Stack` component as a layout primitive to add spaces between components. It allows you to define
+spacing in one direction, either `row` or `column`. This is very useful when stacking components within a bigger grid system. 
+
+```js
+import { Stack, Box, Grid } from 'theme-ui'
+```
+
+```jsx live=true
+
+<Grid
+  gap={3}
+  columns={2}>
+  <Box bg="muted">
+    <Stack gap={3} flow="row">
+      <Box bg="primary" color="white">Stack Item</Box>
+      <Box bg="primary" color="white">Stack Item</Box>
+      <Box bg="primary" color="white">Stack Item</Box>
+    </Stack>
+  </Box>
+  <Box bg='muted'>Box</Box>
+</Grid>
+```
+
+Change the spacing by using the gap property
+
+```js
+import { Stack, Box } from 'theme-ui'
+```
+
+```jsx live=true
+<Stack gap="3">
+  <Box bg="primary" color="white">Stack Item</Box>
+  <Box bg="muted">Stack Item</Box>
+  <Box bg="primary" color="white">Stack Item</Box>
+</Stack>
+```
+
+Want to stack items horizontally? Use the flow property
+
+```js
+import { Stack, Box } from 'theme-ui'
+```
+
+```jsx live=true
+<Stack flow={"column"}>
+  <Box bg="primary" color="white">Stack Item</Box>
+  <Box bg="muted">Stack Item</Box>
+  <Box bg="primary" color="white">Stack Item</Box>
+</Stack>
+```
+
+The Stack component Supports responsive values too
+
+
+```js
+import { Stack, Box } from 'theme-ui'
+```
+
+```jsx live=true
+<Stack flow={["row", "row", "row", "column"]} gap={[3,3,4]}>
+  <Box bg="primary" color="white">Stack Item</Box>
+  <Box bg="muted">Stack Item</Box>
+  <Box bg="primary" color="white">Stack Item</Box>
+</Stack>
+```

--- a/packages/docs/src/pages/components/stack.mdx
+++ b/packages/docs/src/pages/components/stack.mdx
@@ -4,20 +4,20 @@ title: Stack
 
 # Stack
 
-Use the `Stack` component as a layout primitive to add spaces between components. It allows you to define
-spacing in one direction, either `row` or `column`. This is very useful when stacking components within a bigger grid system. 
+Use the `Stack` component as a layout primitive to add spaces between components.
+This is very useful when stacking components within a bigger grid system, as it allows you to maintain a vertical rhythm.
+It also enforces the decoupling of layout from components.
 
 ```js
 import { Stack, Box, Grid } from 'theme-ui'
 ```
 
 ```jsx live=true
-
 <Grid
   gap={3}
   columns={2}>
   <Box bg="muted">
-    <Stack gap={3} flow="row">
+    <Stack>
       <Box bg="primary" color="white">Stack Item</Box>
       <Box bg="primary" color="white">Stack Item</Box>
       <Box bg="primary" color="white">Stack Item</Box>
@@ -27,35 +27,28 @@ import { Stack, Box, Grid } from 'theme-ui'
 </Grid>
 ```
 
-Change the spacing by using the gap property
+You can change the spacing by using the gap property
 
 ```js
 import { Stack, Box } from 'theme-ui'
 ```
 
 ```jsx live=true
-<Stack gap="3">
-  <Box bg="primary" color="white">Stack Item</Box>
-  <Box bg="muted">Stack Item</Box>
-  <Box bg="primary" color="white">Stack Item</Box>
-</Stack>
+<Grid
+  gap={3}
+  columns={2}>
+  <Box bg="muted">
+    <Stack gap={3}>
+      <Box bg="primary" color="white">Stack Item</Box>
+      <Box bg="primary" color="white">Stack Item</Box>
+      <Box bg="primary" color="white">Stack Item</Box>
+    </Stack>
+  </Box>
+  <Box bg='muted'>Box</Box>
+</Grid>
 ```
 
-Want to stack items horizontally? Use the flow property
-
-```js
-import { Stack, Box } from 'theme-ui'
-```
-
-```jsx live=true
-<Stack flow={"column"}>
-  <Box bg="primary" color="white">Stack Item</Box>
-  <Box bg="muted">Stack Item</Box>
-  <Box bg="primary" color="white">Stack Item</Box>
-</Stack>
-```
-
-The Stack component Supports responsive values too
+The Stack component Supports responsive values too. Try resizing this screen.
 
 
 ```js
@@ -63,9 +56,9 @@ import { Stack, Box } from 'theme-ui'
 ```
 
 ```jsx live=true
-<Stack flow={["row", "row", "row", "column"]} gap={[3,3,4]}>
+<Stack gap={[2, 3, 4]}>
   <Box bg="primary" color="white">Stack Item</Box>
-  <Box bg="muted">Stack Item</Box>
+  <Box bg="primary" color="white">Stack Item</Box>
   <Box bg="primary" color="white">Stack Item</Box>
 </Stack>
 ```

--- a/packages/docs/src/sidebar.mdx
+++ b/packages/docs/src/sidebar.mdx
@@ -16,6 +16,7 @@
   - [Box](/components/box)
   - [Flex](/components/flex)
   - [Grid](/components/grid)
+  - [Stack](/components/stack)
   - [Button](/components/button)
   - [Text](/components/text)
   - [Heading](/components/heading)


### PR DESCRIPTION
This PR is an attempt at solving https://github.com/system-ui/theme-ui/issues/556

- [X] Working component
- [ ] Finish documentation
- [ ] Add tests

**Prior art**
I've taken inspiration from both https://every-layout.dev/layouts/stack/ and https://github.com/seek-oss/braid-design-system.

**Technical approach**
I've started out using the `Grid` component directly, based on the [Stack recipe](https://theme-ui.com/recipes/stack). However, because a `Stack` component only flows in one direction and I'd like to support IE11 (which doesn't support grid-gap) I thought it would be better to use more traditional methods of building a Stack layout.

The [lobotomized owl selector](https://alistapart.com/article/axiomatic-css-and-lobotomized-owls/) by Heydon sounded like the right approach, but I wanted to avoid using brittle child css selectors within `__css` or `sx`, so I used `React.children.map` to pass extra props to nested items.

By passing a `marginTop` property to every child element except the first one, we realize a cross-browser stack component.

**No horizontal layout**
In theory it should be possible to make column based stacks by using `Flex` instead of `Box`. However, I feel you're better off using `Grid` directly if you need that. This component does one thing and it does one thing well, maintaining a vertical rhythm in your page by enforcing the same margins between components.

**Tradeoffs**
If the child component does not support the `marginTop` prop, the `Stack` component won't work at all. Not sure yet how to solve that, but I'm sure someone here can give advice on that if the rest of the approach is solid.

**Alternative approach**
Styling the child items directly from the Stack component with (pseudocode)
```
__css={{
  '> *+*': {
    mt: gap
  }
}}
```

Similar to how ReactUI solves this.
[Example](https://react-ui.dev/components/Stack)
[Source](https://github.com/siddharthkp/react-ui/blob/master/packages/react-ui/src/components/stack/index.js
)

**Future ideas**
- By using flexbox, you can introduce more advanced patterns such as using `margin: auto` on one of the children. I suspect that's too advanced for the scope of this component.
- Support a `direction` prop. It would mean all components need to get a display prop of inline-block or flex?