### PR TITLE
docs: added custom CacheProvider guide

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@babel/cli": "^7.4.4",
     "@babel/core": "^7.4.5",
+    "@babel/helper-validator-identifier": "^7.9.0",
     "@babel/plugin-transform-runtime": "^7.7.6",
     "@babel/preset-env": "^7.4.5",
     "@babel/preset-react": "^7.0.0",

--- a/packages/docs/src/pages/guides/custom-cache-provider.mdx
+++ b/packages/docs/src/pages/guides/custom-cache-provider.mdx
@@ -1,0 +1,74 @@
+---
+title: Custom CacheProvider
+---
+
+# Custom CacheProvider
+
+## Style container
+
+You may come across a situation where you want to inject the generated styles into a
+different element than the current document head (an iframe perhaps).
+
+By using the CacheProvider from `@emotion/core` and `createCache` from `@emotion/cache` you can
+specify the target container element.
+
+```jsx
+import { ThemeProvider } from 'theme-ui'
+import { CacheProvider } from '@emotion/core'
+import createCache from '@emotion/cache'
+
+/**
+ * @see https://emotion.sh/docs/@emotion/cache
+ */
+const cache = createCache({
+  container: document.getElementById('my-cool-iframe'),
+})
+
+const theme = {
+  colors: {
+    text: 'tomato',
+  },
+}
+
+export default ({ children }) => {
+  return (
+    <CacheProvider value={cache}>
+      <ThemeProvider theme={theme}>{children}</ThemeProvider>
+    </CacheProvider>
+  )
+}
+```
+
+### With react-frame-component
+
+```jsx
+import { ThemeProvider } from 'theme-ui'
+import { CacheProvider } from '@emotion/core'
+import createCache from '@emotion/cache'
+import Iframe, { FrameContextConsumer } from 'react-frame-component'
+
+const theme = {
+  colors: {
+    text: 'tomato',
+  },
+}
+
+export default ({ children }) => {
+  return (
+    <Iframe initialContent="IFRAME_CONTENT">
+      <FrameContextConsumer>
+        {frameContext => {
+          const cache = createCache({
+            container: frameContext.document.head,
+          })
+          return (
+            <CacheProvider value={cache}>
+              <ThemeProvider theme={theme}>{children}</ThemeProvider>
+            </CacheProvider>
+          )
+        }}
+      </FrameContextConsumer>
+    </Iframe>
+  )
+}
+```

--- a/packages/docs/src/pages/guides/index.mdx
+++ b/packages/docs/src/pages/guides/index.mdx
@@ -28,6 +28,8 @@ import { Cards } from '../..'
   Style content responsively
 - [Nested ThemeProviders](/guides/nested-theme-providers)
   Add contextual theme and stylistic changes
+- [Custom CacheProvider](/guides/custom-cache-provider)
+  Customise the styles generated and where they are injected
 - [Syntax Highlighting](/guides/syntax-highlighting)
   Add syntax highlighting to MDX code blocks
 - [Theme Color Meta Tag](/guides/theme-color-meta-tag)

--- a/packages/docs/src/sidebar.mdx
+++ b/packages/docs/src/sidebar.mdx
@@ -72,6 +72,7 @@
   - [MDX Layout Components](/guides/mdx-layout-components)
   - [Responsive Typography](/guides/responsive-typography)
   - [Nested ThemeProviders](/guides/nested-theme-providers)
+  - [Custom CacheProvider](/guides/custom-cache-provider)
   - [Syntax Highlighting](/guides/syntax-highlighting)
   - [Theme Color Meta Tag](/guides/theme-color-meta-tag)
   - [Color Mode Toggles](/guides/color-mode-toggles)

--- a/yarn.lock
+++ b/yarn.lock
@@ -563,6 +563,11 @@
   dependencies:
     "@babel/types" "^7.8.3"
 
+"@babel/helper-validator-identifier@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.0.tgz#ad53562a7fc29b3b9a91bbf7d10397fd146346ed"
+  integrity sha512-6G8bQKjOh+of4PV/ThDm/rRqlU7+IGoJuofpagU5GlEl29Vv0RGqqt86ZGRV8ZuSOY3o+8yXl5y782SMcG7SHw==
+
 "@babel/helper-wrap-function@^7.7.4":
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.7.4.tgz#37ab7fed5150e22d9d7266e830072c0cdd8baace"


### PR DESCRIPTION
I came across the need to specify a different container element (iframe) for the styles generated by emotion, so providing this guide for anyone needing to do the same.