### PR TITLE
New variant API

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -10,11 +10,7 @@
   },
   "dependencies": {
     "@emotion/core": "^10.0.0",
-    "@emotion/styled": "^10.0.0",
-    "@styled-system/color": "^5.1.2",
-    "@styled-system/should-forward-prop": "^5.1.2",
-    "@styled-system/space": "^5.1.2",
-    "@theme-ui/css": "^0.4.0-alpha.0"
+    "@theme-ui/core": "^0.4.0-alpha.0"
   },
   "peerDependencies": {
     "react": "^16.8.0"

--- a/packages/components/src/Alert.js
+++ b/packages/components/src/Alert.js
@@ -2,11 +2,12 @@
 import { jsx } from '@theme-ui/core'
 import React from 'react'
 import { useVariant } from './util'
+import Box from './Box'
 
 export const Alert = React.forwardRef(function Alert({ variant, ...props }, ref) {
   const variantStyle = useVariant('alerts', variant)
   return (
-    <div
+    <Box
       ref={ref}
       {...props}
       __css={{

--- a/packages/components/src/Alert.js
+++ b/packages/components/src/Alert.js
@@ -1,20 +1,22 @@
 import React from 'react'
 import Box from './Box'
 
-export const Alert = React.forwardRef((props, ref) => (
-  <Box
-    ref={ref}
-    {...props}
-    __themeKey="alerts"
-    __css={{
-      display: 'flex',
-      alignItems: 'center',
-      px: 3,
-      py: 2,
-      fontWeight: 'bold',
-      color: 'white',
-      bg: 'primary',
-      borderRadius: 4,
-    }}
-  />
-))
+export const Alert = React.forwardRef(function Alert(props, ref) {
+  return (
+    <Box
+      ref={ref}
+      {...props}
+      __themeKey="alerts"
+      __css={{
+        display: 'flex',
+        alignItems: 'center',
+        px: 3,
+        py: 2,
+        fontWeight: 'bold',
+        color: 'white',
+        bg: 'primary',
+        borderRadius: 4,
+      }}
+    />
+  )
+})

--- a/packages/components/src/Alert.js
+++ b/packages/components/src/Alert.js
@@ -9,7 +9,7 @@ export const Alert = React.forwardRef(function Alert({ variant, ...props }, ref)
     <div
       ref={ref}
       {...props}
-      sx={{
+      __css={{
         display: 'flex',
         alignItems: 'center',
         px: 3,

--- a/packages/components/src/Alert.js
+++ b/packages/components/src/Alert.js
@@ -4,7 +4,7 @@ import React from 'react'
 import { useVariant } from './util'
 
 export const Alert = React.forwardRef(function Alert({ variant, ...props }, ref) {
-  const variation = useVariant('alerts', variant)
+  const variantStyle = useVariant('alerts', variant)
   return (
     <div
       ref={ref}
@@ -18,7 +18,7 @@ export const Alert = React.forwardRef(function Alert({ variant, ...props }, ref)
         color: 'white',
         bg: 'primary',
         borderRadius: 4,
-        ...variation,
+        ...variantStyle,
       }}
     />
   )

--- a/packages/components/src/Alert.js
+++ b/packages/components/src/Alert.js
@@ -1,13 +1,15 @@
+/** @jsx jsx */
+import { jsx } from '@theme-ui/core'
 import React from 'react'
-import Box from './Box'
+import { useVariant } from './util'
 
-export const Alert = React.forwardRef(function Alert(props, ref) {
+export const Alert = React.forwardRef(function Alert({ variant, ...props }, ref) {
+  const variation = useVariant('alerts', variant)
   return (
-    <Box
+    <div
       ref={ref}
       {...props}
-      __themeKey="alerts"
-      __css={{
+      sx={{
         display: 'flex',
         alignItems: 'center',
         px: 3,
@@ -16,6 +18,7 @@ export const Alert = React.forwardRef(function Alert(props, ref) {
         color: 'white',
         bg: 'primary',
         borderRadius: 4,
+        ...variation,
       }}
     />
   )

--- a/packages/components/src/AspectImage.js
+++ b/packages/components/src/AspectImage.js
@@ -13,7 +13,7 @@ export const AspectImage = React.forwardRef(function AspectImage(
       <Image
         ref={ref}
         {...props}
-        sx={{
+        __css={{
           objectFit: 'cover',
         }}
       />

--- a/packages/components/src/AspectImage.js
+++ b/packages/components/src/AspectImage.js
@@ -2,14 +2,19 @@ import React from 'react'
 import { AspectRatio } from './AspectRatio'
 import { Image } from './Image'
 
-export const AspectImage = React.forwardRef(({ ratio, ...props }, ref) => (
-  <AspectRatio ratio={ratio}>
-    <Image
-      ref={ref}
-      {...props}
-      __css={{
-        objectFit: 'cover',
-      }}
-    />
-  </AspectRatio>
-))
+export const AspectImage = React.forwardRef(function AspectImage(
+  { ratio, ...props },
+  ref
+) {
+  return (
+    <AspectRatio ratio={ratio}>
+      <Image
+        ref={ref}
+        {...props}
+        __css={{
+          objectFit: 'cover',
+        }}
+      />
+    </AspectRatio>
+  )
+})

--- a/packages/components/src/AspectImage.js
+++ b/packages/components/src/AspectImage.js
@@ -1,3 +1,5 @@
+/** @jsx jsx */
+import { jsx } from '@theme-ui/core'
 import React from 'react'
 import { AspectRatio } from './AspectRatio'
 import { Image } from './Image'
@@ -11,7 +13,7 @@ export const AspectImage = React.forwardRef(function AspectImage(
       <Image
         ref={ref}
         {...props}
-        __css={{
+        sx={{
           objectFit: 'cover',
         }}
       />

--- a/packages/components/src/AspectRatio.js
+++ b/packages/components/src/AspectRatio.js
@@ -1,3 +1,5 @@
+/** @jsx jsx */
+import { jsx } from '@theme-ui/core'
 import React from 'react'
 import Box from './Box'
 
@@ -21,7 +23,7 @@ export const AspectRatio = React.forwardRef(function AspectRatio(
       />
       <Box
         {...props}
-        __css={{
+        sx={{
           position: 'absolute',
           top: 0,
           right: 0,

--- a/packages/components/src/AspectRatio.js
+++ b/packages/components/src/AspectRatio.js
@@ -1,8 +1,11 @@
 import React from 'react'
 import Box from './Box'
 
-export const AspectRatio = React.forwardRef(
-  ({ ratio = 4 / 3, children, ...props }, ref) => (
+export const AspectRatio = React.forwardRef(function AspectRatio(
+  { ratio = 4 / 3, children, ...props },
+  ref
+) {
+  return (
     <Box
       ref={ref}
       sx={{
@@ -29,4 +32,4 @@ export const AspectRatio = React.forwardRef(
       </Box>
     </Box>
   )
-)
+})

--- a/packages/components/src/AspectRatio.js
+++ b/packages/components/src/AspectRatio.js
@@ -10,12 +10,12 @@ export const AspectRatio = React.forwardRef(function AspectRatio(
   return (
     <Box
       ref={ref}
-      sx={{
+      __css={{
         position: 'relative',
         overflow: 'hidden',
       }}>
       <Box
-        sx={{
+        __css={{
           width: '100%',
           height: 0,
           paddingBottom: 100 / ratio + '%',
@@ -23,7 +23,7 @@ export const AspectRatio = React.forwardRef(function AspectRatio(
       />
       <Box
         {...props}
-        sx={{
+        __css={{
           position: 'absolute',
           top: 0,
           right: 0,

--- a/packages/components/src/Avatar.js
+++ b/packages/components/src/Avatar.js
@@ -1,3 +1,5 @@
+/** @jsx jsx */
+import { jsx } from '@theme-ui/core'
 import React from 'react'
 import { Image } from './Image'
 
@@ -12,7 +14,7 @@ export const Avatar = React.forwardRef(function Avatar(
       height={size}
       variant="avatar"
       {...props}
-      __css={{
+      sx={{
         borderRadius: 9999,
       }}
     />

--- a/packages/components/src/Avatar.js
+++ b/packages/components/src/Avatar.js
@@ -1,15 +1,20 @@
 import React from 'react'
 import { Image } from './Image'
 
-export const Avatar = React.forwardRef(({ size = 48, ...props }, ref) => (
-  <Image
-    ref={ref}
-    width={size}
-    height={size}
-    variant="avatar"
-    {...props}
-    __css={{
-      borderRadius: 9999,
-    }}
-  />
-))
+export const Avatar = React.forwardRef(function Avatar(
+  { size = 48, ...props },
+  ref
+) {
+  return (
+    <Image
+      ref={ref}
+      width={size}
+      height={size}
+      variant="avatar"
+      {...props}
+      __css={{
+        borderRadius: 9999,
+      }}
+    />
+  )
+})

--- a/packages/components/src/Avatar.js
+++ b/packages/components/src/Avatar.js
@@ -14,7 +14,7 @@ export const Avatar = React.forwardRef(function Avatar(
       height={size}
       variant="avatar"
       {...props}
-      sx={{
+      __css={{
         borderRadius: 9999,
       }}
     />

--- a/packages/components/src/Badge.js
+++ b/packages/components/src/Badge.js
@@ -1,13 +1,19 @@
+/** @jsx jsx */
+import { jsx } from '@theme-ui/core'
 import React from 'react'
 import Box from './Box'
+import { useVariant } from './util'
 
-export const Badge = React.forwardRef(function Badge(props, ref) {
+export const Badge = React.forwardRef(function Badge(
+  { variant, ...props },
+  ref
+) {
+  const variation = useVariant('badges', variant)
   return (
     <Box
       ref={ref}
       {...props}
-      __themeKey="badges"
-      __css={{
+      sx={{
         display: 'inline-block',
         verticalAlign: 'baseline',
         fontSize: 0,
@@ -17,6 +23,7 @@ export const Badge = React.forwardRef(function Badge(props, ref) {
         borderRadius: 2,
         color: 'white',
         bg: 'primary',
+        ...variation,
       }}
     />
   )

--- a/packages/components/src/Badge.js
+++ b/packages/components/src/Badge.js
@@ -1,21 +1,23 @@
 import React from 'react'
 import Box from './Box'
 
-export const Badge = React.forwardRef((props, ref) => (
-  <Box
-    ref={ref}
-    {...props}
-    __themeKey="badges"
-    __css={{
-      display: 'inline-block',
-      verticalAlign: 'baseline',
-      fontSize: 0,
-      fontWeight: 'bold',
-      whiteSpace: 'nowrap',
-      px: 1,
-      borderRadius: 2,
-      color: 'white',
-      bg: 'primary',
-    }}
-  />
-))
+export const Badge = React.forwardRef(function Badge(props, ref) {
+  return (
+    <Box
+      ref={ref}
+      {...props}
+      __themeKey="badges"
+      __css={{
+        display: 'inline-block',
+        verticalAlign: 'baseline',
+        fontSize: 0,
+        fontWeight: 'bold',
+        whiteSpace: 'nowrap',
+        px: 1,
+        borderRadius: 2,
+        color: 'white',
+        bg: 'primary',
+      }}
+    />
+  )
+})

--- a/packages/components/src/Badge.js
+++ b/packages/components/src/Badge.js
@@ -13,7 +13,7 @@ export const Badge = React.forwardRef(function Badge(
     <Box
       ref={ref}
       {...props}
-      sx={{
+      __css={{
         display: 'inline-block',
         verticalAlign: 'baseline',
         fontSize: 0,

--- a/packages/components/src/Badge.js
+++ b/packages/components/src/Badge.js
@@ -8,7 +8,7 @@ export const Badge = React.forwardRef(function Badge(
   { variant, ...props },
   ref
 ) {
-  const variation = useVariant('badges', variant)
+  const variantStyle = useVariant('badges', variant)
   return (
     <Box
       ref={ref}
@@ -23,7 +23,7 @@ export const Badge = React.forwardRef(function Badge(
         borderRadius: 2,
         color: 'white',
         bg: 'primary',
-        ...variation,
+        ...variantStyle,
       }}
     />
   )

--- a/packages/components/src/Box.js
+++ b/packages/components/src/Box.js
@@ -15,6 +15,7 @@ const variant = ({ theme, variant, __themeKey = 'variants' }) =>
   css(get(theme, __themeKey + '.' + variant, get(theme, variant)))
 
 export const Box = styled('div', {
+  label: 'Box',
   shouldForwardProp,
 })(
   {

--- a/packages/components/src/Box.js
+++ b/packages/components/src/Box.js
@@ -1,12 +1,13 @@
 /** @jsx jsx */
 import { jsx } from '@theme-ui/core'
 
-export const Box = ({ as = 'div', ...props }) => {
+export const Box = ({ as = 'div', __css, ...props }) => {
   return jsx(as, {
     sx: {
       boxSizing: 'border-box',
       margin: 0,
       minWidth: 0,
+      ...__css,
     },
     ...props,
   })

--- a/packages/components/src/Box.js
+++ b/packages/components/src/Box.js
@@ -1,34 +1,15 @@
-import styled from '@emotion/styled'
-import { css, get } from '@theme-ui/css'
-import { createShouldForwardProp } from '@styled-system/should-forward-prop'
-import space from '@styled-system/space'
-import color from '@styled-system/color'
+/** @jsx jsx */
+import { jsx } from '@theme-ui/core'
 
-const shouldForwardProp = createShouldForwardProp([
-  ...space.propNames,
-  ...color.propNames,
-])
-
-const sx = props => css(props.sx)(props.theme)
-const base = props => css(props.__css)(props.theme)
-const variant = ({ theme, variant, __themeKey = 'variants' }) =>
-  css(get(theme, __themeKey + '.' + variant, get(theme, variant)))
-
-export const Box = styled('div', {
-  label: 'Box',
-  shouldForwardProp,
-})(
-  {
-    boxSizing: 'border-box',
-    margin: 0,
-    minWidth: 0,
-  },
-  base,
-  variant,
-  space,
-  color,
-  sx,
-  props => props.css
-)
+export const Box = ({ as = 'div', ...props }) => {
+  return jsx(as, {
+    sx: {
+      boxSizing: 'border-box',
+      margin: 0,
+      minWidth: 0,
+    },
+    ...props,
+  })
+}
 
 export default Box

--- a/packages/components/src/Button.js
+++ b/packages/components/src/Button.js
@@ -1,26 +1,28 @@
 import React from 'react'
 import Box from './Box'
 
-export const Button = React.forwardRef((props, ref) => (
-  <Box
-    ref={ref}
-    as="button"
-    variant="primary"
-    {...props}
-    __themeKey="buttons"
-    __css={{
-      appearance: 'none',
-      display: 'inline-block',
-      textAlign: 'center',
-      lineHeight: 'inherit',
-      textDecoration: 'none',
-      fontSize: 'inherit',
-      px: 3,
-      py: 2,
-      color: 'white',
-      bg: 'primary',
-      border: 0,
-      borderRadius: 4,
-    }}
-  />
-))
+export const Button = React.forwardRef(function Button(props, ref) {
+  return (
+    <Box
+      ref={ref}
+      as="button"
+      variant="primary"
+      {...props}
+      __themeKey="buttons"
+      __css={{
+        appearance: 'none',
+        display: 'inline-block',
+        textAlign: 'center',
+        lineHeight: 'inherit',
+        textDecoration: 'none',
+        fontSize: 'inherit',
+        px: 3,
+        py: 2,
+        color: 'white',
+        bg: 'primary',
+        border: 0,
+        borderRadius: 4,
+      }}
+    />
+  )
+})

--- a/packages/components/src/Button.js
+++ b/packages/components/src/Button.js
@@ -14,7 +14,7 @@ export const Button = React.forwardRef(function Button(
       ref={ref}
       as="button"
       {...props}
-      sx={{
+      __css={{
         appearance: 'none',
         display: 'inline-block',
         textAlign: 'center',

--- a/packages/components/src/Button.js
+++ b/packages/components/src/Button.js
@@ -8,7 +8,7 @@ export const Button = React.forwardRef(function Button(
   { variant = 'primary', ...props },
   ref
 ) {
-  const variation = useVariant('buttons', variant)
+  const variantStyle = useVariant('buttons', variant)
   return (
     <Box
       ref={ref}
@@ -27,7 +27,7 @@ export const Button = React.forwardRef(function Button(
         bg: 'primary',
         border: 0,
         borderRadius: 4,
-        ...variation,
+        ...variantStyle,
       }}
     />
   )

--- a/packages/components/src/Button.js
+++ b/packages/components/src/Button.js
@@ -1,15 +1,20 @@
+/** @jsx jsx */
+import { jsx } from '@theme-ui/core'
 import React from 'react'
 import Box from './Box'
+import { useVariant } from './util'
 
-export const Button = React.forwardRef(function Button(props, ref) {
+export const Button = React.forwardRef(function Button(
+  { variant = 'primary', ...props },
+  ref
+) {
+  const variation = useVariant('buttons', variant)
   return (
     <Box
       ref={ref}
       as="button"
-      variant="primary"
       {...props}
-      __themeKey="buttons"
-      __css={{
+      sx={{
         appearance: 'none',
         display: 'inline-block',
         textAlign: 'center',
@@ -22,6 +27,7 @@ export const Button = React.forwardRef(function Button(props, ref) {
         bg: 'primary',
         border: 0,
         borderRadius: 4,
+        ...variation,
       }}
     />
   )

--- a/packages/components/src/Card.js
+++ b/packages/components/src/Card.js
@@ -8,6 +8,6 @@ export const Card = React.forwardRef(function Card(
   { variant = 'primary', ...props },
   ref
 ) {
-  const variation = useVariant('cards', variant)
-  return <Box ref={ref} {...props} sx={variation} />
+  const variantStyle = useVariant('cards', variant)
+  return <Box ref={ref} {...props} sx={variantStyle} />
 })

--- a/packages/components/src/Card.js
+++ b/packages/components/src/Card.js
@@ -1,6 +1,13 @@
+/** @jsx jsx */
+import { jsx } from '@theme-ui/core'
 import React from 'react'
 import Box from './Box'
+import { useVariant } from './util'
 
-export const Card = React.forwardRef(function Card(props, ref) {
-  return <Box ref={ref} variant="primary" {...props} __themeKey="cards" />
+export const Card = React.forwardRef(function Card(
+  { variant = 'primary', ...props },
+  ref
+) {
+  const variation = useVariant('cards', variant)
+  return <Box ref={ref} {...props} sx={variation} />
 })

--- a/packages/components/src/Card.js
+++ b/packages/components/src/Card.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import Box from './Box'
 
-export const Card = React.forwardRef((props, ref) => (
-  <Box ref={ref} variant="primary" {...props} __themeKey="cards" />
-))
+export const Card = React.forwardRef(function Card(props, ref) {
+  return <Box ref={ref} variant="primary" {...props} __themeKey="cards" />
+})

--- a/packages/components/src/Checkbox.js
+++ b/packages/components/src/Checkbox.js
@@ -44,9 +44,9 @@ export const Checkbox = React.forwardRef(function Checkbox(
   { className, variant = 'checkbox', ...props },
   ref
 ) {
-  const variation = useVariant('forms', variant)
+  const variantStyle = useVariant('forms', variant)
   return (
-    <Box sx={variation.container}>
+    <Box sx={variantStyle.container}>
       <Box
         ref={ref}
         as="input"
@@ -59,7 +59,7 @@ export const Checkbox = React.forwardRef(function Checkbox(
           width: 1,
           height: 1,
           overflow: 'hidden',
-          ...(variation.input && { ...variation.input }),
+          ...(variantStyle.input && { ...variantStyle.input }),
         }}
       />
       <Box
@@ -77,7 +77,7 @@ export const Checkbox = React.forwardRef(function Checkbox(
             color: 'primary',
             bg: 'highlight',
           },
-          ...(variation.icon && { ...variation.icon }),
+          ...(variantStyle.icon && { ...variantStyle.icon }),
         }}
       />
     </Box>

--- a/packages/components/src/Checkbox.js
+++ b/packages/components/src/Checkbox.js
@@ -21,7 +21,7 @@ const CheckboxIcon = props => (
   <React.Fragment>
     <CheckboxChecked
       {...props}
-      sx={{
+      __css={{
         display: 'none',
         'input:checked ~ &': {
           display: 'block',
@@ -30,7 +30,7 @@ const CheckboxIcon = props => (
     />
     <CheckboxUnchecked
       {...props}
-      sx={{
+      __css={{
         display: 'block',
         'input:checked ~ &': {
           display: 'none',
@@ -52,7 +52,7 @@ export const Checkbox = React.forwardRef(function Checkbox(
         as="input"
         type="checkbox"
         {...props}
-        sx={{
+        __css={{
           position: 'absolute',
           opacity: 0,
           zIndex: -1,
@@ -66,7 +66,7 @@ export const Checkbox = React.forwardRef(function Checkbox(
         as={CheckboxIcon}
         aria-hidden="true"
         className={className}
-        sx={{
+        __css={{
           mr: 2,
           borderRadius: 4,
           color: 'gray',

--- a/packages/components/src/Checkbox.js
+++ b/packages/components/src/Checkbox.js
@@ -37,8 +37,11 @@ const CheckboxIcon = props => (
   </React.Fragment>
 )
 
-export const Checkbox = React.forwardRef(
-  ({ className, sx, variant = 'checkbox', ...props }, ref) => (
+export const Checkbox = React.forwardRef(function Checkbox(
+  { className, sx, variant = 'checkbox', ...props },
+  ref
+) {
+  return (
     <Box>
       <Box
         ref={ref}
@@ -76,4 +79,4 @@ export const Checkbox = React.forwardRef(
       />
     </Box>
   )
-)
+})

--- a/packages/components/src/Checkbox.js
+++ b/packages/components/src/Checkbox.js
@@ -1,6 +1,9 @@
+/** @jsx jsx */
+import { jsx } from '@theme-ui/core'
 import React from 'react'
 import Box from './Box'
 import SVG from './SVG'
+import { useVariant } from './util'
 
 const CheckboxChecked = props => (
   <SVG {...props}>
@@ -18,7 +21,7 @@ const CheckboxIcon = props => (
   <React.Fragment>
     <CheckboxChecked
       {...props}
-      __css={{
+      sx={{
         display: 'none',
         'input:checked ~ &': {
           display: 'block',
@@ -27,7 +30,7 @@ const CheckboxIcon = props => (
     />
     <CheckboxUnchecked
       {...props}
-      __css={{
+      sx={{
         display: 'block',
         'input:checked ~ &': {
           display: 'none',
@@ -38,11 +41,12 @@ const CheckboxIcon = props => (
 )
 
 export const Checkbox = React.forwardRef(function Checkbox(
-  { className, sx, variant = 'checkbox', ...props },
+  { className, variant = 'checkbox', ...props },
   ref
 ) {
+  const variation = useVariant('forms', variant)
   return (
-    <Box>
+    <Box sx={variation.container}>
       <Box
         ref={ref}
         as="input"
@@ -55,16 +59,14 @@ export const Checkbox = React.forwardRef(function Checkbox(
           width: 1,
           height: 1,
           overflow: 'hidden',
+          ...(variation.input && { ...variation.input }),
         }}
       />
       <Box
         as={CheckboxIcon}
         aria-hidden="true"
-        __themeKey="forms"
-        variant={variant}
         className={className}
-        sx={sx}
-        __css={{
+        sx={{
           mr: 2,
           borderRadius: 4,
           color: 'gray',
@@ -75,6 +77,7 @@ export const Checkbox = React.forwardRef(function Checkbox(
             color: 'primary',
             bg: 'highlight',
           },
+          ...(variation.icon && { ...variation.icon }),
         }}
       />
     </Box>

--- a/packages/components/src/Close.js
+++ b/packages/components/src/Close.js
@@ -12,13 +12,18 @@ const x = (
   </svg>
 )
 
-export const Close = React.forwardRef(({ size = 32, ...props }, ref) => (
-  <IconButton
-    ref={ref}
-    title="Close"
-    aria-label="Close"
-    variant="close"
-    {...props}
-    children={x}
-  />
-))
+export const Close = React.forwardRef(function Close(
+  { size = 32, ...props },
+  ref
+) {
+  return (
+    <IconButton
+      ref={ref}
+      title="Close"
+      aria-label="Close"
+      variant="close"
+      {...props}
+      children={x}
+    />
+  )
+})

--- a/packages/components/src/Close.js
+++ b/packages/components/src/Close.js
@@ -1,3 +1,5 @@
+/** @jsx jsx */
+import { jsx } from '@theme-ui/core'
 import React from 'react'
 import { IconButton } from './IconButton'
 

--- a/packages/components/src/Container.js
+++ b/packages/components/src/Container.js
@@ -8,7 +8,7 @@ export const Container = React.forwardRef(function Container(
   { variant, ...props },
   ref
 ) {
-  const variation = useVariant('layout', variant)
+  const variantStyle = useVariant('layout', variant)
   return (
     <Box
       ref={ref}
@@ -17,7 +17,7 @@ export const Container = React.forwardRef(function Container(
         width: '100%',
         maxWidth: 'container',
         mx: 'auto',
-        ...variation,
+        ...variantStyle,
       }}
     />
   )

--- a/packages/components/src/Container.js
+++ b/packages/components/src/Container.js
@@ -1,16 +1,18 @@
 import React from 'react'
 import Box from './Box'
 
-export const Container = React.forwardRef((props, ref) => (
-  <Box
-    ref={ref}
-    variant="container"
-    {...props}
-    __themeKey="layout"
-    __css={{
-      width: '100%',
-      maxWidth: 'container',
-      mx: 'auto',
-    }}
-  />
-))
+export const Container = React.forwardRef(function Container(props, ref) {
+  return (
+    <Box
+      ref={ref}
+      variant="container"
+      {...props}
+      __themeKey="layout"
+      __css={{
+        width: '100%',
+        maxWidth: 'container',
+        mx: 'auto',
+      }}
+    />
+  )
+})

--- a/packages/components/src/Container.js
+++ b/packages/components/src/Container.js
@@ -13,7 +13,7 @@ export const Container = React.forwardRef(function Container(
     <Box
       ref={ref}
       {...props}
-      sx={{
+      __css={{
         width: '100%',
         maxWidth: 'container',
         mx: 'auto',

--- a/packages/components/src/Container.js
+++ b/packages/components/src/Container.js
@@ -1,17 +1,23 @@
+/** @jsx jsx */
+import { jsx } from '@theme-ui/core'
 import React from 'react'
 import Box from './Box'
+import { useVariant } from './util'
 
-export const Container = React.forwardRef(function Container(props, ref) {
+export const Container = React.forwardRef(function Container(
+  { variant, ...props },
+  ref
+) {
+  const variation = useVariant('layout', variant)
   return (
     <Box
       ref={ref}
-      variant="container"
       {...props}
-      __themeKey="layout"
-      __css={{
+      sx={{
         width: '100%',
         maxWidth: 'container',
         mx: 'auto',
+        ...variation,
       }}
     />
   )

--- a/packages/components/src/Divider.js
+++ b/packages/components/src/Divider.js
@@ -11,7 +11,7 @@ export const Divider = React.forwardRef(function Divider(props, ref) {
       ref={ref}
       as="hr"
       {...props}
-      sx={{
+      __css={{
         color: 'gray',
         m: 0,
         my: 2,

--- a/packages/components/src/Divider.js
+++ b/packages/components/src/Divider.js
@@ -1,18 +1,20 @@
 import React from 'react'
 import Box from './Box'
 
-export const Divider = React.forwardRef((props, ref) => (
-  <Box
-    ref={ref}
-    as="hr"
-    variant="styles.hr"
-    {...props}
-    __css={{
-      color: 'gray',
-      m: 0,
-      my: 2,
-      border: 0,
-      borderBottom: '1px solid',
-    }}
-  />
-))
+export const Divider = React.forwardRef(function Divider(props, ref) {
+  return (
+    <Box
+      ref={ref}
+      as="hr"
+      variant="styles.hr"
+      {...props}
+      __css={{
+        color: 'gray',
+        m: 0,
+        my: 2,
+        border: 0,
+        borderBottom: '1px solid',
+      }}
+    />
+  )
+})

--- a/packages/components/src/Divider.js
+++ b/packages/components/src/Divider.js
@@ -1,19 +1,23 @@
+/** @jsx jsx */
+import { jsx } from '@theme-ui/core'
 import React from 'react'
 import Box from './Box'
+import { useVariant } from './util'
 
 export const Divider = React.forwardRef(function Divider(props, ref) {
+  const variation = useVariant('styles', 'hr')
   return (
     <Box
       ref={ref}
       as="hr"
-      variant="styles.hr"
       {...props}
-      __css={{
+      sx={{
         color: 'gray',
         m: 0,
         my: 2,
         border: 0,
         borderBottom: '1px solid',
+        ...variation,
       }}
     />
   )

--- a/packages/components/src/Divider.js
+++ b/packages/components/src/Divider.js
@@ -5,7 +5,7 @@ import Box from './Box'
 import { useVariant } from './util'
 
 export const Divider = React.forwardRef(function Divider(props, ref) {
-  const variation = useVariant('styles', 'hr')
+  const variantStyle = useVariant('styles', 'hr')
   return (
     <Box
       ref={ref}
@@ -17,7 +17,7 @@ export const Divider = React.forwardRef(function Divider(props, ref) {
         my: 2,
         border: 0,
         borderBottom: '1px solid',
-        ...variation,
+        ...variantStyle,
       }}
     />
   )

--- a/packages/components/src/Donut.js
+++ b/packages/components/src/Donut.js
@@ -26,7 +26,7 @@ export const Donut = React.forwardRef(function Donut(
       aria-valuemin={min}
       aria-valuemax={max}
       {...props}
-      sx={{
+      __css={{
         color: 'primary',
       }}>
       {title && <title>{title}</title>}

--- a/packages/components/src/Donut.js
+++ b/packages/components/src/Donut.js
@@ -1,3 +1,5 @@
+/** @jsx jsx */
+import { jsx } from '@theme-ui/core'
 import React from 'react'
 import Box from './Box'
 
@@ -24,7 +26,7 @@ export const Donut = React.forwardRef(function Donut(
       aria-valuemin={min}
       aria-valuemax={max}
       {...props}
-      __css={{
+      sx={{
         color: 'primary',
       }}>
       {title && <title>{title}</title>}

--- a/packages/components/src/Donut.js
+++ b/packages/components/src/Donut.js
@@ -1,52 +1,42 @@
 import React from 'react'
 import Box from './Box'
 
-export const Donut = React.forwardRef(
-  (
-    {
-      size = 128,
-      strokeWidth = 2,
-      value = 0,
-      min = 0,
-      max = 1,
-      title,
-      ...props
-    },
-    ref
-  ) => {
-    const r = 16 - strokeWidth
-    const C = 2 * r * Math.PI
-    const offset = C - ((value - min) / (max - min)) * C
+export const Donut = React.forwardRef(function Donut(
+  { size = 128, strokeWidth = 2, value = 0, min = 0, max = 1, title, ...props },
+  ref
+) {
+  const r = 16 - strokeWidth
+  const C = 2 * r * Math.PI
+  const offset = C - ((value - min) / (max - min)) * C
 
-    return (
-      <Box
-        ref={ref}
-        as="svg"
-        viewBox="0 0 32 32"
-        width={size}
-        height={size}
-        strokeWidth={strokeWidth}
-        fill="none"
-        stroke="currentcolor"
-        role="img"
-        aria-valuenow={value}
-        aria-valuemin={min}
-        aria-valuemax={max}
-        {...props}
-        __css={{
-          color: 'primary',
-        }}>
-        {title && <title>{title}</title>}
-        <circle cx={16} cy={16} r={r} opacity={1 / 8} />
-        <circle
-          cx={16}
-          cy={16}
-          r={r}
-          strokeDasharray={C}
-          strokeDashoffset={offset}
-          transform="rotate(-90 16 16)"
-        />
-      </Box>
-    )
-  }
-)
+  return (
+    <Box
+      ref={ref}
+      as="svg"
+      viewBox="0 0 32 32"
+      width={size}
+      height={size}
+      strokeWidth={strokeWidth}
+      fill="none"
+      stroke="currentcolor"
+      role="img"
+      aria-valuenow={value}
+      aria-valuemin={min}
+      aria-valuemax={max}
+      {...props}
+      __css={{
+        color: 'primary',
+      }}>
+      {title && <title>{title}</title>}
+      <circle cx={16} cy={16} r={r} opacity={1 / 8} />
+      <circle
+        cx={16}
+        cy={16}
+        r={r}
+        strokeDasharray={C}
+        strokeDashoffset={offset}
+        transform="rotate(-90 16 16)"
+      />
+    </Box>
+  )
+})

--- a/packages/components/src/Embed.js
+++ b/packages/components/src/Embed.js
@@ -19,7 +19,7 @@ export const Embed = React.forwardRef(function Embed(
   return (
     <Box
       {...props}
-      sx={{
+      __css={{
         width: '100%',
         height: 0,
         paddingBottom: 100 / ratio + '%',
@@ -35,7 +35,7 @@ export const Embed = React.forwardRef(function Embed(
         frameBorder={frameBorder}
         allowFullScreen={allowFullScreen}
         allow={allow}
-        sx={{
+        __css={{
           position: 'absolute',
           width: '100%',
           height: '100%',

--- a/packages/components/src/Embed.js
+++ b/packages/components/src/Embed.js
@@ -1,20 +1,20 @@
 import React from 'react'
 import Box from './Box'
 
-export const Embed = React.forwardRef(
-  (
-    {
-      ratio = 16 / 9,
-      src,
-      frameBorder = 0,
-      allowFullScreen = true,
-      width = 560,
-      height = 315,
-      allow,
-      ...props
-    },
-    ref
-  ) => (
+export const Embed = React.forwardRef(function Embed(
+  {
+    ratio = 16 / 9,
+    src,
+    frameBorder = 0,
+    allowFullScreen = true,
+    width = 560,
+    height = 315,
+    allow,
+    ...props
+  },
+  ref
+) {
+  return (
     <Box
       {...props}
       __css={{
@@ -45,4 +45,4 @@ export const Embed = React.forwardRef(
       />
     </Box>
   )
-)
+})

--- a/packages/components/src/Embed.js
+++ b/packages/components/src/Embed.js
@@ -1,3 +1,5 @@
+/** @jsx jsx */
+import { jsx } from '@theme-ui/core'
 import React from 'react'
 import Box from './Box'
 
@@ -17,7 +19,7 @@ export const Embed = React.forwardRef(function Embed(
   return (
     <Box
       {...props}
-      __css={{
+      sx={{
         width: '100%',
         height: 0,
         paddingBottom: 100 / ratio + '%',
@@ -33,7 +35,7 @@ export const Embed = React.forwardRef(function Embed(
         frameBorder={frameBorder}
         allowFullScreen={allowFullScreen}
         allow={allow}
-        __css={{
+        sx={{
           position: 'absolute',
           width: '100%',
           height: '100%',

--- a/packages/components/src/Field.js
+++ b/packages/components/src/Field.js
@@ -4,13 +4,14 @@ import { Label } from './Label'
 import { Input } from './Input'
 import { getMargin, omitMargin } from './util'
 
-export const Field = React.forwardRef(
-  ({ as: Control = Input, label, name, ...props }, ref) => {
-    return (
-      <Box {...getMargin(props)}>
-        <Label htmlFor={name}>{label}</Label>
-        <Control ref={ref} id={name} name={name} {...omitMargin(props)} />
-      </Box>
-    )
-  }
-)
+export const Field = React.forwardRef(function Field(
+  { as: Control = Input, label, name, ...props },
+  ref
+) {
+  return (
+    <Box {...getMargin(props)}>
+      <Label htmlFor={name}>{label}</Label>
+      <Control ref={ref} id={name} name={name} {...omitMargin(props)} />
+    </Box>
+  )
+})

--- a/packages/components/src/Field.js
+++ b/packages/components/src/Field.js
@@ -1,3 +1,5 @@
+/** @jsx jsx */
+import { jsx } from '@theme-ui/core'
 import React from 'react'
 import Box from './Box'
 import { Label } from './Label'

--- a/packages/components/src/Flex.js
+++ b/packages/components/src/Flex.js
@@ -2,4 +2,4 @@
 import { jsx } from '@theme-ui/core'
 import Box from './Box'
 
-export const Flex = props => <Box sx={{ display: 'flex' }} {...props} />
+export const Flex = props => <Box __css={{ display: 'flex' }} {...props} />

--- a/packages/components/src/Flex.js
+++ b/packages/components/src/Flex.js
@@ -1,6 +1,5 @@
-import styled from '@emotion/styled'
+/** @jsx jsx */
+import { jsx } from '@theme-ui/core'
 import Box from './Box'
 
-export const Flex = styled(Box, { label: 'Flex' })({
-  display: 'flex',
-})
+export const Flex = props => <Box sx={{ display: 'flex' }} {...props} />

--- a/packages/components/src/Flex.js
+++ b/packages/components/src/Flex.js
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import Box from './Box'
 
-export const Flex = styled(Box)({
+export const Flex = styled(Box, { label: 'Flex' })({
   display: 'flex',
 })

--- a/packages/components/src/Grid.js
+++ b/packages/components/src/Grid.js
@@ -30,7 +30,7 @@ export const Grid = React.forwardRef(function Grid(
     <Box
       ref={ref}
       {...props}
-      sx={{
+      __css={{
         display: 'grid',
         gridGap: gap,
         gridTemplateColumns,

--- a/packages/components/src/Grid.js
+++ b/packages/components/src/Grid.js
@@ -24,7 +24,7 @@ export const Grid = React.forwardRef(function Grid(
     ? widthToColumns(width)
     : countToColumns(columns)
 
-  const variation = useVariant('grids', variant)
+  const variantStyle = useVariant('grids', variant)
 
   return (
     <Box
@@ -34,7 +34,7 @@ export const Grid = React.forwardRef(function Grid(
         display: 'grid',
         gridGap: gap,
         gridTemplateColumns,
-        ...variation,
+        ...variantStyle,
       }}
     />
   )

--- a/packages/components/src/Grid.js
+++ b/packages/components/src/Grid.js
@@ -1,5 +1,8 @@
+/** @jsx jsx */
+import { jsx } from '@theme-ui/core'
 import React from 'react'
 import Box from './Box'
+import { useVariant } from './util'
 
 const px = n => (typeof n === 'number' ? n + 'px' : n)
 
@@ -14,22 +17,24 @@ const countToColumns = n =>
     : !!n && (typeof n === 'number' ? `repeat(${n}, 1fr)` : n)
 
 export const Grid = React.forwardRef(function Grid(
-  { width, columns, gap = 3, ...props },
+  { width, columns, gap = 3, variant, ...props },
   ref
 ) {
   const gridTemplateColumns = !!width
     ? widthToColumns(width)
     : countToColumns(columns)
 
+  const variation = useVariant('grids', variant)
+
   return (
     <Box
       ref={ref}
       {...props}
-      __themeKey="grids"
-      __css={{
+      sx={{
         display: 'grid',
         gridGap: gap,
         gridTemplateColumns,
+        ...variation,
       }}
     />
   )

--- a/packages/components/src/Grid.js
+++ b/packages/components/src/Grid.js
@@ -13,23 +13,24 @@ const countToColumns = n =>
     ? n.map(countToColumns)
     : !!n && (typeof n === 'number' ? `repeat(${n}, 1fr)` : n)
 
-export const Grid = React.forwardRef(
-  ({ width, columns, gap = 3, ...props }, ref) => {
-    const gridTemplateColumns = !!width
-      ? widthToColumns(width)
-      : countToColumns(columns)
+export const Grid = React.forwardRef(function Grid(
+  { width, columns, gap = 3, ...props },
+  ref
+) {
+  const gridTemplateColumns = !!width
+    ? widthToColumns(width)
+    : countToColumns(columns)
 
-    return (
-      <Box
-        ref={ref}
-        {...props}
-        __themeKey="grids"
-        __css={{
-          display: 'grid',
-          gridGap: gap,
-          gridTemplateColumns,
-        }}
-      />
-    )
-  }
-)
+  return (
+    <Box
+      ref={ref}
+      {...props}
+      __themeKey="grids"
+      __css={{
+        display: 'grid',
+        gridGap: gap,
+        gridTemplateColumns,
+      }}
+    />
+  )
+})

--- a/packages/components/src/Heading.js
+++ b/packages/components/src/Heading.js
@@ -1,17 +1,19 @@
 import React from 'react'
 import Box from './Box'
 
-export const Heading = React.forwardRef((props, ref) => (
-  <Box
-    ref={ref}
-    as="h2"
-    variant="heading"
-    {...props}
-    __themeKey="text"
-    __css={{
-      fontFamily: 'heading',
-      fontWeight: 'heading',
-      lineHeight: 'heading',
-    }}
-  />
-))
+export const Heading = React.forwardRef(function Heading(props, ref) {
+  return (
+    <Box
+      ref={ref}
+      as="h2"
+      variant="heading"
+      {...props}
+      __themeKey="text"
+      __css={{
+        fontFamily: 'heading',
+        fontWeight: 'heading',
+        lineHeight: 'heading',
+      }}
+    />
+  )
+})

--- a/packages/components/src/Heading.js
+++ b/packages/components/src/Heading.js
@@ -11,7 +11,7 @@ export const Heading = React.forwardRef(function Heading(props, ref) {
       ref={ref}
       as="h2"
       {...props}
-      sx={{
+      __css={{
         fontFamily: 'heading',
         fontWeight: 'heading',
         lineHeight: 'heading',

--- a/packages/components/src/Heading.js
+++ b/packages/components/src/Heading.js
@@ -5,7 +5,7 @@ import Box from './Box'
 import { useVariant } from './util'
 
 export const Heading = React.forwardRef(function Heading(props, ref) {
-  const variation = useVariant('text', 'heading')
+  const variantStyle = useVariant('text', 'heading')
   return (
     <Box
       ref={ref}
@@ -15,7 +15,7 @@ export const Heading = React.forwardRef(function Heading(props, ref) {
         fontFamily: 'heading',
         fontWeight: 'heading',
         lineHeight: 'heading',
-        ...variation,
+        ...variantStyle,
       }}
     />
   )

--- a/packages/components/src/Heading.js
+++ b/packages/components/src/Heading.js
@@ -1,18 +1,21 @@
+/** @jsx jsx */
+import { jsx } from '@theme-ui/core'
 import React from 'react'
 import Box from './Box'
+import { useVariant } from './util'
 
 export const Heading = React.forwardRef(function Heading(props, ref) {
+  const variation = useVariant('text', 'heading')
   return (
     <Box
       ref={ref}
       as="h2"
-      variant="heading"
       {...props}
-      __themeKey="text"
-      __css={{
+      sx={{
         fontFamily: 'heading',
         fontWeight: 'heading',
         lineHeight: 'heading',
+        ...variation,
       }}
     />
   )

--- a/packages/components/src/IconButton.js
+++ b/packages/components/src/IconButton.js
@@ -14,7 +14,7 @@ export const IconButton = React.forwardRef(function IconButton(
       ref={ref}
       as="button"
       {...props}
-      sx={{
+      __css={{
         appearance: 'none',
         display: 'inline-flex',
         alignItems: 'center',

--- a/packages/components/src/IconButton.js
+++ b/packages/components/src/IconButton.js
@@ -1,18 +1,20 @@
+/** @jsx jsx */
+import { jsx } from '@theme-ui/core'
 import React from 'react'
 import Box from './Box'
+import { useVariant } from './util'
 
 export const IconButton = React.forwardRef(function IconButton(
-  { size = 32, ...props },
+  { size = 32, variant = 'icon', ...props },
   ref
 ) {
+  const variation = useVariant('buttons', variant)
   return (
     <Box
       ref={ref}
       as="button"
-      variant="icon"
       {...props}
-      __themeKey="buttons"
-      __css={{
+      sx={{
         appearance: 'none',
         display: 'inline-flex',
         alignItems: 'center',
@@ -24,6 +26,7 @@ export const IconButton = React.forwardRef(function IconButton(
         bg: 'transparent',
         border: 'none',
         borderRadius: 4,
+        ...variation,
       }}
     />
   )

--- a/packages/components/src/IconButton.js
+++ b/packages/components/src/IconButton.js
@@ -1,25 +1,30 @@
 import React from 'react'
 import Box from './Box'
 
-export const IconButton = React.forwardRef(({ size = 32, ...props }, ref) => (
-  <Box
-    ref={ref}
-    as="button"
-    variant="icon"
-    {...props}
-    __themeKey="buttons"
-    __css={{
-      appearance: 'none',
-      display: 'inline-flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      padding: 1,
-      width: size,
-      height: size,
-      color: 'inherit',
-      bg: 'transparent',
-      border: 'none',
-      borderRadius: 4,
-    }}
-  />
-))
+export const IconButton = React.forwardRef(function IconButton(
+  { size = 32, ...props },
+  ref
+) {
+  return (
+    <Box
+      ref={ref}
+      as="button"
+      variant="icon"
+      {...props}
+      __themeKey="buttons"
+      __css={{
+        appearance: 'none',
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 1,
+        width: size,
+        height: size,
+        color: 'inherit',
+        bg: 'transparent',
+        border: 'none',
+        borderRadius: 4,
+      }}
+    />
+  )
+})

--- a/packages/components/src/IconButton.js
+++ b/packages/components/src/IconButton.js
@@ -8,7 +8,7 @@ export const IconButton = React.forwardRef(function IconButton(
   { size = 32, variant = 'icon', ...props },
   ref
 ) {
-  const variation = useVariant('buttons', variant)
+  const variantStyle = useVariant('buttons', variant)
   return (
     <Box
       ref={ref}
@@ -26,7 +26,7 @@ export const IconButton = React.forwardRef(function IconButton(
         bg: 'transparent',
         border: 'none',
         borderRadius: 4,
-        ...variation,
+        ...variantStyle,
       }}
     />
   )

--- a/packages/components/src/Image.js
+++ b/packages/components/src/Image.js
@@ -8,7 +8,7 @@ export const Image = React.forwardRef(function Image(
   { variant, ...props },
   ref
 ) {
-  const variation = useVariant('images', variant)
+  const variantStyle = useVariant('images', variant)
   return (
     <Box
       ref={ref}
@@ -17,7 +17,7 @@ export const Image = React.forwardRef(function Image(
       sx={{
         maxWidth: '100%',
         height: 'auto',
-        ...variation,
+        ...variantStyle,
       }}
     />
   )

--- a/packages/components/src/Image.js
+++ b/packages/components/src/Image.js
@@ -1,17 +1,23 @@
+/** @jsx jsx */
+import { jsx } from '@theme-ui/core'
 import React from 'react'
 import Box from './Box'
+import { useVariant } from './util'
 
-export const Image = React.forwardRef(function Image(props, ref) {
+export const Image = React.forwardRef(function Image(
+  { variant, ...props },
+  ref
+) {
+  const variation = useVariant('images', variant)
   return (
     <Box
       ref={ref}
       as="img"
       {...props}
-      __themeKey="images"
-      __css={{
+      sx={{
         maxWidth: '100%',
         height: 'auto',
-        ...props.__css,
+        ...variation,
       }}
     />
   )

--- a/packages/components/src/Image.js
+++ b/packages/components/src/Image.js
@@ -14,9 +14,10 @@ export const Image = React.forwardRef(function Image(
       ref={ref}
       as="img"
       {...props}
-      sx={{
+      __css={{
         maxWidth: '100%',
         height: 'auto',
+        ...props.__css,
         ...variantStyle,
       }}
     />

--- a/packages/components/src/Image.js
+++ b/packages/components/src/Image.js
@@ -1,16 +1,18 @@
 import React from 'react'
 import Box from './Box'
 
-export const Image = React.forwardRef((props, ref) => (
-  <Box
-    ref={ref}
-    as="img"
-    {...props}
-    __themeKey="images"
-    __css={{
-      maxWidth: '100%',
-      height: 'auto',
-      ...props.__css,
-    }}
-  />
-))
+export const Image = React.forwardRef(function Image(props, ref) {
+  return (
+    <Box
+      ref={ref}
+      as="img"
+      {...props}
+      __themeKey="images"
+      __css={{
+        maxWidth: '100%',
+        height: 'auto',
+        ...props.__css,
+      }}
+    />
+  )
+})

--- a/packages/components/src/Input.js
+++ b/packages/components/src/Input.js
@@ -11,7 +11,7 @@ export const Input = React.forwardRef(function Input(props, ref) {
       ref={ref}
       as="input"
       {...props}
-      sx={{
+      __css={{
         display: 'block',
         width: '100%',
         p: 2,

--- a/packages/components/src/Input.js
+++ b/packages/components/src/Input.js
@@ -1,15 +1,17 @@
+/** @jsx jsx */
+import { jsx } from '@theme-ui/core'
 import React from 'react'
 import Box from './Box'
+import { useVariant } from './util'
 
 export const Input = React.forwardRef(function Input(props, ref) {
+  const variation = useVariant('forms', 'input')
   return (
     <Box
       ref={ref}
       as="input"
-      variant="input"
       {...props}
-      __themeKey="forms"
-      __css={{
+      sx={{
         display: 'block',
         width: '100%',
         p: 2,
@@ -20,6 +22,7 @@ export const Input = React.forwardRef(function Input(props, ref) {
         borderRadius: 4,
         color: 'inherit',
         bg: 'transparent',
+        ...variation,
       }}
     />
   )

--- a/packages/components/src/Input.js
+++ b/packages/components/src/Input.js
@@ -5,7 +5,7 @@ import Box from './Box'
 import { useVariant } from './util'
 
 export const Input = React.forwardRef(function Input(props, ref) {
-  const variation = useVariant('forms', 'input')
+  const variantStyle = useVariant('forms', 'input')
   return (
     <Box
       ref={ref}
@@ -22,7 +22,7 @@ export const Input = React.forwardRef(function Input(props, ref) {
         borderRadius: 4,
         color: 'inherit',
         bg: 'transparent',
-        ...variation,
+        ...variantStyle,
       }}
     />
   )

--- a/packages/components/src/Input.js
+++ b/packages/components/src/Input.js
@@ -1,24 +1,26 @@
 import React from 'react'
 import Box from './Box'
 
-export const Input = React.forwardRef((props, ref) => (
-  <Box
-    ref={ref}
-    as="input"
-    variant="input"
-    {...props}
-    __themeKey="forms"
-    __css={{
-      display: 'block',
-      width: '100%',
-      p: 2,
-      appearance: 'none',
-      fontSize: 'inherit',
-      lineHeight: 'inherit',
-      border: '1px solid',
-      borderRadius: 4,
-      color: 'inherit',
-      bg: 'transparent',
-    }}
-  />
-))
+export const Input = React.forwardRef(function Input(props, ref) {
+  return (
+    <Box
+      ref={ref}
+      as="input"
+      variant="input"
+      {...props}
+      __themeKey="forms"
+      __css={{
+        display: 'block',
+        width: '100%',
+        p: 2,
+        appearance: 'none',
+        fontSize: 'inherit',
+        lineHeight: 'inherit',
+        border: '1px solid',
+        borderRadius: 4,
+        color: 'inherit',
+        bg: 'transparent',
+      }}
+    />
+  )
+})

--- a/packages/components/src/Label.js
+++ b/packages/components/src/Label.js
@@ -1,17 +1,20 @@
+/** @jsx jsx */
+import { jsx } from '@theme-ui/core'
 import React from 'react'
 import Box from './Box'
+import { useVariant } from './util'
 
 export const Label = React.forwardRef(function Label(props, ref) {
+  const variation = useVariant('forms', 'label')
   return (
     <Box
       ref={ref}
       as="label"
-      variant="label"
       {...props}
-      __themeKey="forms"
-      __css={{
+      sx={{
         width: '100%',
         display: 'flex',
+        ...variation,
       }}
     />
   )

--- a/packages/components/src/Label.js
+++ b/packages/components/src/Label.js
@@ -11,7 +11,7 @@ export const Label = React.forwardRef(function Label(props, ref) {
       ref={ref}
       as="label"
       {...props}
-      sx={{
+      __css={{
         width: '100%',
         display: 'flex',
         ...variantStyle,

--- a/packages/components/src/Label.js
+++ b/packages/components/src/Label.js
@@ -5,7 +5,7 @@ import Box from './Box'
 import { useVariant } from './util'
 
 export const Label = React.forwardRef(function Label(props, ref) {
-  const variation = useVariant('forms', 'label')
+  const variantStyle = useVariant('forms', 'label')
   return (
     <Box
       ref={ref}
@@ -14,7 +14,7 @@ export const Label = React.forwardRef(function Label(props, ref) {
       sx={{
         width: '100%',
         display: 'flex',
-        ...variation,
+        ...variantStyle,
       }}
     />
   )

--- a/packages/components/src/Label.js
+++ b/packages/components/src/Label.js
@@ -1,16 +1,18 @@
 import React from 'react'
 import Box from './Box'
 
-export const Label = React.forwardRef((props, ref) => (
-  <Box
-    ref={ref}
-    as="label"
-    variant="label"
-    {...props}
-    __themeKey="forms"
-    __css={{
-      width: '100%',
-      display: 'flex',
-    }}
-  />
-))
+export const Label = React.forwardRef(function Label(props, ref) {
+  return (
+    <Box
+      ref={ref}
+      as="label"
+      variant="label"
+      {...props}
+      __themeKey="forms"
+      __css={{
+        width: '100%',
+        display: 'flex',
+      }}
+    />
+  )
+})

--- a/packages/components/src/Link.js
+++ b/packages/components/src/Link.js
@@ -8,6 +8,6 @@ export const Link = React.forwardRef(function Link(
   { variant = 'styles.a', ...props },
   ref
 ) {
-  const variation = useVariant('links', variant)
-  return <Box ref={ref} as="a" {...props} sx={variation} />
+  const variantStyle = useVariant('links', variant)
+  return <Box ref={ref} as="a" {...props} sx={variantStyle} />
 })

--- a/packages/components/src/Link.js
+++ b/packages/components/src/Link.js
@@ -1,8 +1,13 @@
+/** @jsx jsx */
+import { jsx } from '@theme-ui/core'
 import React from 'react'
 import Box from './Box'
+import { useVariant } from './util'
 
-export const Link = React.forwardRef(function Link(props, ref) {
-  return (
-    <Box ref={ref} as="a" variant="styles.a" {...props} __themeKey="links" />
-  )
+export const Link = React.forwardRef(function Link(
+  { variant = 'styles.a', ...props },
+  ref
+) {
+  const variation = useVariant('links', variant)
+  return <Box ref={ref} as="a" {...props} sx={variation} />
 })

--- a/packages/components/src/Link.js
+++ b/packages/components/src/Link.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import Box from './Box'
 
-export const Link = React.forwardRef((props, ref) => (
-  <Box ref={ref} as="a" variant="styles.a" {...props} __themeKey="links" />
-))
+export const Link = React.forwardRef(function Link(props, ref) {
+  return (
+    <Box ref={ref} as="a" variant="styles.a" {...props} __themeKey="links" />
+  )
+})

--- a/packages/components/src/MenuButton.js
+++ b/packages/components/src/MenuButton.js
@@ -18,13 +18,15 @@ export const MenuIcon = ({ size = 24 }) => (
   </Box>
 )
 
-export const MenuButton = React.forwardRef((props, ref) => (
-  <IconButton
-    ref={ref}
-    title="Menu"
-    aria-label="Toggle Menu"
-    variant="menu"
-    {...props}>
-    <MenuIcon />
-  </IconButton>
-))
+export const MenuButton = React.forwardRef(function MenuButton(props, ref) {
+  return (
+    <IconButton
+      ref={ref}
+      title="Menu"
+      aria-label="Toggle Menu"
+      variant="menu"
+      {...props}>
+      <MenuIcon />
+    </IconButton>
+  )
+})

--- a/packages/components/src/MenuButton.js
+++ b/packages/components/src/MenuButton.js
@@ -1,3 +1,5 @@
+/** @jsx jsx */
+import { jsx } from '@theme-ui/core'
 import React from 'react'
 import Box from './Box'
 import { IconButton } from './IconButton'

--- a/packages/components/src/MenuButton.js
+++ b/packages/components/src/MenuButton.js
@@ -12,7 +12,7 @@ export const MenuIcon = ({ size = 24 }) => (
     height={size}
     fill="currentcolor"
     viewBox="0 0 24 24"
-    sx={{
+    __css={{
       display: 'block',
       margin: 0,
     }}>

--- a/packages/components/src/Message.js
+++ b/packages/components/src/Message.js
@@ -8,7 +8,7 @@ export const Message = React.forwardRef(function Message(
   { variant, ...props },
   ref
 ) {
-  const variation = useVariant('messages', variant)
+  const variantStyle = useVariant('messages', variant)
   return (
     <Box
       ref={ref}
@@ -21,7 +21,7 @@ export const Message = React.forwardRef(function Message(
         borderLeftColor: 'primary',
         borderRadius: 4,
         bg: 'highlight',
-        ...variation,
+        ...variantStyle,
       }}
     />
   )

--- a/packages/components/src/Message.js
+++ b/packages/components/src/Message.js
@@ -1,19 +1,21 @@
 import React from 'react'
 import Box from './Box'
 
-export const Message = React.forwardRef((props, ref) => (
-  <Box
-    ref={ref}
-    {...props}
-    __themeKey="messages"
-    __css={{
-      padding: 3,
-      paddingLeft: t => t.space[3] - t.space[1],
-      borderLeftWidth: t => t.space[1],
-      borderLeftStyle: 'solid',
-      borderLeftColor: 'primary',
-      borderRadius: 4,
-      bg: 'highlight',
-    }}
-  />
-))
+export const Message = React.forwardRef(function Message(props, ref) {
+  return (
+    <Box
+      ref={ref}
+      {...props}
+      __themeKey="messages"
+      __css={{
+        padding: 3,
+        paddingLeft: t => t.space[3] - t.space[1],
+        borderLeftWidth: t => t.space[1],
+        borderLeftStyle: 'solid',
+        borderLeftColor: 'primary',
+        borderRadius: 4,
+        bg: 'highlight',
+      }}
+    />
+  )
+})

--- a/packages/components/src/Message.js
+++ b/packages/components/src/Message.js
@@ -1,12 +1,18 @@
+/** @jsx jsx */
+import { jsx } from '@theme-ui/core'
 import React from 'react'
 import Box from './Box'
+import { useVariant } from './util'
 
-export const Message = React.forwardRef(function Message(props, ref) {
+export const Message = React.forwardRef(function Message(
+  { variant, ...props },
+  ref
+) {
+  const variation = useVariant('messages', variant)
   return (
     <Box
       ref={ref}
       {...props}
-      __themeKey="messages"
       __css={{
         padding: 3,
         paddingLeft: t => t.space[3] - t.space[1],
@@ -15,6 +21,7 @@ export const Message = React.forwardRef(function Message(props, ref) {
         borderLeftColor: 'primary',
         borderRadius: 4,
         bg: 'highlight',
+        ...variation,
       }}
     />
   )

--- a/packages/components/src/NavLink.js
+++ b/packages/components/src/NavLink.js
@@ -9,7 +9,7 @@ export const NavLink = React.forwardRef(function NavLink(props, ref) {
       ref={ref}
       variant="nav"
       {...props}
-      sx={{
+      __css={{
         color: 'inherit',
         textDecoration: 'none',
         fontWeight: 'bold',

--- a/packages/components/src/NavLink.js
+++ b/packages/components/src/NavLink.js
@@ -1,19 +1,21 @@
 import React from 'react'
 import { Link } from './Link'
 
-export const NavLink = React.forwardRef((props, ref) => (
-  <Link
-    ref={ref}
-    variant="nav"
-    {...props}
-    __css={{
-      color: 'inherit',
-      textDecoration: 'none',
-      fontWeight: 'bold',
-      display: 'inline-block',
-      '&:hover, &:focus, &.active': {
-        color: 'primary',
-      },
-    }}
-  />
-))
+export const NavLink = React.forwardRef(function NavLink(props, ref) {
+  return (
+    <Link
+      ref={ref}
+      variant="nav"
+      {...props}
+      __css={{
+        color: 'inherit',
+        textDecoration: 'none',
+        fontWeight: 'bold',
+        display: 'inline-block',
+        '&:hover, &:focus, &.active': {
+          color: 'primary',
+        },
+      }}
+    />
+  )
+})

--- a/packages/components/src/NavLink.js
+++ b/packages/components/src/NavLink.js
@@ -1,3 +1,5 @@
+/** @jsx jsx */
+import { jsx } from '@theme-ui/core'
 import React from 'react'
 import { Link } from './Link'
 
@@ -7,7 +9,7 @@ export const NavLink = React.forwardRef(function NavLink(props, ref) {
       ref={ref}
       variant="nav"
       {...props}
-      __css={{
+      sx={{
         color: 'inherit',
         textDecoration: 'none',
         fontWeight: 'bold',

--- a/packages/components/src/Progress.js
+++ b/packages/components/src/Progress.js
@@ -5,7 +5,7 @@ import Box from './Box'
 import { useVariant } from './util'
 
 export const Progress = React.forwardRef(function Progress(props, ref) {
-  const variation = useVariant('styles', 'progress')
+  const variantStyle = useVariant('styles', 'progress')
   return (
     <Box
       ref={ref}
@@ -32,7 +32,7 @@ export const Progress = React.forwardRef(function Progress(props, ref) {
         '&::-moz-progress-bar': {
           bg: 'currentcolor',
         },
-        ...variation,
+        ...variantStyle,
       }}
     />
   )

--- a/packages/components/src/Progress.js
+++ b/packages/components/src/Progress.js
@@ -11,7 +11,7 @@ export const Progress = React.forwardRef(function Progress(props, ref) {
       ref={ref}
       as="progress"
       {...props}
-      sx={{
+      __css={{
         display: 'block',
         width: '100%',
         height: '4px',

--- a/packages/components/src/Progress.js
+++ b/packages/components/src/Progress.js
@@ -1,14 +1,17 @@
+/** @jsx jsx */
+import { jsx } from '@theme-ui/core'
 import React from 'react'
 import Box from './Box'
+import { useVariant } from './util'
 
 export const Progress = React.forwardRef(function Progress(props, ref) {
+  const variation = useVariant('styles', 'progress')
   return (
     <Box
       ref={ref}
       as="progress"
-      variant="styles.progress"
       {...props}
-      __css={{
+      sx={{
         display: 'block',
         width: '100%',
         height: '4px',
@@ -29,6 +32,7 @@ export const Progress = React.forwardRef(function Progress(props, ref) {
         '&::-moz-progress-bar': {
           bg: 'currentcolor',
         },
+        ...variation,
       }}
     />
   )

--- a/packages/components/src/Progress.js
+++ b/packages/components/src/Progress.js
@@ -1,33 +1,35 @@
 import React from 'react'
 import Box from './Box'
 
-export const Progress = React.forwardRef((props, ref) => (
-  <Box
-    ref={ref}
-    as="progress"
-    variant="styles.progress"
-    {...props}
-    __css={{
-      display: 'block',
-      width: '100%',
-      height: '4px',
-      margin: 0,
-      padding: 0,
-      overflow: 'hidden',
-      appearance: 'none',
-      color: 'primary',
-      bg: 'gray',
-      borderRadius: 9999,
-      border: 'none',
-      '&::-webkit-progress-bar': {
-        bg: 'transparent',
-      },
-      '&::-webkit-progress-value': {
-        bg: 'currentcolor',
-      },
-      '&::-moz-progress-bar': {
-        bg: 'currentcolor',
-      },
-    }}
-  />
-))
+export const Progress = React.forwardRef(function Progress(props, ref) {
+  return (
+    <Box
+      ref={ref}
+      as="progress"
+      variant="styles.progress"
+      {...props}
+      __css={{
+        display: 'block',
+        width: '100%',
+        height: '4px',
+        margin: 0,
+        padding: 0,
+        overflow: 'hidden',
+        appearance: 'none',
+        color: 'primary',
+        bg: 'gray',
+        borderRadius: 9999,
+        border: 'none',
+        '&::-webkit-progress-bar': {
+          bg: 'transparent',
+        },
+        '&::-webkit-progress-value': {
+          bg: 'currentcolor',
+        },
+        '&::-moz-progress-bar': {
+          bg: 'currentcolor',
+        },
+      }}
+    />
+  )
+})

--- a/packages/components/src/Radio.js
+++ b/packages/components/src/Radio.js
@@ -21,7 +21,7 @@ const RadioIcon = props => (
   <React.Fragment>
     <RadioChecked
       {...props}
-      sx={{
+      __css={{
         display: 'none',
         'input:checked ~ &': {
           display: 'block',
@@ -30,7 +30,7 @@ const RadioIcon = props => (
     />
     <RadioUnchecked
       {...props}
-      sx={{
+      __css={{
         display: 'block',
         'input:checked ~ &': {
           display: 'none',
@@ -52,7 +52,7 @@ export const Radio = React.forwardRef(function Radio(
         as="input"
         type="radio"
         {...props}
-        sx={{
+        __css={{
           position: 'absolute',
           opacity: 0,
           zIndex: -1,
@@ -66,7 +66,7 @@ export const Radio = React.forwardRef(function Radio(
         as={RadioIcon}
         aria-hidden="true"
         className={className}
-        sx={{
+        __css={{
           // todo: system props??
           mr: 2,
           borderRadius: 9999,

--- a/packages/components/src/Radio.js
+++ b/packages/components/src/Radio.js
@@ -37,8 +37,11 @@ const RadioIcon = props => (
   </React.Fragment>
 )
 
-export const Radio = React.forwardRef(
-  ({ className, sx, variant = 'radio', ...props }, ref) => (
+export const Radio = React.forwardRef(function Radio(
+  { className, sx, variant = 'radio', ...props },
+  ref
+) {
+  return (
     <Box>
       <Box
         ref={ref}
@@ -76,4 +79,4 @@ export const Radio = React.forwardRef(
       />
     </Box>
   )
-)
+})

--- a/packages/components/src/Radio.js
+++ b/packages/components/src/Radio.js
@@ -44,9 +44,9 @@ export const Radio = React.forwardRef(function Radio(
   { className, variant = 'radio', ...props },
   ref
 ) {
-  const variation = useVariant('forms', variant)
+  const variantStyle = useVariant('forms', variant)
   return (
-    <Box sx={variation.container}>
+    <Box sx={variantStyle.container}>
       <Box
         ref={ref}
         as="input"
@@ -59,7 +59,7 @@ export const Radio = React.forwardRef(function Radio(
           width: 1,
           height: 1,
           overflow: 'hidden',
-          ...variation.radio,
+          ...variantStyle.radio,
         }}
       />
       <Box
@@ -77,7 +77,7 @@ export const Radio = React.forwardRef(function Radio(
           'input:focus ~ &': {
             bg: 'highlight',
           },
-          ...variation.icon,
+          ...variantStyle.icon,
         }}
       />
     </Box>

--- a/packages/components/src/Radio.js
+++ b/packages/components/src/Radio.js
@@ -1,6 +1,9 @@
+/** @jsx jsx */
+import { jsx } from '@theme-ui/core'
 import React from 'react'
 import Box from './Box'
 import SVG from './SVG'
+import { useVariant } from './util'
 
 const RadioChecked = props => (
   <SVG {...props}>
@@ -18,7 +21,7 @@ const RadioIcon = props => (
   <React.Fragment>
     <RadioChecked
       {...props}
-      __css={{
+      sx={{
         display: 'none',
         'input:checked ~ &': {
           display: 'block',
@@ -27,7 +30,7 @@ const RadioIcon = props => (
     />
     <RadioUnchecked
       {...props}
-      __css={{
+      sx={{
         display: 'block',
         'input:checked ~ &': {
           display: 'none',
@@ -38,11 +41,12 @@ const RadioIcon = props => (
 )
 
 export const Radio = React.forwardRef(function Radio(
-  { className, sx, variant = 'radio', ...props },
+  { className, variant = 'radio', ...props },
   ref
 ) {
+  const variation = useVariant('forms', variant)
   return (
-    <Box>
+    <Box sx={variation.container}>
       <Box
         ref={ref}
         as="input"
@@ -55,16 +59,14 @@ export const Radio = React.forwardRef(function Radio(
           width: 1,
           height: 1,
           overflow: 'hidden',
+          ...variation.radio,
         }}
       />
       <Box
         as={RadioIcon}
         aria-hidden="true"
-        __themeKey="forms"
-        variant={variant}
         className={className}
-        sx={sx}
-        __css={{
+        sx={{
           // todo: system props??
           mr: 2,
           borderRadius: 9999,
@@ -75,6 +77,7 @@ export const Radio = React.forwardRef(function Radio(
           'input:focus ~ &': {
             bg: 'highlight',
           },
+          ...variation.icon,
         }}
       />
     </Box>

--- a/packages/components/src/SVG.js
+++ b/packages/components/src/SVG.js
@@ -1,4 +1,5 @@
-import React from 'react'
+/** @jsx jsx */
+import { jsx } from '@theme-ui/core'
 import Box from './Box'
 
 export default ({ size = 24, ...props }) => (

--- a/packages/components/src/Select.js
+++ b/packages/components/src/Select.js
@@ -19,7 +19,7 @@ export const Select = React.forwardRef(function Select(
   return (
     <Box
       {...getMargin(props)}
-      sx={{
+      __css={{
         display: 'flex',
         ...variantStyle.container,
       }}>
@@ -27,7 +27,7 @@ export const Select = React.forwardRef(function Select(
         ref={ref}
         as="select"
         {...omitMargin(props)}
-        sx={{
+        __css={{
           display: 'block',
           width: '100%',
           p: 2,
@@ -42,7 +42,7 @@ export const Select = React.forwardRef(function Select(
         }}
       />
       <DownArrow
-        sx={{
+        __css={{
           ml: -28,
           alignSelf: 'center',
           pointerEvents: 'none',

--- a/packages/components/src/Select.js
+++ b/packages/components/src/Select.js
@@ -1,7 +1,9 @@
+/** @jsx jsx */
+import { jsx } from '@theme-ui/core'
 import React from 'react'
 import Box from './Box'
 import SVG from './SVG'
-import { getMargin, omitMargin } from './util'
+import { getMargin, omitMargin, useVariant } from './util'
 
 const DownArrow = props => (
   <SVG {...props}>
@@ -9,20 +11,23 @@ const DownArrow = props => (
   </SVG>
 )
 
-export const Select = React.forwardRef(function Select(props, ref) {
+export const Select = React.forwardRef(function Select(
+  { variant = 'select', ...props },
+  ref
+) {
+  const variation = useVariant('forms', variant)
   return (
     <Box
       {...getMargin(props)}
       sx={{
         display: 'flex',
+        ...variation.container,
       }}>
       <Box
         ref={ref}
         as="select"
-        variant="select"
         {...omitMargin(props)}
-        __themeKey="forms"
-        __css={{
+        sx={{
           display: 'block',
           width: '100%',
           p: 2,
@@ -33,6 +38,7 @@ export const Select = React.forwardRef(function Select(props, ref) {
           borderRadius: 4,
           color: 'inherit',
           bg: 'transparent',
+          ...variation.select,
         }}
       />
       <DownArrow
@@ -40,6 +46,7 @@ export const Select = React.forwardRef(function Select(props, ref) {
           ml: -28,
           alignSelf: 'center',
           pointerEvents: 'none',
+          ...variation.arrow,
         }}
       />
     </Box>

--- a/packages/components/src/Select.js
+++ b/packages/components/src/Select.js
@@ -15,13 +15,13 @@ export const Select = React.forwardRef(function Select(
   { variant = 'select', ...props },
   ref
 ) {
-  const variation = useVariant('forms', variant)
+  const variantStyle = useVariant('forms', variant)
   return (
     <Box
       {...getMargin(props)}
       sx={{
         display: 'flex',
-        ...variation.container,
+        ...variantStyle.container,
       }}>
       <Box
         ref={ref}
@@ -38,7 +38,7 @@ export const Select = React.forwardRef(function Select(
           borderRadius: 4,
           color: 'inherit',
           bg: 'transparent',
-          ...variation.select,
+          ...variantStyle.select,
         }}
       />
       <DownArrow
@@ -46,7 +46,7 @@ export const Select = React.forwardRef(function Select(
           ml: -28,
           alignSelf: 'center',
           pointerEvents: 'none',
-          ...variation.arrow,
+          ...variantStyle.arrow,
         }}
       />
     </Box>

--- a/packages/components/src/Select.js
+++ b/packages/components/src/Select.js
@@ -9,37 +9,39 @@ const DownArrow = props => (
   </SVG>
 )
 
-export const Select = React.forwardRef((props, ref) => (
-  <Box
-    {...getMargin(props)}
-    sx={{
-      display: 'flex',
-    }}>
+export const Select = React.forwardRef(function Select(props, ref) {
+  return (
     <Box
-      ref={ref}
-      as="select"
-      variant="select"
-      {...omitMargin(props)}
-      __themeKey="forms"
-      __css={{
-        display: 'block',
-        width: '100%',
-        p: 2,
-        appearance: 'none',
-        fontSize: 'inherit',
-        lineHeight: 'inherit',
-        border: '1px solid',
-        borderRadius: 4,
-        color: 'inherit',
-        bg: 'transparent',
-      }}
-    />
-    <DownArrow
+      {...getMargin(props)}
       sx={{
-        ml: -28,
-        alignSelf: 'center',
-        pointerEvents: 'none',
-      }}
-    />
-  </Box>
-))
+        display: 'flex',
+      }}>
+      <Box
+        ref={ref}
+        as="select"
+        variant="select"
+        {...omitMargin(props)}
+        __themeKey="forms"
+        __css={{
+          display: 'block',
+          width: '100%',
+          p: 2,
+          appearance: 'none',
+          fontSize: 'inherit',
+          lineHeight: 'inherit',
+          border: '1px solid',
+          borderRadius: 4,
+          color: 'inherit',
+          bg: 'transparent',
+        }}
+      />
+      <DownArrow
+        sx={{
+          ml: -28,
+          alignSelf: 'center',
+          pointerEvents: 'none',
+        }}
+      />
+    </Box>
+  )
+})

--- a/packages/components/src/Slider.js
+++ b/packages/components/src/Slider.js
@@ -15,7 +15,7 @@ const thumb = {
 }
 
 export const Slider = React.forwardRef(function Slider(props, ref) {
-  const variation = useVariant('forms', 'slider')
+  const variantStyle = useVariant('forms', 'slider')
   return (
     <Box
       ref={ref}
@@ -39,7 +39,7 @@ export const Slider = React.forwardRef(function Slider(props, ref) {
         '&::-webkit-slider-thumb': thumb,
         '&::-moz-range-thumb': thumb,
         '&::-ms-thumb': thumb,
-        ...variation,
+        ...variantStyle,
       }}
     />
   )

--- a/packages/components/src/Slider.js
+++ b/packages/components/src/Slider.js
@@ -11,31 +11,33 @@ const thumb = {
   variant: 'forms.slider.thumb',
 }
 
-export const Slider = React.forwardRef((props, ref) => (
-  <Box
-    ref={ref}
-    as="input"
-    type="range"
-    variant="slider"
-    {...props}
-    __themeKey="forms"
-    __css={{
-      display: 'block',
-      width: '100%',
-      height: 4,
-      my: 2,
-      cursor: 'pointer',
-      appearance: 'none',
-      borderRadius: 9999,
-      color: 'inherit',
-      bg: 'gray',
-      ':focus': {
-        outline: 'none',
-        color: 'primary',
-      },
-      '&::-webkit-slider-thumb': thumb,
-      '&::-moz-range-thumb': thumb,
-      '&::-ms-thumb': thumb,
-    }}
-  />
-))
+export const Slider = React.forwardRef(function Slider(props, ref) {
+  return (
+    <Box
+      ref={ref}
+      as="input"
+      type="range"
+      variant="slider"
+      {...props}
+      __themeKey="forms"
+      __css={{
+        display: 'block',
+        width: '100%',
+        height: 4,
+        my: 2,
+        cursor: 'pointer',
+        appearance: 'none',
+        borderRadius: 9999,
+        color: 'inherit',
+        bg: 'gray',
+        ':focus': {
+          outline: 'none',
+          color: 'primary',
+        },
+        '&::-webkit-slider-thumb': thumb,
+        '&::-moz-range-thumb': thumb,
+        '&::-ms-thumb': thumb,
+      }}
+    />
+  )
+})

--- a/packages/components/src/Slider.js
+++ b/packages/components/src/Slider.js
@@ -1,5 +1,8 @@
+/** @jsx jsx */
+import { jsx } from '@theme-ui/core'
 import React from 'react'
 import Box from './Box'
+import { useVariant } from './util'
 
 const thumb = {
   appearance: 'none',
@@ -12,15 +15,14 @@ const thumb = {
 }
 
 export const Slider = React.forwardRef(function Slider(props, ref) {
+  const variation = useVariant('forms', 'slider')
   return (
     <Box
       ref={ref}
       as="input"
       type="range"
-      variant="slider"
       {...props}
-      __themeKey="forms"
-      __css={{
+      sx={{
         display: 'block',
         width: '100%',
         height: 4,
@@ -37,6 +39,7 @@ export const Slider = React.forwardRef(function Slider(props, ref) {
         '&::-webkit-slider-thumb': thumb,
         '&::-moz-range-thumb': thumb,
         '&::-ms-thumb': thumb,
+        ...variation,
       }}
     />
   )

--- a/packages/components/src/Slider.js
+++ b/packages/components/src/Slider.js
@@ -22,7 +22,7 @@ export const Slider = React.forwardRef(function Slider(props, ref) {
       as="input"
       type="range"
       {...props}
-      sx={{
+      __css={{
         display: 'block',
         width: '100%',
         height: 4,

--- a/packages/components/src/Spinner.js
+++ b/packages/components/src/Spinner.js
@@ -11,56 +11,54 @@ const spin = keyframes({
   },
 })
 
-export const Spinner = React.forwardRef(
-  (
-    {
-      size = 48,
-      strokeWidth = 4,
-      max = 1,
-      title = 'Loading...',
-      duration = 500,
-      ...props
-    },
-    ref
-  ) => {
-    const r = 16 - strokeWidth
-    const C = 2 * r * Math.PI
-    const offset = C - (1 / 4) * C
+export const Spinner = React.forwardRef(function Spinner(
+  {
+    size = 48,
+    strokeWidth = 4,
+    max = 1,
+    title = 'Loading...',
+    duration = 500,
+    ...props
+  },
+  ref
+) {
+  const r = 16 - strokeWidth
+  const C = 2 * r * Math.PI
+  const offset = C - (1 / 4) * C
 
-    return (
+  return (
+    <Box
+      ref={ref}
+      as="svg"
+      viewBox="0 0 32 32"
+      width={size}
+      height={size}
+      strokeWidth={strokeWidth}
+      fill="none"
+      stroke="currentcolor"
+      role="img"
+      {...props}
+      __css={{
+        color: 'primary',
+        overflow: 'visible',
+      }}>
+      <title>{title}</title>
+      <circle cx={16} cy={16} r={r} opacity={1 / 8} />
       <Box
-        ref={ref}
-        as="svg"
-        viewBox="0 0 32 32"
-        width={size}
-        height={size}
-        strokeWidth={strokeWidth}
-        fill="none"
-        stroke="currentcolor"
-        role="img"
-        {...props}
+        as="circle"
+        cx={16}
+        cy={16}
+        r={r}
+        strokeDasharray={C}
+        strokeDashoffset={offset}
         __css={{
-          color: 'primary',
-          overflow: 'visible',
-        }}>
-        <title>{title}</title>
-        <circle cx={16} cy={16} r={r} opacity={1 / 8} />
-        <Box
-          as="circle"
-          cx={16}
-          cy={16}
-          r={r}
-          strokeDasharray={C}
-          strokeDashoffset={offset}
-          __css={{
-            transformOrigin: '50% 50%',
-            animationName: spin.toString(),
-            animationTimingFunction: 'linear',
-            animationDuration: duration + 'ms',
-            animationIterationCount: 'infinite',
-          }}
-        />
-      </Box>
-    )
-  }
-)
+          transformOrigin: '50% 50%',
+          animationName: spin.toString(),
+          animationTimingFunction: 'linear',
+          animationDuration: duration + 'ms',
+          animationIterationCount: 'infinite',
+        }}
+      />
+    </Box>
+  )
+})

--- a/packages/components/src/Spinner.js
+++ b/packages/components/src/Spinner.js
@@ -40,7 +40,7 @@ export const Spinner = React.forwardRef(function Spinner(
       stroke="currentcolor"
       role="img"
       {...props}
-      sx={{
+      __css={{
         color: 'primary',
         overflow: 'visible',
       }}>
@@ -53,7 +53,7 @@ export const Spinner = React.forwardRef(function Spinner(
         r={r}
         strokeDasharray={C}
         strokeDashoffset={offset}
-        sx={{
+        __css={{
           transformOrigin: '50% 50%',
           animationName: spin.toString(),
           animationTimingFunction: 'linear',

--- a/packages/components/src/Spinner.js
+++ b/packages/components/src/Spinner.js
@@ -1,3 +1,5 @@
+/** @jsx jsx */
+import { jsx } from '@theme-ui/core'
 import React from 'react'
 import { keyframes } from '@emotion/core'
 import Box from './Box'
@@ -38,7 +40,7 @@ export const Spinner = React.forwardRef(function Spinner(
       stroke="currentcolor"
       role="img"
       {...props}
-      __css={{
+      sx={{
         color: 'primary',
         overflow: 'visible',
       }}>
@@ -51,7 +53,7 @@ export const Spinner = React.forwardRef(function Spinner(
         r={r}
         strokeDasharray={C}
         strokeDashoffset={offset}
-        __css={{
+        sx={{
           transformOrigin: '50% 50%',
           animationName: spin.toString(),
           animationTimingFunction: 'linear',

--- a/packages/components/src/Text.js
+++ b/packages/components/src/Text.js
@@ -5,6 +5,6 @@ import Box from './Box'
 import { useVariant } from './util'
 
 export const Text = React.forwardRef(function Text({ variant, ...props }, ref) {
-  const variation = useVariant('text', variant)
-  return <Box ref={ref} {...props} sx={variation} />
+  const variantStyle = useVariant('text', variant)
+  return <Box ref={ref} {...props} sx={variantStyle} />
 })

--- a/packages/components/src/Text.js
+++ b/packages/components/src/Text.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import Box from './Box'
 
-export const Text = React.forwardRef((props, ref) => (
-  <Box ref={ref} {...props} __themeKey="text" />
-))
+export const Text = React.forwardRef(function Text(props, ref) {
+  return <Box ref={ref} {...props} __themeKey="text" />
+})

--- a/packages/components/src/Text.js
+++ b/packages/components/src/Text.js
@@ -1,6 +1,10 @@
+/** @jsx jsx */
+import { jsx } from '@theme-ui/core'
 import React from 'react'
 import Box from './Box'
+import { useVariant } from './util'
 
-export const Text = React.forwardRef(function Text(props, ref) {
-  return <Box ref={ref} {...props} __themeKey="text" />
+export const Text = React.forwardRef(function Text({ variant, ...props }, ref) {
+  const variation = useVariant('text', variant)
+  return <Box ref={ref} {...props} sx={variation} />
 })

--- a/packages/components/src/Textarea.js
+++ b/packages/components/src/Textarea.js
@@ -5,7 +5,7 @@ import Box from './Box'
 import { useVariant } from './util'
 
 export const Textarea = React.forwardRef(function Textarea(props, ref) {
-  const variation = useVariant('forms', 'textarea')
+  const variantStyle = useVariant('forms', 'textarea')
   return (
     <Box
       ref={ref}
@@ -22,7 +22,7 @@ export const Textarea = React.forwardRef(function Textarea(props, ref) {
         borderRadius: 4,
         color: 'inherit',
         bg: 'transparent',
-        ...variation
+        ...variantStyle
       }}
     />
   )

--- a/packages/components/src/Textarea.js
+++ b/packages/components/src/Textarea.js
@@ -11,7 +11,7 @@ export const Textarea = React.forwardRef(function Textarea(props, ref) {
       ref={ref}
       as="textarea"
       {...props}
-      sx={{
+      __css={{
         display: 'block',
         width: '100%',
         p: 2,

--- a/packages/components/src/Textarea.js
+++ b/packages/components/src/Textarea.js
@@ -1,24 +1,26 @@
 import React from 'react'
 import Box from './Box'
 
-export const Textarea = React.forwardRef((props, ref) => (
-  <Box
-    ref={ref}
-    as="textarea"
-    variant="textarea"
-    {...props}
-    __themeKey="forms"
-    __css={{
-      display: 'block',
-      width: '100%',
-      p: 2,
-      appearance: 'none',
-      fontSize: 'inherit',
-      lineHeight: 'inherit',
-      border: '1px solid',
-      borderRadius: 4,
-      color: 'inherit',
-      bg: 'transparent',
-    }}
-  />
-))
+export const Textarea = React.forwardRef(function Textarea(props, ref) {
+  return (
+    <Box
+      ref={ref}
+      as="textarea"
+      variant="textarea"
+      {...props}
+      __themeKey="forms"
+      __css={{
+        display: 'block',
+        width: '100%',
+        p: 2,
+        appearance: 'none',
+        fontSize: 'inherit',
+        lineHeight: 'inherit',
+        border: '1px solid',
+        borderRadius: 4,
+        color: 'inherit',
+        bg: 'transparent',
+      }}
+    />
+  )
+})

--- a/packages/components/src/Textarea.js
+++ b/packages/components/src/Textarea.js
@@ -1,15 +1,17 @@
+/** @jsx jsx */
+import { jsx } from '@theme-ui/core'
 import React from 'react'
 import Box from './Box'
+import { useVariant } from './util'
 
 export const Textarea = React.forwardRef(function Textarea(props, ref) {
+  const variation = useVariant('forms', 'textarea')
   return (
     <Box
       ref={ref}
       as="textarea"
-      variant="textarea"
       {...props}
-      __themeKey="forms"
-      __css={{
+      sx={{
         display: 'block',
         width: '100%',
         p: 2,
@@ -20,6 +22,7 @@ export const Textarea = React.forwardRef(function Textarea(props, ref) {
         borderRadius: 4,
         color: 'inherit',
         bg: 'transparent',
+        ...variation
       }}
     />
   )

--- a/packages/components/src/util.js
+++ b/packages/components/src/util.js
@@ -17,5 +17,11 @@ export const omitMargin = getProps(k => !MRE.test(k))
 
 export const useVariant = (key, variant) => {
   const theme = React.useContext(ThemeContext)
-  return variant ? get(theme, key + '.' + variant) : {}
+  if (variant) {
+    const variation = get(theme, key + '.' + variant)
+    if (variation) {
+      return variation
+    }
+  }
+  return {}
 }

--- a/packages/components/src/util.js
+++ b/packages/components/src/util.js
@@ -1,3 +1,7 @@
+import { ThemeContext } from '@emotion/core'
+import React from 'react'
+import { get } from '@theme-ui/css'
+
 export const getProps = test => props => {
   const next = {}
   for (const key in props) {
@@ -10,3 +14,8 @@ const MRE = /^m[trblxy]?$/
 
 export const getMargin = getProps(k => MRE.test(k))
 export const omitMargin = getProps(k => !MRE.test(k))
+
+export const useVariant = (key, variant) => {
+  const theme = React.useContext(ThemeContext)
+  return variant ? get(theme, key + '.' + variant) : {}
+}

--- a/packages/components/src/util.js
+++ b/packages/components/src/util.js
@@ -18,9 +18,9 @@ export const omitMargin = getProps(k => !MRE.test(k))
 export const useVariant = (key, variant) => {
   const theme = React.useContext(ThemeContext)
   if (variant) {
-    const variation = get(theme, key + '.' + variant)
-    if (variation) {
-      return variation
+    const variantStyle = get(theme, key + '.' + variant)
+    if (variantStyle) {
+      return variantStyle
     }
   }
   return {}

--- a/packages/docs/src/gatsby-plugin-theme-ui/index.js
+++ b/packages/docs/src/gatsby-plugin-theme-ui/index.js
@@ -90,14 +90,14 @@ export default {
       fontWeight: 'bold',
     },
     secondary: {
-      variant: 'buttons.primary',
       color: 'background',
       bg: 'secondary',
+      fontWeight: 'bold',
     },
     black: {
-      fontWeight: 'bold',
       color: 'background',
       bg: 'text',
+      fontWeight: 'bold',
       '&:hover, &:focus': {
         bg: 'primary',
       },


### PR DESCRIPTION
This is a work in progress and a bit of a proof of concept refactor to replace the `variant` `sx` property with the `variant` prop. See #800. This would be a breaking change, but theme-ui is not v1.0 yet 🔨😄. I've also refactored the `Box` and `Flex` components and removed the dependencies on both `styled-system` and `@emotion/styled`, which also addresses issues with #817 and #690. We could probably drop the usage of `Box` from all the other components now as it's not doing all that much. I've also decided to drop the use of the few styled-system props that were previously part of the `Box` component in favour of using the `sx` prop instead.

There is also a new API for components with multiple elements: `Select`, `Checkbox` and `Radio`. It's now possible to supply styles to each part. Such as for `Select`:

```js
const theme = {
  ...
  forms: {
    select: {
      // styles for select element
      select: {
        borderRadius: 5,
      },
      container: {
        // styles for root element
      },
      arrow: {
        // styles for arrow icon go here
      },
    },
  },
}
```

Todo:
- [ ] MDX
- [ ] Tests
- [ ] Update docs examples
- [ ] Update docs theme object
- [ ] Update other themes
- [ ] Remove variant handling from `css` function
- [ ] Make `useVariant` hook public? – could be quite useful for custom components.