### PR TITLE
Fixing broken link in theming.mdx after typescript impl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Removes overriding property on editor combobox
 - Adjust media query sort logic #600
 - Fixed link to Gatsby Plugin page in `getting-started` page. Issue #602
+- Fix broken base-preset link on `theming` page
 
 ## v0.3.0 2019-01-22
 

--- a/packages/docs/src/pages/theming.mdx
+++ b/packages/docs/src/pages/theming.mdx
@@ -274,5 +274,5 @@ export const theme = {
 
 For more information on the Theme UI `theme` object, see the [Theme Specification docs](/theme-spec).
 
-[example]: https://github.com/system-ui/theme-ui/tree/master/packages/preset-base/src/index.js
+[example]: https://github.com/system-ui/theme-ui/tree/master/packages/preset-base/src/index.ts
 [emotion]: https://emotion.sh


### PR DESCRIPTION
With the change to typescript, a link back to the Github repo inside `theming.mdx` was broken.

This PR adjusts the docs and adds to the changelog, as requested.