### PR TITLE
Fix global style docs code typo

### DIFF
--- a/packages/docs/src/pages/guides/global-styles.mdx
+++ b/packages/docs/src/pages/guides/global-styles.mdx
@@ -21,7 +21,7 @@ import { Global } from '@emotion/core'
 export default props =>
   <Global
     styles={theme => ({
-      *: {
+      '*': {
         boxSizing: 'border-box',
       }
     })}


### PR DESCRIPTION
A small typo in the docs where a raw `*` is an object key name for the example code. Have wrapped it with quotes.