### PR TITLE
feat(@theme-ui/components) Add a Stack component based on Flex layout

### DIFF
--- a/packages/components/src/Stack.js
+++ b/packages/components/src/Stack.js
@@ -1,24 +1,61 @@
 import React from 'react'
 import { Box } from './Box'
 
+export const merge = (...objs) => {
+  return objs.reduce(function(merged, currentValue) {
+    return mergeTwo(merged, currentValue)
+  }, {})
+}
+
+const createGap = (direction, gap) => {
+  if (direction === 'vertical') {
+    return {
+      marginBottom: gap,
+      marginRight: 0,
+    }
+  }
+
+  return {
+    marginBottom: 0,
+    marginRight: gap,
+  }
+}
+
 export const Stack = React.forwardRef(
-  ({ gap = 2, children, ...props }, ref) => {
-    /** Make a copy of the children so we can pass the styles as props instead of using brittle CSS selectors */
-    const elements = React.Children.map(children, (element, index) => {
-      if (index === 0) {
-        return element
-      }
+  (
+    {
+      gap = 2,
+      direction = 'vertical',
+      inline = false,
+      justify = 'normal',
+      align = 'normal',
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const styles = {
+      display: inline ? 'inline-flex' : 'flex',
+      width: '100%',
+      justifyContent: justify,
+      alignItems: align,
+    }
 
-      const newProps = {
-        marginTop: gap,
-      }
+    if (Array.isArray(direction)) {
+      styles.flexDirection = direction.map(d =>
+        d === 'vertical' ? 'column' : 'row'
+      )
+      styles['> *:not(:last-child)'] = direction.map(d => createGap(d, gap))
+    } else {
+      styles.flexDirection = direction === 'vertical' ? 'column' : 'row'
+      styles['> *:not(:last-child)'] = createGap(direction, gap)
+    }
 
-      return React.cloneElement(element, newProps)
-    })
+    console.log(styles)
 
     return (
-      <Box ref={ref} {...props} __themeKey="stacks">
-        {elements}
+      <Box ref={ref} {...props} __themeKey="stacks" __css={styles}>
+        {children}
       </Box>
     )
   }

--- a/packages/components/src/Stack.js
+++ b/packages/components/src/Stack.js
@@ -51,8 +51,6 @@ export const Stack = React.forwardRef(
       styles['> *:not(:last-child)'] = createSpace(direction, space)
     }
 
-    console.log(styles)
-
     return (
       <Box ref={ref} {...props} __themeKey="stacks" __css={styles}>
         {children}

--- a/packages/components/src/Stack.js
+++ b/packages/components/src/Stack.js
@@ -1,19 +1,25 @@
 import React from 'react'
-import Box from './Box'
+import { Box } from './Box'
 
 export const Stack = React.forwardRef(
-  ({ gap = 2, flow = 'row', ...props }, ref) => {
+  ({ gap = 2, children, ...props }, ref) => {
+    /** Make a copy of the children so we can pass the styles as props instead of using brittle CSS selectors */
+    const elements = React.Children.map(children, (element, index) => {
+      if (index === 0) {
+        return element
+      }
+
+      const newProps = {
+        marginTop: gap,
+      }
+
+      return React.cloneElement(element, newProps)
+    })
+
     return (
-      <Box
-        ref={ref}
-        {...props}
-        __themeKey="stacks"
-        __css={{
-          display: 'grid',
-          gridGap: gap,
-          gridAutoFlow: flow,
-        }}
-      />
+      <Box ref={ref} {...props} __themeKey="stacks">
+        {elements}
+      </Box>
     )
   }
 )

--- a/packages/components/src/Stack.js
+++ b/packages/components/src/Stack.js
@@ -2,24 +2,16 @@ import React from 'react'
 import { Box } from './Box'
 
 export const Stack = React.forwardRef(
-  ({ gap = 2, children, ...props }, ref) => {
-    /** Make a copy of the children so we can pass the styles as props instead of using brittle CSS selectors */
-    const elements = React.Children.map(children, (element, index) => {
-      if (index === 0) {
-        return element
-      }
-
-      const newProps = {
-        marginTop: gap,
-      }
-
-      return React.cloneElement(element, newProps)
-    })
-
-    return (
-      <Box ref={ref} {...props} __themeKey="stacks">
-        {elements}
-      </Box>
-    )
-  }
+  ({ gap = 2, children, ...props }, ref) => (
+    <Box
+      ref={ref}
+      {...props}
+      __themeKey="stacks"
+      __css={{
+        display: 'grid',
+        gridGap: gap,
+      }}>
+      {children}
+    </Box>
+  )
 )

--- a/packages/components/src/Stack.js
+++ b/packages/components/src/Stack.js
@@ -2,16 +2,24 @@ import React from 'react'
 import { Box } from './Box'
 
 export const Stack = React.forwardRef(
-  ({ gap = 2, children, ...props }, ref) => (
-    <Box
-      ref={ref}
-      {...props}
-      __themeKey="stacks"
-      __css={{
-        display: 'grid',
-        gridGap: gap,
-      }}>
-      {children}
-    </Box>
-  )
+  ({ gap = 2, children, ...props }, ref) => {
+    /** Make a copy of the children so we can pass the styles as props instead of using brittle CSS selectors */
+    const elements = React.Children.map(children, (element, index) => {
+      if (index === 0) {
+        return element
+      }
+
+      const newProps = {
+        marginTop: gap,
+      }
+
+      return React.cloneElement(element, newProps)
+    })
+
+    return (
+      <Box ref={ref} {...props} __themeKey="stacks">
+        {elements}
+      </Box>
+    )
+  }
 )

--- a/packages/components/src/Stack.js
+++ b/packages/components/src/Stack.js
@@ -7,24 +7,24 @@ export const merge = (...objs) => {
   }, {})
 }
 
-const createGap = (direction, gap) => {
+const createSpace = (direction, space) => {
   if (direction === 'vertical') {
     return {
-      marginBottom: gap,
+      marginBottom: space,
       marginRight: 0,
     }
   }
 
   return {
     marginBottom: 0,
-    marginRight: gap,
+    marginRight: space,
   }
 }
 
 export const Stack = React.forwardRef(
   (
     {
-      gap = 2,
+      space = 2,
       direction = 'vertical',
       inline = false,
       justify = 'normal',
@@ -45,10 +45,10 @@ export const Stack = React.forwardRef(
       styles.flexDirection = direction.map(d =>
         d === 'vertical' ? 'column' : 'row'
       )
-      styles['> *:not(:last-child)'] = direction.map(d => createGap(d, gap))
+      styles['> *:not(:last-child)'] = direction.map(d => createSpace(d, space))
     } else {
       styles.flexDirection = direction === 'vertical' ? 'column' : 'row'
-      styles['> *:not(:last-child)'] = createGap(direction, gap)
+      styles['> *:not(:last-child)'] = createSpace(direction, space)
     }
 
     console.log(styles)

--- a/packages/components/src/Stack.js
+++ b/packages/components/src/Stack.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import Box from './Box'
+
+export const Stack = React.forwardRef(
+  ({ gap = 2, flow = 'row', ...props }, ref) => {
+    return (
+      <Box
+        ref={ref}
+        {...props}
+        __themeKey="stacks"
+        __css={{
+          display: 'grid',
+          gridGap: gap,
+          gridAutoFlow: flow,
+        }}
+      />
+    )
+  }
+)

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -1,6 +1,7 @@
 export { Box } from './Box'
 export { Flex } from './Flex'
 export { Grid } from './Grid'
+export { Stack } from './Stack'
 export { Button } from './Button'
 export { Link } from './Link'
 export { Text } from './Text'

--- a/packages/components/test/__snapshots__/index.js.snap
+++ b/packages/components/test/__snapshots__/index.js.snap
@@ -1308,6 +1308,204 @@ exports[`Spinner renders 1`] = `
 </svg>
 `;
 
+exports[`Stack renders 1`] = `
+.emotion-0 {
+  box-sizing: border-box;
+  margin: 0;
+  min-width: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  -webkit-box-pack: normal;
+  -webkit-justify-content: normal;
+  -ms-flex-pack: normal;
+  justify-content: normal;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.emotion-0 > *:not(:last-child) {
+  margin-bottom: 8px;
+  margin-right: 0;
+}
+
+<div
+  className="emotion-0"
+/>
+`;
+
+exports[`Stack renders with align prop 1`] = `
+.emotion-0 {
+  box-sizing: border-box;
+  margin: 0;
+  min-width: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.emotion-0 > *:not(:last-child) {
+  margin-bottom: 8px;
+  margin-right: 0;
+}
+
+<div
+  className="emotion-0"
+/>
+`;
+
+exports[`Stack renders with align prop 2`] = `
+.emotion-0 {
+  box-sizing: border-box;
+  margin: 0;
+  min-width: 0;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: 100%;
+  -webkit-box-pack: normal;
+  -webkit-justify-content: normal;
+  -ms-flex-pack: normal;
+  justify-content: normal;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.emotion-0 > *:not(:last-child) {
+  margin-bottom: 8px;
+  margin-right: 0;
+}
+
+<div
+  className="emotion-0"
+/>
+`;
+
+exports[`Stack renders with direction prop 1`] = `
+.emotion-0 {
+  box-sizing: border-box;
+  margin: 0;
+  min-width: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  -webkit-box-pack: normal;
+  -webkit-justify-content: normal;
+  -ms-flex-pack: normal;
+  justify-content: normal;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.emotion-0 > *:not(:last-child) {
+  margin-bottom: 0;
+  margin-right: 8px;
+}
+
+<div
+  className="emotion-0"
+/>
+`;
+
+exports[`Stack renders with justify prop 1`] = `
+.emotion-0 {
+  box-sizing: border-box;
+  margin: 0;
+  min-width: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.emotion-0 > *:not(:last-child) {
+  margin-bottom: 8px;
+  margin-right: 0;
+}
+
+<div
+  className="emotion-0"
+/>
+`;
+
+exports[`Stack renders with space prop 1`] = `
+.emotion-0 {
+  box-sizing: border-box;
+  margin: 0;
+  min-width: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  -webkit-box-pack: normal;
+  -webkit-justify-content: normal;
+  -ms-flex-pack: normal;
+  justify-content: normal;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.emotion-0 > *:not(:last-child) {
+  margin-bottom: 64px;
+  margin-right: 0;
+}
+
+<div
+  className="emotion-0"
+/>
+`;
+
 exports[`Text renders 1`] = `
 .emotion-0 {
   box-sizing: border-box;

--- a/packages/components/test/index.js
+++ b/packages/components/test/index.js
@@ -8,6 +8,7 @@ import {
   Card,
   Flex,
   Grid,
+  Stack,
   Heading,
   Image,
   Link,

--- a/packages/components/test/index.js
+++ b/packages/components/test/index.js
@@ -237,6 +237,62 @@ describe('Grid', () => {
   })
 })
 
+describe('Stack', () => {
+  test('renders', () => {
+    const json = renderJSON(
+      <ThemeProvider theme={theme}>
+        <Stack />
+      </ThemeProvider>
+    )
+    expect(json).toMatchSnapshot()
+  })
+
+  test('renders with direction prop', () => {
+    const json = renderJSON(
+      <ThemeProvider theme={theme}>
+        <Stack direction="horizontal" />
+      </ThemeProvider>
+    )
+    expect(json).toMatchSnapshot()
+  })
+
+  test('renders with space prop', () => {
+    const json = renderJSON(
+      <ThemeProvider theme={theme}>
+        <Stack space={5} />
+      </ThemeProvider>
+    )
+    expect(json).toMatchSnapshot()
+  })
+
+  test('renders with justify prop', () => {
+    const json = renderJSON(
+      <ThemeProvider theme={theme}>
+        <Stack justify="center" />
+      </ThemeProvider>
+    )
+    expect(json).toMatchSnapshot()
+  })
+
+  test('renders with align prop', () => {
+    const json = renderJSON(
+      <ThemeProvider theme={theme}>
+        <Stack justify="center" />
+      </ThemeProvider>
+    )
+    expect(json).toMatchSnapshot()
+  })
+
+  test('renders with align prop', () => {
+    const json = renderJSON(
+      <ThemeProvider theme={theme}>
+        <Stack inline />
+      </ThemeProvider>
+    )
+    expect(json).toMatchSnapshot()
+  })
+})
+
 describe('Heading', () => {
   test('renders', () => {
     const json = renderJSON(

--- a/packages/docs/src/pages/components/stack.mdx
+++ b/packages/docs/src/pages/components/stack.mdx
@@ -1,0 +1,71 @@
+---
+title: Stack
+---
+
+# Stack
+
+Use the `Stack` component as a layout primitive to add spaces between components. It allows you to define
+spacing in one direction, either `row` or `column`. This is very useful when stacking components within a bigger grid system. 
+
+```js
+import { Stack, Box, Grid } from 'theme-ui'
+```
+
+```jsx live=true
+
+<Grid
+  gap={3}
+  columns={2}>
+  <Box bg="muted">
+    <Stack gap={3} flow="row">
+      <Box bg="primary" color="white">Stack Item</Box>
+      <Box bg="primary" color="white">Stack Item</Box>
+      <Box bg="primary" color="white">Stack Item</Box>
+    </Stack>
+  </Box>
+  <Box bg='muted'>Box</Box>
+</Grid>
+```
+
+Change the spacing by using the gap property
+
+```js
+import { Stack, Box } from 'theme-ui'
+```
+
+```jsx live=true
+<Stack gap="3">
+  <Box bg="primary" color="white">Stack Item</Box>
+  <Box bg="muted">Stack Item</Box>
+  <Box bg="primary" color="white">Stack Item</Box>
+</Stack>
+```
+
+Want to stack items horizontally? Use the flow property
+
+```js
+import { Stack, Box } from 'theme-ui'
+```
+
+```jsx live=true
+<Stack flow={"column"}>
+  <Box bg="primary" color="white">Stack Item</Box>
+  <Box bg="muted">Stack Item</Box>
+  <Box bg="primary" color="white">Stack Item</Box>
+</Stack>
+```
+
+The Stack component Supports responsive values too
+
+
+```js
+import { Stack, Box } from 'theme-ui'
+```
+
+```jsx live=true
+<Stack flow={["row", "row", "row", "column"]} gap={[3,3,4]}>
+  <Box bg="primary" color="white">Stack Item</Box>
+  <Box bg="muted">Stack Item</Box>
+  <Box bg="primary" color="white">Stack Item</Box>
+</Stack>
+```

--- a/packages/docs/src/pages/components/stack.mdx
+++ b/packages/docs/src/pages/components/stack.mdx
@@ -13,17 +13,27 @@ import { Stack, Box } from 'theme-ui'
 ```
 
 ```jsx live xray
-<Stack gap={[2, 3, 4]}>
+<Stack space={4}>
   <Box>1</Box>
   <Box>2</Box>
   <Box>3</Box>
 </Stack>
 ```
 
-You can stack horizontally
+You can stack horizontally too.
 
 ```jsx live xray
-<Stack gap={[2, 3, 4]} direction="horizontal">
+<Stack space={4} direction="horizontal">
+  <Box>Stack Item</Box>
+  <Box>Stack Item</Box>
+  <Box>Stack Item</Box>
+</Stack>
+```
+
+The space prop supports array values to adapt to your themes breakpoints.
+
+```jsx live xray
+<Stack space={[4, 5, 6]} direction="horizontal">
   <Box>Stack Item</Box>
   <Box>Stack Item</Box>
   <Box>Stack Item</Box>
@@ -35,7 +45,7 @@ Nest Stacks components to create complex layouts!
 import { Stack, Box, AspectRatio, Avatar } from 'theme-ui'
 
 ```jsx live xray
-<Stack gap={4} direction="horizontal">
+<Stack space={4} direction="horizontal">
   <Box>
     <Avatar src={images.logo} />
     <Badge
@@ -49,8 +59,8 @@ import { Stack, Box, AspectRatio, Avatar } from 'theme-ui'
     </Badge>
   </Box>
 
-  <Stack gap={4}>
-    <Heading>Hello</Heading>
+  <Stack space={2}>
+    <Heading>A nested stack component</Heading>
     <Stack direction="horizontal">
       <Badge variant="accent">Create</Badge>
       <Badge variant="accent">Remove</Badge>
@@ -63,10 +73,10 @@ import { Stack, Box, AspectRatio, Avatar } from 'theme-ui'
 
 ## Props
 
-| Name        | Type      | Description                                            |
-| ----------- | --------- | ------------------------------------------------------ |
-| `direction` | Component | Can be either `vertical` or `horizontal`               |
-| `gap`       | String    | How big the gap between items should be                |
-| `justify`   | String    | Any valid flexbox justify property                     |
-| `align`     | String    | Any valid flexbox align property                       |
-| `inline`    | boolean   | When true, renders as inline-flex item instead of flex |
+| Name        | Type      | Description                                            | Default  |
+| ----------- | --------- | ------------------------------------------------------ | -------- |
+| `direction` | Component | Can be either `vertical` (default) or `horizontal`     | vertical |
+| `space`     | String    | How big the space between items should be              | 2        |
+| `justify`   | String    | Any valid flexbox justify property                     | normal   |
+| `align`     | String    | Any valid flexbox align property                       | normal   |
+| `inline`    | boolean   | When true, renders as inline-flex item instead of flex | false    |

--- a/packages/docs/src/pages/components/stack.mdx
+++ b/packages/docs/src/pages/components/stack.mdx
@@ -6,59 +6,67 @@ title: Stack
 
 Use the `Stack` component as a layout primitive to add spaces between components.
 This is very useful when stacking components within a bigger grid system, as it allows you to maintain a vertical rhythm.
-It also enforces the decoupling of layout from components.
-
-```js
-import { Stack, Box, Grid } from 'theme-ui'
-```
-
-```jsx live=true
-<Grid
-  gap={3}
-  columns={2}>
-  <Box bg="muted">
-    <Stack>
-      <Box bg="primary" color="white">Stack Item</Box>
-      <Box bg="primary" color="white">Stack Item</Box>
-      <Box bg="primary" color="white">Stack Item</Box>
-    </Stack>
-  </Box>
-  <Box bg='muted'>Box</Box>
-</Grid>
-```
-
-You can change the spacing by using the gap property
+It forces the decoupling of layout from components.
 
 ```js
 import { Stack, Box } from 'theme-ui'
 ```
 
-```jsx live=true
-<Grid
-  gap={3}
-  columns={2}>
-  <Box bg="muted">
-    <Stack gap={3}>
-      <Box bg="primary" color="white">Stack Item</Box>
-      <Box bg="primary" color="white">Stack Item</Box>
-      <Box bg="primary" color="white">Stack Item</Box>
-    </Stack>
-  </Box>
-  <Box bg='muted'>Box</Box>
-</Grid>
-```
-
-The Stack component Supports responsive values too. Try resizing this screen.
-
-
-```js
-import { Stack, Box } from 'theme-ui'
-```
-
-```jsx live=true
+```jsx live xray
 <Stack gap={[2, 3, 4]}>
-  <Box bg="primary" color="white">Stack Item</Box>
-  <Box bg="primary" color="white">Stack Item</Box>
-  <Box bg="primary" color="white">Stack Item</Box>
+  <Box>1</Box>
+  <Box>2</Box>
+  <Box>3</Box>
 </Stack>
 ```
+
+You can stack horizontally
+
+```jsx live xray
+<Stack gap={[2, 3, 4]} direction="horizontal">
+  <Box>Stack Item</Box>
+  <Box>Stack Item</Box>
+  <Box>Stack Item</Box>
+</Stack>
+```
+
+Nest Stacks components to create complex layouts!
+
+import { Stack, Box, AspectRatio, Avatar } from 'theme-ui'
+
+```jsx live xray
+<Stack gap={4} direction="horizontal">
+  <Box>
+    <Avatar src={images.logo} />
+    <Badge
+      variant="circle"
+      sx={{
+        position: 'relative',
+        left: 4,
+        top: -4,
+      }}>
+      16
+    </Badge>
+  </Box>
+
+  <Stack gap={4}>
+    <Heading>Hello</Heading>
+    <Stack direction="horizontal">
+      <Badge variant="accent">Create</Badge>
+      <Badge variant="accent">Remove</Badge>
+      <Badge variant="accent">Update</Badge>
+      <Badge variant="accent">Delete</Badge>
+    </Stack>
+  </Stack>
+</Stack>
+```
+
+## Props
+
+| Name        | Type      | Description                                            |
+| ----------- | --------- | ------------------------------------------------------ |
+| `direction` | Component | Can be either `vertical` or `horizontal`               |
+| `gap`       | String    | How big the gap between items should be                |
+| `justify`   | String    | Any valid flexbox justify property                     |
+| `align`     | String    | Any valid flexbox align property                       |
+| `inline`    | boolean   | When true, renders as inline-flex item instead of flex |

--- a/packages/docs/src/pages/components/stack.mdx
+++ b/packages/docs/src/pages/components/stack.mdx
@@ -4,20 +4,20 @@ title: Stack
 
 # Stack
 
-Use the `Stack` component as a layout primitive to add spaces between components. It allows you to define
-spacing in one direction, either `row` or `column`. This is very useful when stacking components within a bigger grid system. 
+Use the `Stack` component as a layout primitive to add spaces between components.
+This is very useful when stacking components within a bigger grid system, as it allows you to maintain a vertical rhythm.
+It also enforces the decoupling of layout from components.
 
 ```js
 import { Stack, Box, Grid } from 'theme-ui'
 ```
 
 ```jsx live=true
-
 <Grid
   gap={3}
   columns={2}>
   <Box bg="muted">
-    <Stack gap={3} flow="row">
+    <Stack>
       <Box bg="primary" color="white">Stack Item</Box>
       <Box bg="primary" color="white">Stack Item</Box>
       <Box bg="primary" color="white">Stack Item</Box>
@@ -27,35 +27,28 @@ import { Stack, Box, Grid } from 'theme-ui'
 </Grid>
 ```
 
-Change the spacing by using the gap property
+You can change the spacing by using the gap property
 
 ```js
 import { Stack, Box } from 'theme-ui'
 ```
 
 ```jsx live=true
-<Stack gap="3">
-  <Box bg="primary" color="white">Stack Item</Box>
-  <Box bg="muted">Stack Item</Box>
-  <Box bg="primary" color="white">Stack Item</Box>
-</Stack>
+<Grid
+  gap={3}
+  columns={2}>
+  <Box bg="muted">
+    <Stack gap={3}>
+      <Box bg="primary" color="white">Stack Item</Box>
+      <Box bg="primary" color="white">Stack Item</Box>
+      <Box bg="primary" color="white">Stack Item</Box>
+    </Stack>
+  </Box>
+  <Box bg='muted'>Box</Box>
+</Grid>
 ```
 
-Want to stack items horizontally? Use the flow property
-
-```js
-import { Stack, Box } from 'theme-ui'
-```
-
-```jsx live=true
-<Stack flow={"column"}>
-  <Box bg="primary" color="white">Stack Item</Box>
-  <Box bg="muted">Stack Item</Box>
-  <Box bg="primary" color="white">Stack Item</Box>
-</Stack>
-```
-
-The Stack component Supports responsive values too
+The Stack component Supports responsive values too. Try resizing this screen.
 
 
 ```js
@@ -63,9 +56,9 @@ import { Stack, Box } from 'theme-ui'
 ```
 
 ```jsx live=true
-<Stack flow={["row", "row", "row", "column"]} gap={[3,3,4]}>
+<Stack gap={[2, 3, 4]}>
   <Box bg="primary" color="white">Stack Item</Box>
-  <Box bg="muted">Stack Item</Box>
+  <Box bg="primary" color="white">Stack Item</Box>
   <Box bg="primary" color="white">Stack Item</Box>
 </Stack>
 ```

--- a/packages/docs/src/recipes/stack.mdx
+++ b/packages/docs/src/recipes/stack.mdx
@@ -23,10 +23,7 @@ Add vertical space between child elements using CSS Grid.
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
 
-export default ({
-  gap = 4,
-  ...props
-}) =>
+export default ({ gap = 4, ...props }) => (
   <div
     {...props}
     sx={{
@@ -34,6 +31,7 @@ export default ({
       gridGap: gap,
     }}
   />
+)
 ```
 
 See also: [Grid component](/components/grid)

--- a/packages/docs/src/sidebar.mdx
+++ b/packages/docs/src/sidebar.mdx
@@ -16,6 +16,7 @@
   - [Box](/components/box)
   - [Flex](/components/flex)
   - [Grid](/components/grid)
+  - [Stack](/components/stack)
   - [Button](/components/button)
   - [Text](/components/text)
   - [Heading](/components/heading)


### PR DESCRIPTION
This PR is an attempt at solving https://github.com/system-ui/theme-ui/issues/556

![image](https://user-images.githubusercontent.com/882219/79513524-5b881d80-8044-11ea-8950-fba6ea0b1432.png)


- [X] Working component
- [X] Finish documentation
- [X] Add tests

**Prior art**
I've taken inspiration from https://github.com/siddharthkp/react-ui/blob/master/packages/react-ui/src/components/stack/index.js

**Technical approach**
This solution uses Flexbox to create stack layouts. I was afraid that by using css selectors you wouldn't be able to override margins anymore, but turns out you can quite easily work your way around it.


For example, you can use a negative value in your child component to negate the gap property:

![image](https://user-images.githubusercontent.com/882219/79513600-83778100-8044-11ea-89d9-96bd9ceb53f1.png)


**Tradeoffs**
Flex components are more complex than a simple grid component. 

**Alternative approach**
This is an alternative, more powerful version of https://github.com/system-ui/theme-ui/pull/809