### PR TITLE
match-media package imports defaultBreakpoints from css package

### DIFF
--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -18,7 +18,7 @@ export function get(
   return obj === undef ? def : obj
 }
 
-const defaultBreakpoints = [40, 52, 64].map(n => n + 'em')
+export const defaultBreakpoints = [40, 52, 64].map(n => n + 'em')
 
 const defaultTheme = {
   space: [0, 4, 8, 16, 32, 64, 128, 256, 512],

--- a/packages/match-media/package.json
+++ b/packages/match-media/package.json
@@ -22,7 +22,8 @@
     "react": "^16.9.0"
   },
   "peerDependencies": {
-    "react": "^16.9.0",
-    "theme-ui": "^0.3.0"
+    "@theme-ui/core": "^0.4.0-alpha.0",
+    "@theme-ui/css": "^0.4.0-alpha.0",
+    "react": "^16.9.0"
   }
 }

--- a/packages/match-media/src/index.ts
+++ b/packages/match-media/src/index.ts
@@ -1,9 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useThemeUI } from '@theme-ui/core'
-import { Theme } from '@theme-ui/css'
-
-// Shared with @theme-ui/css
-const defaultBreakpoints = [40, 52, 64].map(n => n + 'em')
+import { Theme, defaultBreakpoints } from '@theme-ui/css'
 
 type defaultOptions = {
   defaultIndex?: number


### PR DESCRIPTION
Just remembered I was going to do this once the css package was included.