### PR TITLE
Allow negative theme lookup of space objects

### DIFF
--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -129,6 +129,11 @@ type Scales = typeof scales
 
 const positiveOrNegative = (scale: object, value: string | number) => {
   if (typeof value !== 'number' || value >= 0) {
+    if (typeof value === 'string' && value.startsWith('-')) {
+      const valueWithoutMinus = value.substring(1)
+      const n = get(scale, valueWithoutMinus, valueWithoutMinus)
+      return `-${n}`
+    }
     return get(scale, value, value)
   }
   const absolute = Math.abs(value)

--- a/packages/css/test/index.ts
+++ b/packages/css/test/index.ts
@@ -259,6 +259,18 @@ test('handles negative top, left, bottom, and right from scale', () => {
   })
 })
 
+test('handles negative margins from scale that is an object', () => {
+  const result = css({
+    mt: '-s',
+    mx: '-m',
+  })({...theme, space: { s: '16px', m: '32px' }})
+  expect(result).toEqual({
+    marginTop: '-16px',
+    marginLeft: '-32px',
+    marginRight: '-32px',
+  })
+})
+
 test('skip breakpoints', () => {
   const result = css({
     width: ['100%', , '50%'],


### PR DESCRIPTION
Currently, if you set your `space` to be an object in theme instead of an array then using for example `-xl` does not work.

Example:
```
// theme.js
const theme = { space : { s: '8px', m: '16px' } } 
```
```
// some-component.js
<div
  sx={{
    margin: '-m'
  }}
/>
```

The `-m` does not get replaced with `-16px`.

What we currently have to do is:
```
// some-component.js
<div
  sx={{
    margin: (theme) => `-${theme.space.m}`
  }}
/>
```
which is not as nice.

This pr will see if the value starts with a `-` and return the theme lookup value and add a `-`.
