### PR TITLE
Add default theme key for Text

### DIFF
--- a/packages/components/src/Text.js
+++ b/packages/components/src/Text.js
@@ -2,5 +2,5 @@ import React from 'react'
 import Box from './Box'
 
 export const Text = React.forwardRef((props, ref) => (
-  <Box ref={ref} {...props} __themeKey="text" />
+  <Box ref={ref} variant="default" {...props} __themeKey="text" />
 ))

--- a/packages/components/test/__snapshots__/index.js.snap
+++ b/packages/components/test/__snapshots__/index.js.snap
@@ -492,12 +492,6 @@ exports[`Embed renders 1`] = `
 `;
 
 exports[`Field renders 1`] = `
-.emotion-2 {
-  box-sizing: border-box;
-  margin: 0;
-  min-width: 0;
-}
-
 .emotion-0 {
   box-sizing: border-box;
   margin: 0;
@@ -525,6 +519,12 @@ exports[`Field renders 1`] = `
   border-radius: 4px;
   color: inherit;
   background-color: transparent;
+}
+
+.emotion-2 {
+  box-sizing: border-box;
+  margin: 0;
+  min-width: 0;
 }
 
 <div
@@ -1313,6 +1313,7 @@ exports[`Text renders 1`] = `
   box-sizing: border-box;
   margin: 0;
   min-width: 0;
+  font-size: 20px;
 }
 
 <div

--- a/packages/components/test/index.js
+++ b/packages/components/test/index.js
@@ -63,6 +63,9 @@ const theme = {
     },
   },
   text: {
+    default: {
+      fontSize: 3,
+    },
     heading: {
       fontSize: 5,
     },

--- a/packages/docs/src/pages/components/text.mdx
+++ b/packages/docs/src/pages/components/text.mdx
@@ -24,11 +24,16 @@ import { Text } from 'theme-ui'
 ## Variants
 
 Text style variants can be defined in the `theme.text` object.
+The Text component uses `theme.text.default` as its default variant style.
 
 ```js
 // example theme variants
 {
   text: {
+    default: {
+      color: 'text',
+      fontSize: 3,
+    },
     caps: {
       textTransform: 'uppercase',
       letterSpacing: '0.2em',


### PR DESCRIPTION
Adds a default theme key of `body` to the `Text` component

**Why should `Text` have a theme key?**
  - We can keep `Text` agnostic from the body font-size (allowing for rem/em customisation where necessary)
  - Right now `Text` fully inherits from the `root`, this particularly becomes a problem in some problem when [transitioning properties](https://bugs.webkit.org/show_bug.cgi?id=46041). 
  - Considering everything else in Theme UI is so component focussed, I feel like it would make sense to avoid this `inherit`ance. Besides, we can also allow for other variants to extend upon `body` if necessary.

**Why `body`?**
  - I think this keeps it inline with `heading` and feels common; `body` is also used in other places 

**Example**

I've used this to avoid the aforementioned '`inherit` flicker' in my [personal site](https://github.com/joe-bell/joebell.co.uk/blob/master/src/theme-ui/themes/base.js#L89), however I still think it would be beneficial for other reasons I've outlined.  