### PR TITLE
Let gatsby-plugin-theme-ui take base preset options

### DIFF
--- a/jest-preprocess.js
+++ b/jest-preprocess.js
@@ -1,0 +1,3 @@
+module.exports = require('babel-jest').createTransformer({
+  presets: ['babel-preset-gatsby'],
+})

--- a/package.json
+++ b/package.json
@@ -96,7 +96,10 @@
     ],
     "setupFiles": [
       "jest-canvas-mock"
-    ]
+    ],
+    "transform": {
+      "^.+\\.jsx?$": "<rootDir>/jest-preprocess.js"
+    }
   },
   "husky": {
     "hooks": {

--- a/packages/gatsby-plugin-theme-ui/README.md
+++ b/packages/gatsby-plugin-theme-ui/README.md
@@ -34,7 +34,7 @@ module.exports = {
   plugins: [
     { resolve: 'gatsby-plugin-theme-ui',
       options: {
-        themePreset: '@theme-ui/preset-funk'
+        preset: '@theme-ui/preset-funk'
         // or require('@theme-ui/preset-funk')
       }
     }],

--- a/packages/gatsby-plugin-theme-ui/README.md
+++ b/packages/gatsby-plugin-theme-ui/README.md
@@ -20,7 +20,7 @@ prevent a flash of unstyled colors when using color modes.
 
 | Key                      | Default value    | Description                                                                      |
 | ------------------------ | ---------------- | -------------------------------------------------------------------------------- |
-| `themePreset`               | `null`            | This can be a JSON theme object or a string package name. Make sure the package you're requiring is installed in your dependencies.               |
+| `preset`               | `null`            | This can be a JSON theme object or a string package name. Make sure the package you're requiring is installed in your dependencies.               |
 
 > Note that this plugin assumes the theme object is exported as `default`.
 

--- a/packages/gatsby-plugin-theme-ui/README.md
+++ b/packages/gatsby-plugin-theme-ui/README.md
@@ -22,9 +22,9 @@ prevent a flash of unstyled colors when using color modes.
 | ------------------------ | ---------------- | -------------------------------------------------------------------------------- |
 | `themeModule`               | `null`            | JSON theme object, use the `require` syntax to include it in options. Make sure the package you're requiring is installed in your dependencies.               |
 | `themeModulePath`            | `null`  | A string package name that the plugin will require for you. Make sure the package you're requiring is installed in your dependencies.                                                             |
-| `moduleExportName`              | `default` | The name of the export from the theme module, applies to `themeModule` or `themeModulePath` resolution depending which one you're using    |
 
-> Note that if your theme is exported at the top level, the `moduleExportName` of `default` is bypassed. See [theme-ui/preset-deep](https://github.com/system-ui/theme-ui/blob/master/packages/preset-deep/src/index.ts).
+
+> Note that this plugin assumes the theme object is exported as `default`.
 
 The theme module you include in options is considered your base theme. Any further customization and shadowing will be merged with it. 
 

--- a/packages/gatsby-plugin-theme-ui/README.md
+++ b/packages/gatsby-plugin-theme-ui/README.md
@@ -16,6 +16,33 @@ module.exports = {
 In addition to providing context, this plugin will also
 prevent a flash of unstyled colors when using color modes.
 
+## Options
+
+| Key                      | Default value    | Description                                                                      |
+| ------------------------ | ---------------- | -------------------------------------------------------------------------------- |
+| `themeModule`               | `null`            | JSON theme object, use the `require` syntax to include it in options. Make sure the package you're requiring is installed in your dependencies.               |
+| `themeModulePath`            | `null`  | A string package name that the plugin will require for you. Make sure the package you're requiring is installed in your dependencies.                                                             |
+| `moduleExportName`              | `default` | The name of the export from the theme module, applies to `themeModule` or `themeModulePath` resolution depending which one you're using    |
+
+> Note that if your theme is exported at the top level, the `moduleExportName` of `default` is bypassed. See [theme-ui/preset-deep](https://github.com/system-ui/theme-ui/blob/master/packages/preset-deep/src/index.ts).
+
+The theme module you include in options is considered your base theme. Any further customization and shadowing will be merged with it. 
+
+### Using options
+
+```js
+// gatsby-config.js
+module.exports = {
+  plugins: [
+    { resolve: 'gatsby-plugin-theme-ui',
+      options: {
+        themeModulePath: '@theme-ui/preset-funk'
+        // or themeModule: require('@theme-ui/preset-funk')
+      }
+    }],
+}
+```
+
 ## Customizing the theme
 
 To customize the theme used in your Gatsby site,

--- a/packages/gatsby-plugin-theme-ui/README.md
+++ b/packages/gatsby-plugin-theme-ui/README.md
@@ -34,8 +34,8 @@ module.exports = {
   plugins: [
     { resolve: 'gatsby-plugin-theme-ui',
       options: {
-        themeModulePath: '@theme-ui/preset-funk'
-        // or themeModule: require('@theme-ui/preset-funk')
+        themePreset: '@theme-ui/preset-funk'
+        // or require('@theme-ui/preset-funk')
       }
     }],
 }

--- a/packages/gatsby-plugin-theme-ui/README.md
+++ b/packages/gatsby-plugin-theme-ui/README.md
@@ -20,9 +20,7 @@ prevent a flash of unstyled colors when using color modes.
 
 | Key                      | Default value    | Description                                                                      |
 | ------------------------ | ---------------- | -------------------------------------------------------------------------------- |
-| `themeModule`               | `null`            | JSON theme object, use the `require` syntax to include it in options. Make sure the package you're requiring is installed in your dependencies.               |
-| `themeModulePath`            | `null`  | A string package name that the plugin will require for you. Make sure the package you're requiring is installed in your dependencies.                                                             |
-
+| `themePreset`               | `null`            | This can be a JSON theme object or a string package name. Make sure the package you're requiring is installed in your dependencies.               |
 
 > Note that this plugin assumes the theme object is exported as `default`.
 

--- a/packages/gatsby-plugin-theme-ui/gatsby-node.js
+++ b/packages/gatsby-plugin-theme-ui/gatsby-node.js
@@ -5,22 +5,11 @@ exports.onPreInit = (__, options) => {
     try {
       options.preset = require(preset)
     } catch {
-      reporter.error(
-        `It appears your theme dependency is not installed. Try running \`${generateInstallInstructions()} ${themeModule}\``
+      reporter.warn(
+        `It appears your theme dependency is not installed. Only local styles will appear.`
       )
     }
   }
-}
-
-function generateInstallInstructions() {
-  const { getConfigStore } = require(`gatsby-core-utils`)
-
-  const packageMangerConfigKey = `cli.packageManager`
-  const PACKAGE_MANGER = getConfigStore().get(packageMangerConfigKey) || `yarn`
-
-  const installKeyWord = PACKAGE_MANGER === `yarn` ? 'add' : 'install'
-
-  return `${PACKAGE_MANGER} ${installKeyWord}`
 }
 
 exports.createSchemaCustomization = ({ actions }) => {

--- a/packages/gatsby-plugin-theme-ui/gatsby-node.js
+++ b/packages/gatsby-plugin-theme-ui/gatsby-node.js
@@ -1,9 +1,9 @@
 exports.onPreInit = (__, options) => {
-  let { themePreset } = options
+  let { preset } = options
 
-  if (typeof themePreset === 'string') {
+  if (typeof preset === 'string') {
     try {
-      options.themePreset = require(themePreset)
+      options.preset = require(preset)
     } catch {
       reporter.error(
         `It appears your theme dependency is not installed. Try running \`${generateInstallInstructions()} ${themeModule}\``
@@ -28,19 +28,16 @@ exports.createSchemaCustomization = ({ actions }) => {
 
   createTypes(`
       type ThemeUiConfig implements Node {
-        themePreset: JSON,
+        preset: JSON,
       }
     `)
 }
 
-exports.sourceNodes = (
-  { actions, createContentDigest },
-  { themePreset = {} }
-) => {
+exports.sourceNodes = ({ actions, createContentDigest }, { preset = {} }) => {
   const { createNode } = actions
 
   const themeUiConfig = {
-    themePreset,
+    preset,
   }
 
   createNode({

--- a/packages/gatsby-plugin-theme-ui/gatsby-node.js
+++ b/packages/gatsby-plugin-theme-ui/gatsby-node.js
@@ -1,0 +1,45 @@
+exports.onPreInit = (__, options) => {
+    let {themeModulePath} = options
+    if(themeModulePath) {
+        options.themeModulePath = require(themeModulePath)
+    }
+}
+
+exports.createSchemaCustomization = ({ actions }) => {
+    const { createTypes } = actions
+  
+    createTypes(`
+      type ThemeUiConfig implements Node {
+        themeModule: JSON,
+        themeModulePath: JSON,
+        moduleExportName: String,
+      }
+    `)
+  }
+  
+  exports.sourceNodes = (
+    { actions, createContentDigest },
+    { moduleExportName = 'default', themeModule, themeModulePath}
+  ) => {      
+    const { createNode } = actions
+  
+    const themeUiConfig = {
+        themeModule,
+        themeModulePath,
+        moduleExportName,
+    }
+  
+    createNode({
+      ...themeUiConfig,
+      id: `gatsby-plugin-theme-ui-config`,
+      parent: null,
+      children: [],
+      internal: {
+        type: `ThemeUiConfig`,
+        contentDigest: createContentDigest(themeUiConfig),
+        content: JSON.stringify(themeUiConfig),
+        description: `Options for gatsby-plugin-theme-ui`,
+      },
+    })
+  } 
+

--- a/packages/gatsby-plugin-theme-ui/gatsby-node.js
+++ b/packages/gatsby-plugin-theme-ui/gatsby-node.js
@@ -29,21 +29,19 @@ exports.createSchemaCustomization = ({ actions }) => {
       type ThemeUiConfig implements Node {
         themeModule: JSON,
         themeModulePath: JSON,
-        moduleExportName: String,
       }
     `)
   }
   
   exports.sourceNodes = (
     { actions, createContentDigest },
-    { moduleExportName = 'default', themeModule, themeModulePath}
+    { themeModule, themeModulePath}
   ) => {      
     const { createNode } = actions
   
     const themeUiConfig = {
         themeModule,
         themeModulePath,
-        moduleExportName,
     }
   
     createNode({

--- a/packages/gatsby-plugin-theme-ui/gatsby-node.js
+++ b/packages/gatsby-plugin-theme-ui/gatsby-node.js
@@ -1,8 +1,25 @@
 exports.onPreInit = (__, options) => {
     let {themeModulePath} = options
+    
     if(themeModulePath) {
+      try {
         options.themeModulePath = require(themeModulePath)
-    }
+      } catch {
+        reporter.error(`It appears your theme dependency is not installed. Try running \`${generateInstallInstructions()} ${themeModulePath}\``)
+      }
+  }
+}
+
+
+function generateInstallInstructions() {
+  const { getConfigStore } = require(`gatsby-core-utils`)
+
+  const packageMangerConfigKey = `cli.packageManager`
+  const PACKAGE_MANGER = getConfigStore().get(packageMangerConfigKey) || `yarn`
+
+  const installKeyWord = PACKAGE_MANGER === `yarn` ? "add" : "install"
+
+  return `${PACKAGE_MANGER} ${installKeyWord}`
 }
 
 exports.createSchemaCustomization = ({ actions }) => {

--- a/packages/gatsby-plugin-theme-ui/gatsby-node.js
+++ b/packages/gatsby-plugin-theme-ui/gatsby-node.js
@@ -1,15 +1,16 @@
 exports.onPreInit = (__, options) => {
-    let {themeModulePath} = options
-    
-    if(themeModulePath) {
-      try {
-        options.themeModulePath = require(themeModulePath)
-      } catch {
-        reporter.error(`It appears your theme dependency is not installed. Try running \`${generateInstallInstructions()} ${themeModulePath}\``)
-      }
+  let { themePreset } = options
+
+  if (typeof themePreset === 'string') {
+    try {
+      options.themePreset = require(themePreset)
+    } catch {
+      reporter.error(
+        `It appears your theme dependency is not installed. Try running \`${generateInstallInstructions()} ${themeModule}\``
+      )
+    }
   }
 }
-
 
 function generateInstallInstructions() {
   const { getConfigStore } = require(`gatsby-core-utils`)
@@ -17,44 +18,41 @@ function generateInstallInstructions() {
   const packageMangerConfigKey = `cli.packageManager`
   const PACKAGE_MANGER = getConfigStore().get(packageMangerConfigKey) || `yarn`
 
-  const installKeyWord = PACKAGE_MANGER === `yarn` ? "add" : "install"
+  const installKeyWord = PACKAGE_MANGER === `yarn` ? 'add' : 'install'
 
   return `${PACKAGE_MANGER} ${installKeyWord}`
 }
 
 exports.createSchemaCustomization = ({ actions }) => {
-    const { createTypes } = actions
-  
-    createTypes(`
+  const { createTypes } = actions
+
+  createTypes(`
       type ThemeUiConfig implements Node {
-        themeModule: JSON,
-        themeModulePath: JSON,
+        themePreset: JSON,
       }
     `)
-  }
-  
-  exports.sourceNodes = (
-    { actions, createContentDigest },
-    { themeModule, themeModulePath}
-  ) => {      
-    const { createNode } = actions
-  
-    const themeUiConfig = {
-        themeModule,
-        themeModulePath,
-    }
-  
-    createNode({
-      ...themeUiConfig,
-      id: `gatsby-plugin-theme-ui-config`,
-      parent: null,
-      children: [],
-      internal: {
-        type: `ThemeUiConfig`,
-        contentDigest: createContentDigest(themeUiConfig),
-        content: JSON.stringify(themeUiConfig),
-        description: `Options for gatsby-plugin-theme-ui`,
-      },
-    })
-  } 
+}
 
+exports.sourceNodes = (
+  { actions, createContentDigest },
+  { themePreset = {} }
+) => {
+  const { createNode } = actions
+
+  const themeUiConfig = {
+    themePreset,
+  }
+
+  createNode({
+    ...themeUiConfig,
+    id: `gatsby-plugin-theme-ui-config`,
+    parent: null,
+    children: [],
+    internal: {
+      type: `ThemeUiConfig`,
+      contentDigest: createContentDigest(themeUiConfig),
+      content: JSON.stringify(themeUiConfig),
+      description: `Options for gatsby-plugin-theme-ui`,
+    },
+  })
+}

--- a/packages/gatsby-plugin-theme-ui/package.json
+++ b/packages/gatsby-plugin-theme-ui/package.json
@@ -6,8 +6,7 @@
   "license": "MIT",
   "peerDependencies": {
     "gatsby": "^2.13.1",
-    "theme-ui": "^0.3.0",
-    "gatsby-core-utils": "^1.2.0"
+    "theme-ui": "^0.3.0"
   },
   "keywords": [
     "gatsby",

--- a/packages/gatsby-plugin-theme-ui/package.json
+++ b/packages/gatsby-plugin-theme-ui/package.json
@@ -6,7 +6,8 @@
   "license": "MIT",
   "peerDependencies": {
     "gatsby": "^2.13.1",
-    "theme-ui": "^0.3.0"
+    "theme-ui": "^0.3.0",
+    "gatsby-core-utils": "^1.2.0"
   },
   "keywords": [
     "gatsby",

--- a/packages/gatsby-plugin-theme-ui/src/hooks/configOptions.js
+++ b/packages/gatsby-plugin-theme-ui/src/hooks/configOptions.js
@@ -1,11 +1,10 @@
-import { useStaticQuery, graphql } from "gatsby"
+import { useStaticQuery, graphql } from 'gatsby'
 
 const useThemeUiConfig = () => {
   const data = useStaticQuery(graphql`
     query {
       themeUiConfig(id: { eq: "gatsby-plugin-theme-ui-config" }) {
-        themeModule
-        themeModulePath
+        themePreset
       }
     }
   `)

--- a/packages/gatsby-plugin-theme-ui/src/hooks/configOptions.js
+++ b/packages/gatsby-plugin-theme-ui/src/hooks/configOptions.js
@@ -6,7 +6,6 @@ const useThemeUiConfig = () => {
       themeUiConfig(id: { eq: "gatsby-plugin-theme-ui-config" }) {
         themeModule
         themeModulePath
-        moduleExportName
       }
     }
   `)

--- a/packages/gatsby-plugin-theme-ui/src/hooks/configOptions.js
+++ b/packages/gatsby-plugin-theme-ui/src/hooks/configOptions.js
@@ -1,0 +1,17 @@
+import { useStaticQuery, graphql } from "gatsby"
+
+const useThemeUiConfig = () => {
+  const data = useStaticQuery(graphql`
+    query {
+      themeUiConfig(id: { eq: "gatsby-plugin-theme-ui-config" }) {
+        themeModule
+        themeModulePath
+        moduleExportName
+      }
+    }
+  `)
+
+  return data.themeUiConfig
+}
+
+export default useThemeUiConfig

--- a/packages/gatsby-plugin-theme-ui/src/hooks/configOptions.js
+++ b/packages/gatsby-plugin-theme-ui/src/hooks/configOptions.js
@@ -4,7 +4,7 @@ const useThemeUiConfig = () => {
   const data = useStaticQuery(graphql`
     query {
       themeUiConfig(id: { eq: "gatsby-plugin-theme-ui-config" }) {
-        themePreset
+        preset
       }
     }
   `)

--- a/packages/gatsby-plugin-theme-ui/src/provider.js
+++ b/packages/gatsby-plugin-theme-ui/src/provider.js
@@ -1,14 +1,14 @@
 /** @jsx jsx */
 import { jsx, ThemeProvider, merge } from 'theme-ui'
-import theme from './index'
+import localTheme from './index'
 import components from './components'
 import useThemeUiConfig from './hooks/configOptions'
 
 const Root = ({ children }) => {
   const themeUiConfig = useThemeUiConfig()
-  const { themePreset } = themeUiConfig
+  const { preset } = themeUiConfig
 
-  const theme = themePreset.default || themePreset
+  const theme = preset.default || preset
 
   const fullTheme = merge(theme, localTheme)
 

--- a/packages/gatsby-plugin-theme-ui/src/provider.js
+++ b/packages/gatsby-plugin-theme-ui/src/provider.js
@@ -2,14 +2,43 @@
 import {
   jsx,
   ThemeProvider,
+  merge
 } from 'theme-ui'
 import theme from './index'
 import components from './components'
+import useThemeUiConfig from './hooks/configOptions'
 
-export const wrapRootElement = ({ element }) =>
-  jsx(ThemeProvider, {
-      theme,
-      components,
-    },
-    element,
+
+const Root = ({children}) => {
+  const themeUiConfig = useThemeUiConfig()
+  const {themeModule, themeModulePath, moduleExportName} = themeUiConfig
+
+  let themeWrapper
+  if (themeModule) {
+    themeWrapper = themeModule
+  }
+
+  if (themeModulePath) {
+    themeWrapper = themeModulePath
+  }
+  
+  if(themeWrapper && (moduleExportName in themeWrapper)) {
+    themeWrapper = themeWrapper[moduleExportName]
+  }
+
+  themeWrapper = merge(themeWrapper, {
+    ...theme
+  })
+  return (
+    <ThemeProvider theme={themeWrapper} components={components}>
+    {children}
+    </ThemeProvider>
   )
+}
+
+export const wrapRootElement = ({ element }) => {
+  return (
+    <Root>{element}</Root>
+  )
+}
+

--- a/packages/gatsby-plugin-theme-ui/src/provider.js
+++ b/packages/gatsby-plugin-theme-ui/src/provider.js
@@ -11,7 +11,7 @@ import useThemeUiConfig from './hooks/configOptions'
 
 const Root = ({children}) => {
   const themeUiConfig = useThemeUiConfig()
-  const {themeModule, themeModulePath, moduleExportName} = themeUiConfig
+  const {themeModule, themeModulePath} = themeUiConfig
 
   let themeWrapper
   if (themeModule) {
@@ -22,8 +22,8 @@ const Root = ({children}) => {
     themeWrapper = themeModulePath
   }
   
-  if(themeWrapper && (moduleExportName in themeWrapper)) {
-    themeWrapper = themeWrapper[moduleExportName]
+  if(themeWrapper && ('default' in themeWrapper)) {
+    themeWrapper = themeWrapper.default
   }
 
   themeWrapper = merge(themeWrapper, {

--- a/packages/gatsby-plugin-theme-ui/src/provider.js
+++ b/packages/gatsby-plugin-theme-ui/src/provider.js
@@ -1,44 +1,24 @@
 /** @jsx jsx */
-import {
-  jsx,
-  ThemeProvider,
-  merge
-} from 'theme-ui'
+import { jsx, ThemeProvider, merge } from 'theme-ui'
 import theme from './index'
 import components from './components'
 import useThemeUiConfig from './hooks/configOptions'
 
-
-const Root = ({children}) => {
+const Root = ({ children }) => {
   const themeUiConfig = useThemeUiConfig()
-  const {themeModule, themeModulePath} = themeUiConfig
+  const { themePreset } = themeUiConfig
 
-  let themeWrapper
-  if (themeModule) {
-    themeWrapper = themeModule
-  }
+  const theme = themePreset.default || themePreset
 
-  if (themeModulePath) {
-    themeWrapper = themeModulePath
-  }
-  
-  if(themeWrapper && ('default' in themeWrapper)) {
-    themeWrapper = themeWrapper.default
-  }
+  const fullTheme = merge(theme, localTheme)
 
-  themeWrapper = merge(themeWrapper, {
-    ...theme
-  })
   return (
-    <ThemeProvider theme={themeWrapper} components={components}>
-    {children}
+    <ThemeProvider theme={fullTheme} components={components}>
+      {children}
     </ThemeProvider>
   )
 }
 
 export const wrapRootElement = ({ element }) => {
-  return (
-    <Root>{element}</Root>
-  )
+  return <Root>{element}</Root>
 }
-

--- a/packages/gatsby-plugin-theme-ui/test/__mocks__/gatsby.js
+++ b/packages/gatsby-plugin-theme-ui/test/__mocks__/gatsby.js
@@ -1,0 +1,12 @@
+const React = require('react')
+const gatsby = jest.requireActual('gatsby')
+
+module.exports = {
+  ...gatsby,
+  graphql: jest.fn(),
+  useStaticQuery: jest.fn(() => ({
+    themeUiConfig: {
+      preset: {},
+    },
+  })),
+}


### PR DESCRIPTION
This code allows users to pass in their base themes through the plugin options. They can do it by path or by requiring the package directly. Any local shadowing is respected and merged with the base preset. 