### PR TITLE
Export presets consistently by name and default

### DIFF
--- a/packages/preset-dark/src/index.ts
+++ b/packages/preset-dark/src/index.ts
@@ -4,7 +4,7 @@ const heading = {
   lineHeight: 'heading',
 }
 
-export default {
+export const dark = {
   colors: {
     text: '#fff',
     background: '#060606',
@@ -151,3 +151,5 @@ export default {
     },
   },
 }
+
+export default dark

--- a/packages/preset-deep/src/index.ts
+++ b/packages/preset-deep/src/index.ts
@@ -4,7 +4,7 @@ const heading = {
   lineHeight: 'heading',
 }
 
-export default {
+export const deep = {
   colors: {
     text: 'hsl(210, 50%, 96%)',
     background: 'hsl(230, 25%, 18%)',
@@ -151,3 +151,5 @@ export default {
     },
   },
 }
+
+export default deep

--- a/packages/preset-swiss/src/index.ts
+++ b/packages/preset-swiss/src/index.ts
@@ -4,7 +4,7 @@ const heading = {
   lineHeight: 'heading',
 }
 
-export default {
+export const swiss = {
   colors: {
     text: 'hsl(10, 20%, 20%)',
     background: 'hsl(10, 10%, 98%)',
@@ -151,3 +151,5 @@ export default {
     },
   },
 }
+
+export default swiss

--- a/packages/preset-system/src/index.ts
+++ b/packages/preset-system/src/index.ts
@@ -4,7 +4,7 @@ const heading = {
   lineHeight: 'heading',
 }
 
-export default {
+export const system = {
   useCustomProperties: true,
   initialColorMode: 'system',
   colors: {
@@ -163,3 +163,5 @@ export default {
     },
   },
 }
+
+export default system

--- a/packages/preset-tosh/src/index.ts
+++ b/packages/preset-tosh/src/index.ts
@@ -4,7 +4,7 @@ const heading = {
   lineHeight: 'heading',
 }
 
-export default {
+export const tosh = {
   useCustomProperties: true,
   initialColorMode: 'light',
   colors: {
@@ -156,3 +156,5 @@ export default {
     },
   },
 }
+
+export default tosh


### PR DESCRIPTION
We're inconsistent with how we define/export theme presets. While some still export subsets of settings, they should all export a full theme using the name of the preset as well as a default export.