### PR TITLE
Fix link to @theme-ui/presets from gatsby-plugin-theme-ui

### DIFF
--- a/packages/gatsby-plugin-theme-ui/README.md
+++ b/packages/gatsby-plugin-theme-ui/README.md
@@ -49,7 +49,7 @@ export default {
 }
 ```
 
-You can also import and use presets from [@theme-ui/presets](https://theme-ui.com/presets) to use as a starting point.
+You can also import and use presets from [@theme-ui/presets](https://theme-ui.com/packages/presets) to use as a starting point.
 
 ## Color Modes
 


### PR DESCRIPTION
Fixing link to @theme-ui/presets from the gatsby-plugin-theme-ui README.md file