### PR TITLE
Fixed muted hex code in theme-spec.mdx

### DIFF
--- a/packages/docs/src/pages/theme-spec.mdx
+++ b/packages/docs/src/pages/theme-spec.mdx
@@ -80,7 +80,7 @@ where the name can be anything, but typically `light` and `dark` are used for ap
     background: '#fff',
     primary: '#07c',
     secondary: '#05a',
-    muted: '#f6f6f6f',
+    muted: '#f6f6f6',
     modes: {
       dark: {
         text: '#fff',


### PR DESCRIPTION
Fixed `muted` hex code in `colors` object in `theme-spec.mdx` file