### PR TITLE
Add Jest setup for mocking Gatsby

### DIFF
--- a/jest-preprocess.js
+++ b/jest-preprocess.js
@@ -1,0 +1,3 @@
+module.exports = require('babel-jest').createTransformer({
+  presets: ['babel-preset-gatsby'],
+})

--- a/package.json
+++ b/package.json
@@ -96,7 +96,10 @@
     ],
     "setupFiles": [
       "jest-canvas-mock"
-    ]
+    ],
+    "transform": {
+      "^.+\\.jsx?$": "<rootDir>/jest-preprocess.js"
+    }
   },
   "husky": {
     "hooks": {

--- a/packages/gatsby-plugin-theme-ui/test/__mocks__/gatsby.js
+++ b/packages/gatsby-plugin-theme-ui/test/__mocks__/gatsby.js
@@ -1,0 +1,12 @@
+const React = require('react')
+const gatsby = jest.requireActual('gatsby')
+
+module.exports = {
+  ...gatsby,
+  graphql: jest.fn(),
+  useStaticQuery: jest.fn(() => ({
+    themeUiConfig: {
+      preset: {},
+    },
+  })),
+}


### PR DESCRIPTION
This mocks `gatsby` and uses mock functions for `graphql` and `useStaticQuery`, making the existing tests pass again