### PR TITLE
add to install theme-ui

### DIFF
--- a/packages/docs/src/pages/getting-started/gatsby.mdx
+++ b/packages/docs/src/pages/getting-started/gatsby.mdx
@@ -7,7 +7,7 @@ title: Getting Started with Gatsby
 To use Theme UI with [Gatsby][], install and use [`gatsby-plugin-theme-ui`](/packages/gatsby-plugin).
 
 ```sh
-npm i gatsby-plugin-theme-ui
+npm i theme-ui gatsby-plugin-theme-ui
 ```
 
 Add the plugin to your `gatsby-config.js`.


### PR DESCRIPTION
To be obvious to new developer, theme-ui module should be installed as well.

I directly land of this page with google search. 
I'm using CodeSandbox to test theme-ui, 
CodeSandbox not throw error. it's just not working

I'm confuse and thought gatsby-plugin-theme-ui include the theme-ui module 

Then I change to use VS Code
It throw an error said theme-ui module is not installed