### PR TITLE
feat(chrome): update chrome to typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "@babel/runtime": "^7.7.7",
     "@testing-library/react": "^9.1.3",
     "@types/jest": "^25.1.2",
+    "@types/lodash.debounce": "^4.0.6",
+    "@types/lodash.merge": "^4.6.6",
     "@types/react-test-renderer": "^16.9.2",
     "babel-jest": "^25.3.0",
     "husky": ">=4.0.7",

--- a/packages/chrome/README.md
+++ b/packages/chrome/README.md
@@ -2,6 +2,12 @@
 
 Chrome devtools extension for editing Theme UI styles in the browser.
 
+## Status: Deprecated.
+
+This package is not compatible with current Theme UI version.
+
+See [Blocks UI](https://github.com/blocks/blocks) for a theme editor and JSX page builder.
+
 ## Installation
 
 1. [Download extension](https://github.com/system-ui/theme-ui/tree/master/packages/chrome/public)
@@ -12,5 +18,5 @@ Chrome devtools extension for editing Theme UI styles in the browser.
 
 ## Local Development
 
-1. Run `yarn prepare` (or `yarn watch`)
+1. Run `yarn __prepare` (or `yarn watch`)
 1. Load unpacked extension from the `public/` directory

--- a/packages/chrome/babel.config.js
+++ b/packages/chrome/babel.config.js
@@ -1,3 +1,1 @@
-module.exports = {
-  presets: ['@babel/preset-env', '@babel/preset-react'],
-}
+module.exports = require('../../babel.config')

--- a/packages/chrome/global.d.ts
+++ b/packages/chrome/global.d.ts
@@ -1,0 +1,7 @@
+export {}
+
+declare global {
+  interface Window {
+    chrome: any
+  }
+}

--- a/packages/chrome/package.json
+++ b/packages/chrome/package.json
@@ -31,5 +31,8 @@
     "webpack": "^4.33.0",
     "webpack-cli": "^3.3.4"
   },
+  "devDependencies": {
+    "@theme-ui/css": "^0.4.0-alpha.1"
+  },
   "gitHead": "bfd026cae085f377ca537de897dc43233d50f5d5"
 }

--- a/packages/chrome/src/index.tsx
+++ b/packages/chrome/src/index.tsx
@@ -1,6 +1,12 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
-import React, { useReducer, useEffect, useRef, useState } from 'react'
+import {
+  useReducer,
+  useEffect,
+  useRef,
+  useState,
+  FunctionComponent,
+} from 'react'
 import { render } from 'react-dom'
 import debounce from 'lodash.debounce'
 import merge from 'lodash.merge'
@@ -15,13 +21,15 @@ import {
   LineHeights,
   FontSizes,
   Space,
+  // @ts-ignore
 } from '@theme-ui/editor'
+import { Theme } from '@theme-ui/css'
 
-const runScript = script =>
+const runScript = (script: any) =>
   new Promise((resolve, reject) => {
     debounce(window.chrome.devtools.inspectedWindow.eval, 100)(
       script,
-      (result, err) => {
+      (result: any, err: Error) => {
         if (err) {
           console.error(err)
           reject(err)
@@ -31,17 +39,17 @@ const runScript = script =>
     )
   })
 
-const mergeState = (state, next) => merge({}, state, next)
+const mergeState = (state: any, next: any) => merge({}, state, next)
 
-const CopyTheme = ({ theme }) => {
+const CopyTheme = ({ theme }: { theme: Theme }) => {
   const [copied, setCopied] = useState(false)
-  const timer = useRef(false)
+  const timer = useRef(0)
 
   const handleClick = () => {
     setCopied(true)
     copyToClipboard(JSON.stringify(theme))
     clearInterval(timer.current)
-    timer.current = setInterval(() => setCopied(false), 1000)
+    timer.current = window.setInterval(() => setCopied(false), 1000)
   }
 
   return (
@@ -51,7 +59,7 @@ const CopyTheme = ({ theme }) => {
 
 const Spacer = () => <div sx={{ my: 2 }} />
 
-const App = () => {
+const App: FunctionComponent = () => {
   const dark = window.chrome.devtools.panels.themeName === 'dark'
 
   const [state, setState] = useReducer(mergeState, {
@@ -71,13 +79,13 @@ const App = () => {
     })
   }
 
-  const setTheme = nextTheme => {
+  const setTheme = (nextTheme: Theme) => {
     const json = JSON.stringify(nextTheme)
     runScript(`window.__THEME_UI__.setTheme(${json})`)
     setState({ theme: nextTheme })
   }
 
-  const setColorMode = nextMode => {
+  const setColorMode = (nextMode: Theme['initialColorModeName']) => {
     setState({ colorMode: nextMode })
     runScript(`window.__THEME_UI__.setColorMode('${nextMode}')`)
   }
@@ -96,7 +104,7 @@ const App = () => {
     setColorMode,
   }
 
-  if (!context.theme) return false
+  if (!context.theme) return null
 
   return (
     <Editor

--- a/packages/chrome/src/theme.ts
+++ b/packages/chrome/src/theme.ts
@@ -1,5 +1,7 @@
-export default {
-  initialColorMode: 'light',
+import { Theme } from '@theme-ui/css'
+
+const theme: Theme = {
+  initialColorModeName: 'light',
   colors: {
     text: '#000',
     background: '#fff',
@@ -30,11 +32,13 @@ export default {
     monospace: 'Menlo, monospace',
   },
   fontWeights: {
-    body: '400',
-    heading: '700',
+    body: 400,
+    heading: 700,
   },
   lineHeights: {
     body: 1.5,
     heading: 1.25,
   },
 }
+
+export default theme

--- a/packages/chrome/tsconfig.json
+++ b/packages/chrome/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "lib": ["ES2015", "DOM"],
+    "jsx": "react"
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.d.ts", "global.d.ts"]
+}

--- a/packages/chrome/webpack.config.js
+++ b/packages/chrome/webpack.config.js
@@ -1,6 +1,7 @@
 const path = require('path')
 
 module.exports = {
+  entry: ['./src/index.tsx'],
   output: {
     path: path.resolve(__dirname, 'public', 'bundle'),
     filename: 'index.js',
@@ -8,7 +9,7 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.js$/,
+        test: /\.tsx?$/,
         use: 'babel-loader',
       },
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -4041,6 +4041,25 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
   integrity sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
 
+"@types/lodash.debounce@^4.0.6":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.debounce/-/lodash.debounce-4.0.6.tgz#c5a2326cd3efc46566c47e4c0aa248dc0ee57d60"
+  integrity sha512-4WTmnnhCfDvvuLMaF3KV4Qfki93KebocUF45msxhYyjMttZDQYzHkO639ohhk8+oco2cluAFL3t5+Jn4mleylQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash.merge@^4.6.6":
+  version "4.6.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.merge/-/lodash.merge-4.6.6.tgz#b84b403c1d31bc42d51772d1cd5557fa008cd3d6"
+  integrity sha512-IB90krzMf7YpfgP3u/EvZEdXVvm4e3gJbUvh5ieuI+o+XqiNEt6fCzqNRaiLlPVScLI59RxIGZMQ3+Ko/DJ8vQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.150"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.150.tgz#649fe44684c3f1fcb6164d943c5a61977e8cf0bd"
+  integrity sha512-kMNLM5JBcasgYscD9x/Gvr6lTAv2NVgsKtet/hm93qMyf/D1pt+7jeEZklKJKxMVmXjxbRVQQGfqDSfipYCO6w==
+
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"


### PR DESCRIPTION
Convert `chrome` package to typescript

I've added `@ts-ignore` to `@theme-ui/editor` since https://github.com/system-ui/theme-ui/pull/900 isn't merged yet. 

Relates to: https://github.com/system-ui/theme-ui/issues/668