### PR TITLE
Add zIndex to OverwriteCSSProperties

### DIFF
--- a/packages/css/src/types.ts
+++ b/packages/css/src/types.ts
@@ -411,6 +411,19 @@ interface OverwriteCSSProperties {
    * @see https://developer.mozilla.org/docs/Web/CSS/border-radius
    */
   borderRadius?: CSS.BorderRadiusProperty<string | number>
+  
+   /**
+   * The **`z-index`** CSS property sets the z-order of a positioned element and its descendants or flex items. Overlapping elements with a larger z-index cover those with a smaller one.
+   *
+   * **Initial value**: `auto`
+   *
+   * | Chrome | Firefox | Safari |  Edge  |  IE   |
+   * | :----: | :-----: | :----: | :----: | :---: |
+   * | **1**  |  **1**  | **1**  | **12** | **4** |
+   *
+   * @see https://developer.mozilla.org/docs/Web/CSS/z-index
+   */
+   zIndex?: ZIndexProperty | string;
 }
 
 /**


### PR DESCRIPTION
Fixes this TS error:

<img width="525" alt="image" src="https://user-images.githubusercontent.com/667029/82128822-01e75000-97b6-11ea-8d0c-392c199cb903.png">
