### PR TITLE
[`@theme-ui/style-guide`] Add missing size for ColorRows that are scales

### DIFF
--- a/packages/style-guide/src/ColorPalette.tsx
+++ b/packages/style-guide/src/ColorPalette.tsx
@@ -45,6 +45,7 @@ export const ColorRow = ({
                 key={key}
                 name={id}
                 colors={color as Colors}
+                size={size}
                 omit={omit}
               />
             )


### PR DESCRIPTION
Without this, a `size` prop applied to a `ColorPalette` is only picked up for top-level colors that are not scales (e.g. typically `primary`, `text`, `background`).