### PR TITLE
Fix Safari closing sidebar on accordion button click

### DIFF
--- a/packages/sidenav/src/index.tsx
+++ b/packages/sidenav/src/index.tsx
@@ -152,6 +152,7 @@ export const AccordionButton: FunctionComponent<{
       title="Expand Section"
       disabled={disabled}
       {...props}
+      onMouseDown={(e) => e.preventDefault()}
       sx={{
         appearance: 'none',
         display: 'flex',

--- a/packages/sidenav/test/__snapshots__/index.tsx.snap
+++ b/packages/sidenav/test/__snapshots__/index.tsx.snap
@@ -242,6 +242,7 @@ exports[`AccordionNav renders open 1`] = `
             disabled={false}
             href="/bop"
             onClick={[Function]}
+            onMouseDown={[Function]}
             pathname=""
             title="Expand Section"
           >
@@ -404,6 +405,7 @@ exports[`AccordionNav renders with nested links 1`] = `
             disabled={false}
             href="/bop"
             onClick={[Function]}
+            onMouseDown={[Function]}
             pathname=""
             title="Expand Section"
           >


### PR DESCRIPTION
Safari removes focus from the sidebar when a button is clicked, triggering

```jsx
<div onBlur={() => setMenuOpen(false)}>
  <Sidebar />
</div>
```

I've set

```jsx
<button onMouseDown={(e) => e.preventDefault()} />
```

to prevent blur when clicking an AccordionButton.

Before:

![Kapture 2020-05-21 at 13 25 15](https://user-images.githubusercontent.com/31006608/82554589-87785080-9b66-11ea-8f9d-7f393f3347ed.gif)

After:

![Kapture 2020-05-21 at 13 21 41](https://user-images.githubusercontent.com/31006608/82554371-1173e980-9b66-11ea-9915-7a108b38a80c.gif)
