### PR TITLE
Update forms.mdx. Use `id` instead of `name` for `htmlFor`

### DIFF
--- a/packages/docs/src/pages/components/forms.mdx
+++ b/packages/docs/src/pages/components/forms.mdx
@@ -26,6 +26,7 @@ import {
   onSubmit={e => e.preventDefault()}>
   <Label htmlFor='username'>Username</Label>
   <Input
+    name='username'
     id='username'
     mb={3}
   />

--- a/packages/docs/src/pages/components/forms.mdx
+++ b/packages/docs/src/pages/components/forms.mdx
@@ -26,13 +26,13 @@ import {
   onSubmit={e => e.preventDefault()}>
   <Label htmlFor='username'>Username</Label>
   <Input
-    name='username'
+    id='username'
     mb={3}
   />
   <Label htmlFor='password'>Password</Label>
   <Input
     type='password'
-    name='password'
+    id='password'
     mb={3}
   />
   <Box>
@@ -42,14 +42,14 @@ import {
     </Label>
   </Box>
   <Label htmlFor='sound'>Sound</Label>
-  <Select name='sound' mb={3}>
+  <Select id='sound' mb={3}>
     <option>Beep</option>
     <option>Boop</option>
     <option>Blip</option>
   </Select>
   <Label htmlFor='comment'>Comment</Label>
   <Textarea
-    name='comment'
+    id='comment'
     rows='6'
     mb={3}
   />

--- a/packages/docs/src/pages/components/forms.mdx
+++ b/packages/docs/src/pages/components/forms.mdx
@@ -32,6 +32,7 @@ import {
   <Label htmlFor='password'>Password</Label>
   <Input
     type='password'
+    name='password'
     id='password'
     mb={3}
   />
@@ -42,13 +43,14 @@ import {
     </Label>
   </Box>
   <Label htmlFor='sound'>Sound</Label>
-  <Select id='sound' mb={3}>
+  <Select name='sound' id='sound' mb={3}>
     <option>Beep</option>
     <option>Boop</option>
     <option>Blip</option>
   </Select>
   <Label htmlFor='comment'>Comment</Label>
   <Textarea
+    name='comment'
     id='comment'
     rows='6'
     mb={3}


### PR DESCRIPTION
Team,

I've updated this page to point `Label`.`htmlFor` to [element id](https://html.spec.whatwg.org/multipage/forms.html#attr-label-for) instead of name.

Please let me know if it makes sense for you.
Thanks