### PR TITLE
Fix inconsistent tabbing in docs navbar

### DIFF
--- a/packages/docs/src/components/button.js
+++ b/packages/docs/src/components/button.js
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
 
-export default props => (
+export default (props) => (
   <button
     {...props}
     sx={{
@@ -16,9 +16,6 @@ export default props => (
       bg: 'muted',
       border: 0,
       borderRadius: 2,
-      ':focus': {
-        outline: '2px solid',
-      },
     }}
   />
 )

--- a/packages/docs/src/components/menu-button.js
+++ b/packages/docs/src/components/menu-button.js
@@ -16,7 +16,7 @@ const Burger = ({ size = '1em' }) => (
   </svg>
 )
 
-export default props => (
+export default (props) => (
   <button
     title="Toggle Menu"
     {...props}
@@ -31,12 +31,7 @@ export default props => (
       m: 0,
       border: 0,
       appearance: 'none',
-      ':focus': {
-        outline: '2px solid',
-      },
-      '@media screen and (min-width: 40em)': {
-        display: 'none',
-      },
+      display: [null, 'none'],
     }}>
     <Burger />
   </button>

--- a/packages/docs/src/components/skip-link.js
+++ b/packages/docs/src/components/skip-link.js
@@ -1,12 +1,14 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
 
-export default props => (
+export default (props) => (
   <a
     children="Skip to content"
     {...props}
     href="#content"
     sx={{
+      color: 'text',
+      bg: 'background',
       clip: 'rect(0 0 0 0)',
       height: 1,
       width: 1,
@@ -23,8 +25,6 @@ export default props => (
         left: 0,
         m: 2,
         fontWeight: 'bold',
-        color: 'black',
-        bg: 'white',
         width: 'auto',
         height: 'auto',
         clip: 'auto',

--- a/packages/docs/src/components/skip-link.js
+++ b/packages/docs/src/components/skip-link.js
@@ -7,8 +7,6 @@ export default (props) => (
     {...props}
     href="#content"
     sx={{
-      color: 'text',
-      bg: 'background',
       clip: 'rect(0 0 0 0)',
       height: 1,
       width: 1,
@@ -25,6 +23,8 @@ export default (props) => (
         left: 0,
         m: 2,
         fontWeight: 'bold',
+        color: 'black',
+        bg: 'white',
         width: 'auto',
         height: 'auto',
         clip: 'auto',

--- a/packages/docs/src/components/skip-link.js
+++ b/packages/docs/src/components/skip-link.js
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
 
-export default (props) => (
+export default props => (
   <a
     children="Skip to content"
     {...props}


### PR DESCRIPTION
While working on #943 I noticed some inconsistencies in the docs navbar.

* Multiple outline styles for different buttons
* SkipLink doesn't follow color scheme which makes it very obtrusive on dark mode

I opened a PR right away because the changes could be made quickly. If those things are on purpose, feel free to close this PR. 😊

| Before | After |
| --- | --- |
| ![Chrome light before](https://user-images.githubusercontent.com/31006608/82604194-355e1c00-9bb4-11ea-82a3-b7a7e2082f74.gif) | ![Chrome light after](https://user-images.githubusercontent.com/31006608/82604419-95ed5900-9bb4-11ea-9f24-68eecaa684d4.gif) |
| ![Safari light before](https://user-images.githubusercontent.com/31006608/82604218-4018b100-9bb4-11ea-8602-b571e3f619db.gif) | ![Safari light after](https://user-images.githubusercontent.com/31006608/82604429-9a197680-9bb4-11ea-87a5-08fc030527d9.gif) |
| ![Chrome dark before](https://user-images.githubusercontent.com/31006608/82604306-68081480-9bb4-11ea-9d76-52dbc143da0f.gif) | ![Chrome dark after](https://user-images.githubusercontent.com/31006608/82604646-e5338980-9bb4-11ea-9bfe-87cf83527530.gif) |
| ![Safari dark before](https://user-images.githubusercontent.com/31006608/82604316-6c343200-9bb4-11ea-804a-1135c2e8e00b.gif) | ![Safari dark after](https://user-images.githubusercontent.com/31006608/82604660-e95fa700-9bb4-11ea-93d8-e719945343f7.gif) |

