### PR TITLE
Add variants to Theme interface

### DIFF
--- a/packages/css/src/types.ts
+++ b/packages/css/src/types.ts
@@ -586,11 +586,10 @@ export interface Theme {
   radii?: ObjectOrArray<CSS.BorderRadiusProperty<TLengthStyledSystem>>
   shadows?: ObjectOrArray<CSS.BoxShadowProperty>
   zIndices?: ObjectOrArray<CSS.ZIndexProperty>
-  buttons?: ObjectOrArray<ThemeUICSSProperties>
   colorStyles?: ObjectOrArray<ThemeUICSSProperties>
   textStyles?: ObjectOrArray<ThemeUICSSProperties>
-  text?: ObjectOrArray<ThemeUICSSProperties>
   opacities?: ObjectOrArray<CSS.OpacityProperty>
+
   /**
    * Enable/disable custom CSS properties/variables if lower browser
    * support is required (for eg. IE 11).
@@ -637,4 +636,125 @@ export interface Theme {
    * fonts, etc.
    */
   styles?: ThemeStyles
+
+  /**
+   * Variants: partial style objects that can be used for stylistic component
+   * variants or making part of an application themeable. These are commonly
+   * used for typographic styles, buttons, and themeable layout components.
+   * Variants are also used to style built-in components.
+   *
+   * @see https://theme-ui.com/theme-spec
+   * @see https://theme-ui.com/components/variants
+   */
+  grids?: Record<string, ThemeUIStyleObject>
+
+  /**
+   * Variants: partial style objects that can be used for stylistic component
+   * variants or making part of an application themeable. These are commonly
+   * used for typographic styles, buttons, and themeable layout components.
+   * Variants are also used to style built-in components.
+   *
+   * @see https://theme-ui.com/theme-spec
+   * @see https://theme-ui.com/components/variants
+   */
+  buttons?: Record<string, ThemeUIStyleObject>
+
+  /**
+   * Variants: partial style objects that can be used for stylistic component
+   * variants or making part of an application themeable. These are commonly
+   * used for typographic styles, buttons, and themeable layout components.
+   * Variants are also used to style built-in components.
+   *
+   * @see https://theme-ui.com/theme-spec
+   * @see https://theme-ui.com/components/variants
+   */
+  text?: Record<string, ThemeUIStyleObject>
+
+  /**
+   * Variants: partial style objects that can be used for stylistic component
+   * variants or making part of an application themeable. These are commonly
+   * used for typographic styles, buttons, and themeable layout components.
+   * Variants are also used to style built-in components.
+   *
+   * @see https://theme-ui.com/theme-spec
+   * @see https://theme-ui.com/components/variants
+   */
+  links?: Record<string, ThemeUIStyleObject>
+
+  /**
+   * Variants: partial style objects that can be used for stylistic component
+   * variants or making part of an application themeable. These are commonly
+   * used for typographic styles, buttons, and themeable layout components.
+   * Variants are also used to style built-in components.
+   *
+   * @see https://theme-ui.com/theme-spec
+   * @see https://theme-ui.com/components/variants
+   */
+  images?: Record<string, ThemeUIStyleObject>
+
+  /**
+   * Variants: partial style objects that can be used for stylistic component
+   * variants or making part of an application themeable. These are commonly
+   * used for typographic styles, buttons, and themeable layout components.
+   * Variants are also used to style built-in components.
+   *
+   * @see https://theme-ui.com/theme-spec
+   * @see https://theme-ui.com/components/variants
+   */
+  cards?: Record<string, ThemeUIStyleObject>
+
+  /**
+   * Variants: partial style objects that can be used for stylistic component
+   * variants or making part of an application themeable. These are commonly
+   * used for typographic styles, buttons, and themeable layout components.
+   * Variants are also used to style built-in components.
+   *
+   * @see https://theme-ui.com/theme-spec
+   * @see https://theme-ui.com/components/variants
+   */
+  layout?: Record<string, ThemeUIStyleObject>
+
+  /**
+   * Variants: partial style objects that can be used for stylistic component
+   * variants or making part of an application themeable. These are commonly
+   * used for typographic styles, buttons, and themeable layout components.
+   * Variants are also used to style built-in components.
+   *
+   * @see https://theme-ui.com/theme-spec
+   * @see https://theme-ui.com/components/variants
+   */
+  forms?: Record<string, ThemeUIStyleObject>
+
+  /**
+   * Variants: partial style objects that can be used for stylistic component
+   * variants or making part of an application themeable. These are commonly
+   * used for typographic styles, buttons, and themeable layout components.
+   * Variants are also used to style built-in components.
+   *
+   * @see https://theme-ui.com/theme-spec
+   * @see https://theme-ui.com/components/variants
+   */
+  badges?: Record<string, ThemeUIStyleObject>
+
+  /**
+   * Variants: partial style objects that can be used for stylistic component
+   * variants or making part of an application themeable. These are commonly
+   * used for typographic styles, buttons, and themeable layout components.
+   * Variants are also used to style built-in components.
+   *
+   * @see https://theme-ui.com/theme-spec
+   * @see https://theme-ui.com/components/variants
+   */
+  alerts?: Record<string, ThemeUIStyleObject>
+
+  /**
+   * Variants: partial style objects that can be used for stylistic component
+   * variants or making part of an application themeable. These are commonly
+   * used for typographic styles, buttons, and themeable layout components.
+   * Variants are also used to style built-in components.
+   *
+   * @see https://theme-ui.com/theme-spec
+   * @see https://theme-ui.com/components/variants
+   */
+  messages?: Record<string, ThemeUIStyleObject>
 }

--- a/packages/css/src/types.ts
+++ b/packages/css/src/types.ts
@@ -645,6 +645,7 @@ export interface Theme {
    *
    * @see https://theme-ui.com/theme-spec
    * @see https://theme-ui.com/components/variants
+   * @see https://theme-ui.com/components/grid#variants
    */
   grids?: Record<string, ThemeUIStyleObject>
 
@@ -656,6 +657,7 @@ export interface Theme {
    *
    * @see https://theme-ui.com/theme-spec
    * @see https://theme-ui.com/components/variants
+   * @see https://theme-ui.com/components/button#variants
    */
   buttons?: Record<string, ThemeUIStyleObject>
 
@@ -667,6 +669,7 @@ export interface Theme {
    *
    * @see https://theme-ui.com/theme-spec
    * @see https://theme-ui.com/components/variants
+   * @see https://theme-ui.com/components/text#variants
    */
   text?: Record<string, ThemeUIStyleObject>
 
@@ -678,6 +681,7 @@ export interface Theme {
    *
    * @see https://theme-ui.com/theme-spec
    * @see https://theme-ui.com/components/variants
+   * @see https://theme-ui.com/components/link#variants
    */
   links?: Record<string, ThemeUIStyleObject>
 
@@ -689,6 +693,7 @@ export interface Theme {
    *
    * @see https://theme-ui.com/theme-spec
    * @see https://theme-ui.com/components/variants
+   * @see https://theme-ui.com/components/image#variants
    */
   images?: Record<string, ThemeUIStyleObject>
 
@@ -700,6 +705,7 @@ export interface Theme {
    *
    * @see https://theme-ui.com/theme-spec
    * @see https://theme-ui.com/components/variants
+   * @see https://theme-ui.com/components/card#variants
    */
   cards?: Record<string, ThemeUIStyleObject>
 
@@ -711,6 +717,7 @@ export interface Theme {
    *
    * @see https://theme-ui.com/theme-spec
    * @see https://theme-ui.com/components/variants
+   * @see https://theme-ui.com/components/container#variants
    */
   layout?: Record<string, ThemeUIStyleObject>
 
@@ -722,6 +729,14 @@ export interface Theme {
    *
    * @see https://theme-ui.com/theme-spec
    * @see https://theme-ui.com/components/variants
+   * @see https://theme-ui.com/components/label#variants
+   * @see https://theme-ui.com/components/input#variants
+   * @see https://theme-ui.com/components/select#variants
+   * @see https://theme-ui.com/components/textarea#variants
+   * @see https://theme-ui.com/components/radio#variants
+   * @see https://theme-ui.com/components/checkbox#variants
+   * @see https://theme-ui.com/components/slider#variants
+   * @see https://theme-ui.com/components/field#variants
    */
   forms?: Record<string, ThemeUIStyleObject>
 
@@ -733,6 +748,7 @@ export interface Theme {
    *
    * @see https://theme-ui.com/theme-spec
    * @see https://theme-ui.com/components/variants
+   * @see https://theme-ui.com/components/badge#variants
    */
   badges?: Record<string, ThemeUIStyleObject>
 
@@ -744,6 +760,7 @@ export interface Theme {
    *
    * @see https://theme-ui.com/theme-spec
    * @see https://theme-ui.com/components/variants
+   * @see https://theme-ui.com/components/alert#variants
    */
   alerts?: Record<string, ThemeUIStyleObject>
 
@@ -755,6 +772,7 @@ export interface Theme {
    *
    * @see https://theme-ui.com/theme-spec
    * @see https://theme-ui.com/components/variants
+   * @see https://theme-ui.com/components/message#variants
    */
   messages?: Record<string, ThemeUIStyleObject>
 }

--- a/packages/css/src/types.ts
+++ b/packages/css/src/types.ts
@@ -638,96 +638,99 @@ export interface Theme {
   styles?: ThemeStyles
 
   /**
-   * Variants: partial style objects that can be used for stylistic component
-   * variants or making part of an application themeable. These are commonly
-   * used for typographic styles, buttons, and themeable layout components.
-   * Variants are also used to style built-in components.
+   * You can define additional CSS grid layouts by adding variants to the
+   * `theme.grids` object. These styles can be used to create a wide variety of
+   * different reusable layouts.
    *
-   * @see https://theme-ui.com/theme-spec
+   * @see https://theme-ui.com/theme-spec#variants
    * @see https://theme-ui.com/components/variants
    * @see https://theme-ui.com/components/grid#variants
    */
   grids?: Record<string, ThemeUIStyleObject>
 
   /**
-   * Variants: partial style objects that can be used for stylistic component
-   * variants or making part of an application themeable. These are commonly
-   * used for typographic styles, buttons, and themeable layout components.
-   * Variants are also used to style built-in components.
+   * Button variants can be defined in the `theme.buttons` object. The `Button`
+   * component uses `theme.buttons.primary` as its default variant style.
    *
-   * @see https://theme-ui.com/theme-spec
+   * @see https://theme-ui.com/theme-spec#variants
    * @see https://theme-ui.com/components/variants
    * @see https://theme-ui.com/components/button#variants
    */
   buttons?: Record<string, ThemeUIStyleObject>
 
   /**
-   * Variants: partial style objects that can be used for stylistic component
-   * variants or making part of an application themeable. These are commonly
-   * used for typographic styles, buttons, and themeable layout components.
-   * Variants are also used to style built-in components.
+   * Text style variants can be defined in the `theme.text` object. The `Text`
+   * component uses `theme.text.default` as its default variant style.
    *
-   * @see https://theme-ui.com/theme-spec
+   * @see https://theme-ui.com/theme-spec#variants
    * @see https://theme-ui.com/components/variants
    * @see https://theme-ui.com/components/text#variants
    */
   text?: Record<string, ThemeUIStyleObject>
 
   /**
-   * Variants: partial style objects that can be used for stylistic component
-   * variants or making part of an application themeable. These are commonly
-   * used for typographic styles, buttons, and themeable layout components.
-   * Variants are also used to style built-in components.
+   * Link variants can be defined in the `theme.links` object. By default the
+   * `Link` component will use styles defined in `theme.styles.a`.
    *
-   * @see https://theme-ui.com/theme-spec
+   * @see https://theme-ui.com/theme-spec#variants
    * @see https://theme-ui.com/components/variants
    * @see https://theme-ui.com/components/link#variants
    */
   links?: Record<string, ThemeUIStyleObject>
 
   /**
-   * Variants: partial style objects that can be used for stylistic component
-   * variants or making part of an application themeable. These are commonly
-   * used for typographic styles, buttons, and themeable layout components.
-   * Variants are also used to style built-in components.
+   * Image style variants can be defined in the `theme.images` object.
    *
-   * @see https://theme-ui.com/theme-spec
+   * @see https://theme-ui.com/theme-spec#variants
    * @see https://theme-ui.com/components/variants
    * @see https://theme-ui.com/components/image#variants
    */
   images?: Record<string, ThemeUIStyleObject>
 
   /**
-   * Variants: partial style objects that can be used for stylistic component
-   * variants or making part of an application themeable. These are commonly
-   * used for typographic styles, buttons, and themeable layout components.
-   * Variants are also used to style built-in components.
+   * Card style variants can be defined in `the theme.cards` object. By default
+   * the `Card` component uses the `theme.cards.primary` variant.
    *
-   * @see https://theme-ui.com/theme-spec
+   * @see https://theme-ui.com/theme-spec#variants
    * @see https://theme-ui.com/components/variants
    * @see https://theme-ui.com/components/card#variants
    */
   cards?: Record<string, ThemeUIStyleObject>
 
   /**
-   * Variants: partial style objects that can be used for stylistic component
-   * variants or making part of an application themeable. These are commonly
-   * used for typographic styles, buttons, and themeable layout components.
-   * Variants are also used to style built-in components.
+   * Container variants can be defined in the `theme.layout` object. The
+   * `Container` component uses `theme.layout.container` as its default variant
+   * style.
    *
-   * @see https://theme-ui.com/theme-spec
+   * @see https://theme-ui.com/theme-spec#variants
    * @see https://theme-ui.com/components/variants
    * @see https://theme-ui.com/components/container#variants
    */
   layout?: Record<string, ThemeUIStyleObject>
 
   /**
-   * Variants: partial style objects that can be used for stylistic component
-   * variants or making part of an application themeable. These are commonly
-   * used for typographic styles, buttons, and themeable layout components.
-   * Variants are also used to style built-in components.
+   * Label variants can be defined in `theme.forms` and the component uses the
+   * `theme.forms.label` variant by default.
    *
-   * @see https://theme-ui.com/theme-spec
+   * Input variants can be defined in `theme.forms` and the component uses the
+   * `theme.forms.input` variant by default.
+   *
+   * Select variants can be defined in `theme.forms` and the component uses the
+   * `theme.forms.select` variant by default.
+   *
+   * Textarea variants can be defined in `theme.forms` and the component uses
+   * the `theme.forms.textarea` variant by default.
+   *
+   * Radio variants can be defined in `theme.forms` and the component uses the
+   * `theme.forms.radio` variant by default.
+   *
+   * Checkbox variants can be defined in `theme.forms` and the component uses
+   * the `theme.forms.checkbox` variant by default.
+   *
+   * Slider variants can be defined in the `theme.forms` object. The `Slider`
+   * component uses `theme.forms.slider` as its default variant style.
+   *
+   * @see https://theme-ui.com/theme-spec#variants
    * @see https://theme-ui.com/components/variants
    * @see https://theme-ui.com/components/label#variants
    * @see https://theme-ui.com/components/input#variants
@@ -736,41 +739,33 @@ export interface Theme {
    * @see https://theme-ui.com/components/radio#variants
    * @see https://theme-ui.com/components/checkbox#variants
    * @see https://theme-ui.com/components/slider#variants
-   * @see https://theme-ui.com/components/field#variants
    */
   forms?: Record<string, ThemeUIStyleObject>
 
   /**
-   * Variants: partial style objects that can be used for stylistic component
-   * variants or making part of an application themeable. These are commonly
-   * used for typographic styles, buttons, and themeable layout components.
-   * Variants are also used to style built-in components.
+   * Badge variants can be defined in `theme.badges`. The `Badge` component uses
+   * `theme.badges.primary` as its default variant.
    *
-   * @see https://theme-ui.com/theme-spec
+   * @see https://theme-ui.com/theme-spec#variants
    * @see https://theme-ui.com/components/variants
    * @see https://theme-ui.com/components/badge#variants
    */
   badges?: Record<string, ThemeUIStyleObject>
 
   /**
-   * Variants: partial style objects that can be used for stylistic component
-   * variants or making part of an application themeable. These are commonly
-   * used for typographic styles, buttons, and themeable layout components.
-   * Variants are also used to style built-in components.
+   * Alert variants can be defined in `theme.alerts`. The `Alert` component uses
+   * `theme.alerts.primary` as its default variant.
    *
-   * @see https://theme-ui.com/theme-spec
+   * @see https://theme-ui.com/theme-spec#variants
    * @see https://theme-ui.com/components/variants
    * @see https://theme-ui.com/components/alert#variants
    */
   alerts?: Record<string, ThemeUIStyleObject>
 
   /**
-   * Variants: partial style objects that can be used for stylistic component
-   * variants or making part of an application themeable. These are commonly
-   * used for typographic styles, buttons, and themeable layout components.
-   * Variants are also used to style built-in components.
+   * Message variants can be defined in the `theme.messages` object.
    *
-   * @see https://theme-ui.com/theme-spec
+   * @see https://theme-ui.com/theme-spec#variants
    * @see https://theme-ui.com/components/variants
    * @see https://theme-ui.com/components/message#variants
    */

--- a/packages/preset-sketchy/src/index.ts
+++ b/packages/preset-sketchy/src/index.ts
@@ -211,7 +211,6 @@ const theme: Theme = {
     },
   },
   links: {
-    color: 'primary',
     nav: {
       borderRadius: 'sketchy1',
       textDecoration: 'none',

--- a/packages/preset-sketchy/src/index.ts
+++ b/packages/preset-sketchy/src/index.ts
@@ -1,14 +1,5 @@
 import { Theme, ThemeUIStyleObject } from '@theme-ui/css'
 
-export interface ThemeSketchy extends Theme {
-  cards: ThemeUIStyleObject
-  links: ThemeUIStyleObject
-  forms: Record<string, ThemeUIStyleObject>
-  badges: ThemeUIStyleObject
-  alerts: ThemeUIStyleObject
-  messages: ThemeUIStyleObject
-}
-
 const defaultBorderStyles: ThemeUIStyleObject = {
   border: 'thick',
   color: 'text',
@@ -36,7 +27,7 @@ const formStyles: ThemeUIStyleObject = {
   },
 }
 
-const theme: ThemeSketchy = {
+const theme: Theme = {
   colors: {
     text: '#000200',
     background: '#FAFAF9',


### PR DESCRIPTION
Per request from @hasparus in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45042, opening this PR to add variants to the `Theme` interface that match the Theme UI documentation for each component as well as here:

- https://theme-ui.com/theme-spec#variants
- https://theme-ui.com/components/variants

Some things to note:

1. `buttons` and `text` were already present, but incorrect (AFAICT) - probably leftover from the initial `@types/styled-system__css` copypasta. We may need to do something different if I've misunderstood these properties, though.
1. This change required removing everything from the `ThemeSketchy` interface in `@theme-ui/preset-sketchy`, so I just changed preset to use `Theme` directly. If there are intentions to make it a different API than a base theme, we can put it back and just leave it as an empty interface or maybe a type alias until there are properties to add. I spot-checked a few other presets and this was the only one that was explicitly typed.
1. I might've gone a little overboard on the doc comments. 😶 Let me know if you have any feedback one way or the other and I can tweak them accordingly.