### PR TITLE
docs(how-it-works): change ThemeProvider import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Update "How it works" docs so that `ThemeProvider` is imported from `theme-ui`
 - Make ThemeProvider `theme` prop required
 - Removes overriding property on editor combobox
 - Adjust media query sort logic #600

--- a/packages/docs/src/pages/guides/how-it-works.mdx
+++ b/packages/docs/src/pages/guides/how-it-works.mdx
@@ -31,7 +31,7 @@ For illustrative purposes, the `ThemeProvider` renders something like the follow
 // for demonstration only – this does not reflect the actual source code
 import React from 'react'
 import { MDXProvider } from '@mdx-js/react'
-import { ThemeProvider } from 'emotion-theming'
+import { ThemeProvider } from 'theme-ui'
 import styled from '@emotion/styled'
 
 const themeUIComponents = {


### PR DESCRIPTION
This changes the `import` statement for `ThemeProvider` so that it's from `theme-ui` instead of `emotion-theming`.