### PR TITLE
fix(@theme-ui/sidenav): move React to peerDependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add `@theme-ui/preset-sketchy`
 - `@theme-ui/prism`: add support for highlighting lines #895
 - `@theme-ui/style-guide`: pass `size` prop to ColorRow component #941
+- `@theme-ui/sidenav`: move React to peerDependencies #978
 
 ## v0.3.0 2020-01-22
 

--- a/packages/sidenav/package.json
+++ b/packages/sidenav/package.json
@@ -13,12 +13,17 @@
   "publishConfig": {
     "access": "public"
   },
+  "peerDependencies": {
+    "react": "^16.8.6"
+  },
+  "devDependencies": {
+    "react": "^16.8.6"
+  },
   "dependencies": {
     "@emotion/core": "^10.0.14",
     "@mdx-js/react": "^1.0.21",
     "@types/mdx-js__react": "^1.5.1",
     "deepmerge": "^4.0.0",
-    "react": "^16.8.6",
     "theme-ui": "^0.4.0-alpha.3"
   },
   "keywords": [


### PR DESCRIPTION
During development of a library I was facing problems with "Invalid hook call" when using hooks.
It turns out that the sidenav package leads to a second copy of React because it is declared as dependency.