### PR TITLE
Use media query value when useColorSchemeMediaQuery is set to true

### DIFF
--- a/packages/color-modes/src/index.js
+++ b/packages/color-modes/src/index.js
@@ -65,21 +65,29 @@ const useColorModeState = (theme = {}) => {
     } else if (stored) setMode(stored)
   }, [theme])
 
-  const handleColorSchemeChange = React.useCallback(({ matches, media }) => {
-    const modeEvaluated = getEvaluatedMode(media)
-    if (matches) setMode(modeEvaluated)
+  const handleColorSchemeChange = React.useCallback((e) => {
+    const modeEvaluated = getEvaluatedMode(e.media)
+    if (e.matches) setMode(modeEvaluated)
   }, [])
 
   React.useEffect(() => {
     if (theme.useColorSchemeMediaQuery && window.matchMedia) {
-      window.matchMedia(darkQuery).addListener(handleColorSchemeChange)
-      window.matchMedia(lightQuery).addListener(handleColorSchemeChange)
+      window
+        .matchMedia(darkQuery)
+        .addEventListener('change', handleColorSchemeChange)
+      window
+        .matchMedia(lightQuery)
+        .addEventListener('change', handleColorSchemeChange)
     }
 
     return () => {
       if (theme.useColorSchemeMediaQuery && window.matchMedia) {
-        window.matchMedia(darkQuery).removeListener(handleColorSchemeChange)
-        window.matchMedia(lightQuery).removeListener(handleColorSchemeChange)
+        window
+          .matchMedia(darkQuery)
+          .removeEventListener('change', handleColorSchemeChange)
+        window
+          .matchMedia(lightQuery)
+          .removeEventListener('change', handleColorSchemeChange)
       }
     }
   }, [theme])

--- a/packages/color-modes/src/index.js
+++ b/packages/color-modes/src/index.js
@@ -52,18 +52,20 @@ const useColorModeState = (theme = {}) => {
   React.useEffect(() => {
     const stored = theme.useLocalStorage !== false && storage.get()
     document.body.classList.remove('theme-ui-' + stored)
-    if (!stored && theme.useColorSchemeMediaQuery) {
+    if (theme.useColorSchemeMediaQuery) {
       const query = getMediaQuery()
-      setMode(query)
-      return
-    }
-    if (!stored || stored === mode) return
-    setMode(stored)
+      if (!stored || stored !== query) setMode(query)
+    } else if (stored && stored !== mode) setMode(stored)
   }, [])
 
   React.useEffect(() => {
-    if (!mode || theme.useLocalStorage === false) return
-    storage.set(mode)
+    if (
+      mode &&
+      theme.useLocalStorage !== false &&
+      !theme.useColorSchemeMediaQuery
+    ) {
+      storage.set(mode)
+    }
   }, [mode])
 
   if (process.env.NODE_ENV !== 'production') {


### PR DESCRIPTION
Currently, even if `useColorSchemeMediaQuery: true`, the color mode stored in localStorage wins. Also, the color mode from the media query gets stored to localStorage.

Update (4814af8): I made the media query color mode get stored in localStorage again, to make the initial flash prevention script still work.

Fixes #787 

Absolutely **loving** theme-ui btw.