### PR TITLE
Correct Tony McDade name

### DIFF
--- a/packages/docs/src/pages/index.mdx
+++ b/packages/docs/src/pages/index.mdx
@@ -19,7 +19,7 @@ export default props =>
 
 ## George Floyd
 
-Natosha McDade, Yassin Mohamed, Finan H. Berhe, Sean Reed, Steven Demarco Taylor,
+Tony McDade, Yassin Mohamed, Finan H. Berhe, Sean Reed, Steven Demarco Taylor,
 Breonna Taylor, Ariane McCree, Terrance Franklin, Miles Hall, Darius Tarver,
 William Green, Samuel David Mallard, Kwame Jones, De’von Bailey, Christopher Whitfield,
 Anthony Hill, De’Von Bailey, Eric Logan, Jamarion Robinson, Gregory Hill Jr,


### PR DESCRIPTION
[Tony McDade](https://www.them.us/story/tony-mcdade-police-killing-tallahassee) was a Black trans man who has been deadnamed here. Please update this list to reflect his chosen name.

