### PR TITLE
fix: add missing comma in color code example

### DIFF
--- a/packages/color/README.md
+++ b/packages/color/README.md
@@ -189,7 +189,7 @@ We can take the result of any of the above helper functions (which return a func
     backgroundImage: t => `
       linear-gradient(
         to bottom,
-        ${alpha('primary', 0.5)(t)}
+        ${alpha('primary', 0.5)(t)},
         ${alpha('secondary', 0.5)(t)}
       )
     `,


### PR DESCRIPTION
In the @theme-ui/color README, the advanced usage example is missing a comma so the css rendered is not valid