### PR TITLE
Add variant composition feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - `@theme-ui/prism`: add support for highlighting lines #895
 - `@theme-ui/style-guide`: pass `size` prop to ColorRow component #941
 - `@theme-ui/sidenav`: move React to peerDependencies #978
+- Move `merge` to `@theme-ui/css` (still exported through `@theme-ui/core`)
+- Add variant composition
 
 ## v0.3.0 2020-01-22
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,8 +18,7 @@
   },
   "dependencies": {
     "@emotion/core": "^10.0.0",
-    "@theme-ui/css": "^0.4.0-rc.1",
-    "deepmerge": "^4.2.2"
+    "@theme-ui/css": "^0.4.0-rc.1"
   },
   "peerDependencies": {
     "react": "^16.11.0"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,14 +4,14 @@ import {
   InterpolationWithTheme,
 } from '@emotion/core'
 // @ts-ignore
-import { css, Theme } from '@theme-ui/css'
+import { css, Theme, merge } from '@theme-ui/css'
 import React from 'react'
-import deepmerge from 'deepmerge'
 import { version as __EMOTION_VERSION__ } from '@emotion/core/package.json'
 
 import './react-jsx'
 
 export * from './types'
+export { merge } from '@theme-ui/css'
 
 const getCSS = (props) => {
   if (!props.sx && !props.css) return undefined
@@ -49,31 +49,6 @@ export const Context = React.createContext<ContextValue>({
 })
 
 export const useThemeUI = () => React.useContext(Context)
-
-const canUseSymbol = typeof Symbol === 'function' && Symbol.for
-
-const REACT_ELEMENT = canUseSymbol ? Symbol.for('react.element') : 0xeac7
-const FORWARD_REF = canUseSymbol ? Symbol.for('react.forward_ref') : 0xeac7
-
-const isMergeableObject = (n) => {
-  return (
-    !!n &&
-    typeof n === 'object' &&
-    n.$$typeof !== REACT_ELEMENT &&
-    n.$$typeof !== FORWARD_REF
-  )
-}
-
-const arrayMerge = (destinationArray, sourceArray, options) => sourceArray
-
-/**
- * Deeply merge themes
- */
-export const merge = (a: Theme, b: Theme): Theme =>
-  deepmerge(a, b, { isMergeableObject, arrayMerge })
-
-merge.all = <T = Theme>(...args: Partial<T>[]) =>
-  deepmerge.all<T>(args, { isMergeableObject, arrayMerge })
 
 interface BaseProviderProps {
   context: ContextValue

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -16,6 +16,7 @@
     "access": "public"
   },
   "dependencies": {
-    "csstype": "^2.5.7"
+    "csstype": "^2.5.7",
+    "deepmerge": "^4.2.2"
   }
 }

--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -295,12 +295,16 @@ export const css = (args: ThemeUIStyleObject = {}) => (
     const val = typeof x === 'function' ? x(theme) : x
 
     if (key === 'variant') {
-      const styles = css(
-        merge.all(
-          ...val.split(VARIANT_SEPARATOR).map(variants => get(theme, variants))
-        )
-      )(theme)
-      result = { ...result, ...styles }
+      const variants = val
+        .split(VARIANT_SEPARATOR)
+        .map((variant) => get(theme, variant))
+        .filter(Boolean)
+
+      if (variants.length > 0) {
+        const styles = css(merge.all(...variants))(theme)
+        result = { ...result, ...styles }
+      }
+
       continue
     }
 

--- a/packages/css/test/index.ts
+++ b/packages/css/test/index.ts
@@ -256,7 +256,7 @@ test('handles responsive variants', () => {
 
 test('merges text.caps over text.title', () => {
   const caps = css({
-    variant: 'text.caps'
+    variant: 'text.caps',
   })(theme)
   const result = css({
     variant: 'text.title text.caps',
@@ -269,13 +269,13 @@ test('merges text.title into text.caps', () => {
     variant: 'text.caps text.title',
   })(theme)
   expect(result).toEqual({
-    "@media screen and (min-width: 40em)": {
-      "fontSize": 36,
-      "letterSpacing": "-0.02em",
+    '@media screen and (min-width: 40em)': {
+      fontSize: 36,
+      letterSpacing: '-0.02em',
     },
-    "fontSize": 24,
-    "letterSpacing": "-0.01em",
-    "textTransform": "uppercase"
+    fontSize: 24,
+    letterSpacing: '-0.01em',
+    textTransform: 'uppercase',
   })
 })
 

--- a/packages/css/test/index.ts
+++ b/packages/css/test/index.ts
@@ -254,6 +254,31 @@ test('handles responsive variants', () => {
   })
 })
 
+test('merges text.caps over text.title', () => {
+  const caps = css({
+    variant: 'text.caps'
+  })(theme)
+  const result = css({
+    variant: 'text.title text.caps',
+  })(theme)
+  expect(result).toEqual(caps)
+})
+
+test('merges text.title into text.caps', () => {
+  const result = css({
+    variant: 'text.caps text.title',
+  })(theme)
+  expect(result).toEqual({
+    "@media screen and (min-width: 40em)": {
+      "fontSize": 36,
+      "letterSpacing": "-0.02em",
+    },
+    "fontSize": 24,
+    "letterSpacing": "-0.01em",
+    "textTransform": "uppercase"
+  })
+})
+
 test('handles negative margins from scale', () => {
   const result = css({
     mt: -3,

--- a/yarn.lock
+++ b/yarn.lock
@@ -9735,7 +9735,7 @@ gatsby-admin@^0.1.58:
     react-icons "^3.10.0"
     strict-ui "^0.1.3"
     subscriptions-transport-ws "^0.9.16"
-    theme-ui "^0.4.0-rc.0"
+    theme-ui "^0.4.0-alpha.3"
     typescript "^3.9.3"
     urql "^1.9.7"
     yup "^0.29.1"


### PR DESCRIPTION
This addition allows for variants defined in `css` style objects to be composed using 
space-separated lists. Style objects will compose on top of each other left-to-right 
(last one wins) before being fed into `css`.

The behavior of single variants is unchanged, but the implementation is now a
byproduct of the composition behavior. (i.e. we `variant.split(' ')` all
variants).

Also, to facilitate this change the `merge` function has been moved to `css`, as
its previous home `core` depends on `css` such that there would be a circular
dependency otherwise. It also just makes sense if we move this merge behavior
down to the level of the `css` package.

`core` now exports `merge` from `css` instead of actually hosting the function.
`deepmerge` has been removed from `core` and added to `css` as a result, as the
`merge` function is the only thing that consumes it in either package. All
previous behavior should still work completely fine.

The variant separator is defined as a global constant, so it can be changed if
we think something like a comma, semicolon, or plus would be more evocative. I
think space is best because it mimics CSS class behavior. We could also get a
little more advanced and make it configurable, but I don't think that's
necessary.

I haven't started on docs yet, I need to find where specifically this behavior should go.  
~~Nor have I done the changelog, but that was just be not knowing about it until just now.~~

I'm excited to get this feature in and hopefully contribute more as I start using theme-ui more heavily!