### PR TITLE
Add comma between color stops in linear-gradient code example in Color package docs

### DIFF
--- a/packages/color/README.md
+++ b/packages/color/README.md
@@ -189,7 +189,7 @@ We can take the result of any of the above helper functions (which return a func
     backgroundImage: t => `
       linear-gradient(
         to bottom,
-        ${alpha('primary', 0.5)(t)}
+        ${alpha('primary', 0.5)(t)},
         ${alpha('secondary', 0.5)(t)}
       )
     `,


### PR DESCRIPTION
Hi there, love the theme-ui project!

I was following the linear gradient example on the [color package documentation](https://theme-ui.com/packages/color/), and noticed the example omits a comma between the primary color stop and secondary color stop, causing browsers to mark the property value as invalid.

From something I was working on using the code example as a starting point:
```jsx
<div
  sx={{
    backgroundImage: t => `
      linear-gradient(
        to bottom,
        ${alpha('inverted_background', 0)(t)}
        ${alpha('inverted_background', 1)(t)}
      )
    `,
  }}>
  Hello
</div>
```

Chrome marking the property as invalid:
<img width="574" alt="CleanShot 2020-06-24 at 17 32 12@2x" src="https://user-images.githubusercontent.com/677025/85531829-affdd980-b641-11ea-81df-de3a077b6630.png">

Separating the colour stops with a comma...
```jsx
<div
  sx={{
    backgroundImage: t => `
      linear-gradient(
        to bottom,
        ${alpha('inverted_background', 0)(t)},
        ${alpha('inverted_background', 1)(t)}
      )
    `,
  }}>
  Hello
</div>
```

Fixes the problem:

<img width="606" alt="CleanShot 2020-06-24 at 17 32 25@2x" src="https://user-images.githubusercontent.com/677025/85531871-b9874180-b641-11ea-9f9b-943ada944607.png">

Cheers!