### PR TITLE
(@theme-ui/components): Pass Checkbox children to wrapping container

### DIFF
--- a/packages/components/src/Checkbox.js
+++ b/packages/components/src/Checkbox.js
@@ -2,19 +2,19 @@ import React from 'react'
 import Box from './Box'
 import SVG from './SVG'
 
-const CheckboxChecked = props => (
+const CheckboxChecked = (props) => (
   <SVG {...props}>
     <path d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z" />
   </SVG>
 )
 
-const CheckboxUnchecked = props => (
+const CheckboxUnchecked = (props) => (
   <SVG {...props}>
     <path d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z" />
   </SVG>
 )
 
-const CheckboxIcon = props => (
+const CheckboxIcon = (props) => (
   <React.Fragment>
     <CheckboxChecked
       {...props}
@@ -38,7 +38,7 @@ const CheckboxIcon = props => (
 )
 
 export const Checkbox = React.forwardRef(
-  ({ className, sx, variant = 'checkbox', ...props }, ref) => (
+  ({ className, sx, variant = 'checkbox', children, ...props }, ref) => (
     <Box>
       <Box
         ref={ref}
@@ -74,6 +74,7 @@ export const Checkbox = React.forwardRef(
           },
         }}
       />
+      {children}
     </Box>
   )
 )


### PR DESCRIPTION
Hello 👋

**Currently**, one can pass children to `Checkbox`, which subsequently are passed to `input` and trigger this lovely error.

> Error: input is a void element tag and must neither have `children` nor use `dangerouslySetInnerHTML`.

[It looks pretty funny if you do it in the docs.](https://user-images.githubusercontent.com/15332326/86528568-94989700-bea9-11ea-80de-7c81eda808d7.png)

**After this PR**, the children are given to the wrapping Box.
What's cool, on top of avoiding error, it now allows this:

![repeatedly toggling checkbox](https://user-images.githubusercontent.com/15332326/86528614-05d84a00-beaa-11ea-8a96-b8a3cbaf49ee.gif)

---

Here's the example source if you wanna try it in the deploy preview.

```tsx
<Label sx={{ '> div': { display: 'flex', alignItems: 'center' } }}>
  <Checkbox>
    <span
      sx={{
        ':before': {
          content: '"No"',
        },
        'input:checked ~ &:before': {
          content: '"Yes"',
        },
      }}
    />
  </Checkbox>
</Label>
```