### PR TITLE
(@theme-ui/css): Add highlight color to ColorMode type

### DIFF
--- a/packages/css/src/types.ts
+++ b/packages/css/src/types.ts
@@ -523,15 +523,20 @@ export interface ColorMode {
   secondary?: CSS.ColorProperty
 
   /**
+   * A contrast color for emphasizing UI
+   */
+  accent?: CSS.ColorProperty
+
+  /**
+   * A background color for highlighting text
+   */
+  highlight?: CSS.ColorProperty
+
+  /**
    * A faint color for backgrounds, borders, and accents that do not require
    * high contrast with the background color
    */
   muted?: CSS.ColorProperty
-
-  /**
-   * A contrast color for emphasizing UI
-   */
-  accent?: CSS.ColorProperty
 
   [k: string]: CSS.ColorProperty | Scale<CSS.ColorProperty> | undefined
 }

--- a/packages/css/test/errors-and-inference.ts
+++ b/packages/css/test/errors-and-inference.ts
@@ -114,3 +114,32 @@ describe('Theme', () => {
     )
   })
 })
+
+describe('ColorMode', () => {
+  const expectedSnippet = expectSnippet(`
+    import { ColorMode } from './packages/css/src'
+
+    const colorMode: ColorMode = {}
+
+    colorMode.text?.toUpperCase();
+
+    const baseColors = [
+      colorMode.text,
+      colorMode.background,
+      colorMode.primary,
+      colorMode.secondary,
+      colorMode.muted,
+      colorMode.highlight,
+      colorMode.accent,
+    ];
+
+    const seriousPink = colorMode.seriousPink
+    if (Array.isArray(seriousPink)) {
+      const [light, medium, dark] = seriousPink
+    }
+  `)
+
+  expectedSnippet.toInfer('baseColors', '(string | undefined)[]')
+  expectedSnippet.toInfer('light', 'string')
+  expectedSnippet.toInfer('dark', 'string')
+})


### PR DESCRIPTION
ColorMode has an index signature, so this is an improvement rather than a fix. 
It may be convenient and suggest an interoperable name.

Described in https://theme-ui.com/theming.

Closes https://github.com/system-ui/theme-ui/issues/1050.
Mirrors https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45967 for v0.3.