### PR TITLE
Add typecheck scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,4 @@ jobs:
           ${{ runner.os }}-yarn-
     - run: yarn
     - run: yarn test --coverage
+    - run: yarn typecheck

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "clean": "lerna run clean",
     "format": "prettier --write \"**/*.js{,on}\" \"**/*.md\"  \"**/*.mdx\"",
     "test": "jest",
+    "typecheck": "lerna run typecheck",
     "logo": "yarn workspace docs logo",
     "dev:chrome": "yarn workspace @theme-ui/chrome dev",
     "dev:editor": "yarn workspace @theme-ui/editor dev"

--- a/packages/color-modes/index.d.ts
+++ b/packages/color-modes/index.d.ts
@@ -1,0 +1,8 @@
+import * as React from 'react'
+
+export function useColorMode<T = string>(): [
+  T,
+  (val: T | ((_: T) => T)) => void
+]
+export const InitializeColorMode: () => JSX.Element
+export const ColorModeProvider: React.FC

--- a/packages/color-modes/package.json
+++ b/packages/color-modes/package.json
@@ -3,6 +3,7 @@
   "version": "0.4.0-rc.1",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
+  "types": "index.d.ts",
   "sideEffects": false,
   "scripts": {
     "prepare": "microbundle --no-compress",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,7 +8,8 @@
   "sideEffects": false,
   "scripts": {
     "prepare": "microbundle --no-compress --tsconfig tsconfig.json",
-    "watch": "microbundle watch --no-compress --tsconfig tsconfig.json"
+    "watch": "microbundle watch --no-compress --tsconfig tsconfig.json",
+    "typecheck": "tsc --noEmit"
   },
   "repository": "system-ui/theme-ui",
   "author": "Brent Jackson",

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -8,7 +8,8 @@
   "sideEffects": false,
   "scripts": {
     "prepare": "microbundle --no-compress --tsconfig tsconfig.json",
-    "watch": "microbundle watch --no-compress --tsconfig tsconfig.json"
+    "watch": "microbundle watch --no-compress --tsconfig tsconfig.json",
+    "typecheck": "tsc --noEmit"
   },
   "author": "Brent Jackson",
   "license": "MIT",

--- a/packages/custom-properties/package.json
+++ b/packages/custom-properties/package.json
@@ -10,7 +10,8 @@
   "license": "MIT",
   "scripts": {
     "prepare": "microbundle --no-compress --tsconfig tsconfig.json",
-    "watch": "microbundle watch --no-compress --tsconfig tsconfig.json"
+    "watch": "microbundle watch --no-compress --tsconfig tsconfig.json",
+    "typecheck": "tsc --noEmit"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -8,7 +8,8 @@
   "license": "MIT",
   "scripts": {
     "prepare": "microbundle --no-compress --tsconfig tsconfig.json",
-    "watch": "microbundle watch --no-compress --tsconfig tsconfig.json"
+    "watch": "microbundle watch --no-compress --tsconfig tsconfig.json",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@theme-ui/components": "^0.4.0-rc.1",

--- a/packages/gatsby-theme-ui-layout/package.json
+++ b/packages/gatsby-theme-ui-layout/package.json
@@ -6,7 +6,8 @@
   "peerDependencies": {
     "gatsby": "^2.13.1",
     "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react-dom": "^16.8.0",
+    "typecheck": "tsc --noEmit"
   },
   "license": "MIT"
 }

--- a/packages/match-media/package.json
+++ b/packages/match-media/package.json
@@ -11,7 +11,8 @@
   "repository": "system-ui/theme-ui",
   "scripts": {
     "prepare": "microbundle --no-compress --tsconfig tsconfig.json",
-    "watch": "microbundle watch --no-compress --tsconfig tsconfig.json"
+    "watch": "microbundle watch --no-compress --tsconfig tsconfig.json",
+    "typecheck": "tsc --noEmit"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mdx/package.json
+++ b/packages/mdx/package.json
@@ -8,7 +8,8 @@
   "sideEffects": false,
   "scripts": {
     "prepare": "microbundle --no-compress --tsconfig tsconfig.json",
-    "watch": "microbundle watch --no-compress --tsconfig tsconfig.json"
+    "watch": "microbundle watch --no-compress --tsconfig tsconfig.json",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@emotion/core": "^10.0.0",

--- a/packages/preset-base/package.json
+++ b/packages/preset-base/package.json
@@ -8,7 +8,8 @@
   "repository": "system-ui/theme-ui",
   "scripts": {
     "prepare": "microbundle --no-compress --tsconfig tsconfig.json",
-    "watch": "microbundle watch --no-compress --tsconfig tsconfig.json"
+    "watch": "microbundle watch --no-compress --tsconfig tsconfig.json",
+    "typecheck": "tsc --noEmit"
   },
   "types": "dist/index.d.ts",
   "source": "src/index.ts",

--- a/packages/preset-bootstrap/package.json
+++ b/packages/preset-bootstrap/package.json
@@ -9,7 +9,8 @@
   "license": "MIT",
   "scripts": {
     "prepare": "microbundle --no-compress",
-    "watch": "microbundle watch --no-compress"
+    "watch": "microbundle watch --no-compress",
+    "typecheck": "tsc --noEmit"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/preset-bulma/package.json
+++ b/packages/preset-bulma/package.json
@@ -9,7 +9,8 @@
   "license": "MIT",
   "scripts": {
     "prepare": "microbundle --no-compress",
-    "watch": "microbundle watch --no-compress"
+    "watch": "microbundle watch --no-compress",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@theme-ui/preset-base": "^0.4.0-rc.1"

--- a/packages/preset-dark/package.json
+++ b/packages/preset-dark/package.json
@@ -9,7 +9,8 @@
   "license": "MIT",
   "scripts": {
     "prepare": "microbundle --no-compress",
-    "watch": "microbundle watch --no-compress"
+    "watch": "microbundle watch --no-compress",
+    "typecheck": "tsc --noEmit"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/preset-deep/package.json
+++ b/packages/preset-deep/package.json
@@ -9,7 +9,8 @@
   "license": "MIT",
   "scripts": {
     "prepare": "microbundle --no-compress",
-    "watch": "microbundle watch --no-compress"
+    "watch": "microbundle watch --no-compress",
+    "typecheck": "tsc --noEmit"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/preset-funk/package.json
+++ b/packages/preset-funk/package.json
@@ -9,7 +9,8 @@
   "license": "MIT",
   "scripts": {
     "prepare": "microbundle --no-compress",
-    "watch": "microbundle watch --no-compress"
+    "watch": "microbundle watch --no-compress",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@theme-ui/preset-base": "^0.4.0-rc.1"

--- a/packages/preset-future/package.json
+++ b/packages/preset-future/package.json
@@ -9,7 +9,8 @@
   "license": "MIT",
   "scripts": {
     "prepare": "microbundle --no-compress",
-    "watch": "microbundle watch --no-compress"
+    "watch": "microbundle watch --no-compress",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@theme-ui/preset-base": "^0.4.0-rc.1"

--- a/packages/preset-polaris/package.json
+++ b/packages/preset-polaris/package.json
@@ -9,7 +9,8 @@
   "license": "MIT",
   "scripts": {
     "prepare": "microbundle --no-compress",
-    "watch": "microbundle watch --no-compress"
+    "watch": "microbundle watch --no-compress",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@theme-ui/preset-base": "^0.4.0-rc.1"

--- a/packages/preset-roboto/package.json
+++ b/packages/preset-roboto/package.json
@@ -9,7 +9,8 @@
   "license": "MIT",
   "scripts": {
     "prepare": "microbundle --no-compress",
-    "watch": "microbundle watch --no-compress"
+    "watch": "microbundle watch --no-compress",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@theme-ui/preset-base": "^0.4.0-rc.1"

--- a/packages/preset-sketchy/package.json
+++ b/packages/preset-sketchy/package.json
@@ -9,7 +9,8 @@
   "license": "MIT",
   "scripts": {
     "prepare": "microbundle --no-compress",
-    "watch": "microbundle watch --no-compress"
+    "watch": "microbundle watch --no-compress",
+    "typecheck": "tsc --noEmit"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/preset-swiss/package.json
+++ b/packages/preset-swiss/package.json
@@ -9,7 +9,8 @@
   "license": "MIT",
   "scripts": {
     "prepare": "microbundle --no-compress",
-    "watch": "microbundle watch --no-compress"
+    "watch": "microbundle watch --no-compress",
+    "typecheck": "tsc --noEmit"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/preset-system/package.json
+++ b/packages/preset-system/package.json
@@ -9,7 +9,8 @@
   "license": "MIT",
   "scripts": {
     "prepare": "microbundle --no-compress",
-    "watch": "microbundle watch --no-compress"
+    "watch": "microbundle watch --no-compress",
+    "typecheck": "tsc --noEmit"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/preset-tailwind/package.json
+++ b/packages/preset-tailwind/package.json
@@ -9,7 +9,8 @@
   "license": "MIT",
   "scripts": {
     "prepare": "microbundle --no-compress",
-    "watch": "microbundle watch --no-compress"
+    "watch": "microbundle watch --no-compress",
+    "typecheck": "tsc --noEmit"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/preset-tosh/package.json
+++ b/packages/preset-tosh/package.json
@@ -10,7 +10,8 @@
   "repository": "system-ui/theme-ui",
   "scripts": {
     "prepare": "microbundle --no-compress",
-    "watch": "microbundle watch --no-compress"
+    "watch": "microbundle watch --no-compress",
+    "typecheck": "tsc --noEmit"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/presets/package.json
+++ b/packages/presets/package.json
@@ -9,7 +9,8 @@
   "license": "MIT",
   "scripts": {
     "prepare": "microbundle --no-compress",
-    "watch": "microbundle watch --no-compress"
+    "watch": "microbundle watch --no-compress",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@theme-ui/preset-base": "^0.4.0-rc.1",

--- a/packages/prism/package.json
+++ b/packages/prism/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "prepare": "microbundle --no-compress -o dist",
     "watch": "microbundle watch --no-compress -o dist",
-    "build-presets": "node build-presets.js"
+    "build-presets": "node build-presets.js",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "prism-react-renderer": "^1.0.2"

--- a/packages/sidenav/package.json
+++ b/packages/sidenav/package.json
@@ -8,7 +8,8 @@
   "license": "MIT",
   "scripts": {
     "prepare": "microbundle --no-compress",
-    "watch": "microbundle watch --no-compress"
+    "watch": "microbundle watch --no-compress",
+    "typecheck": "tsc --noEmit"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/style-guide/package.json
+++ b/packages/style-guide/package.json
@@ -9,7 +9,8 @@
   "license": "MIT",
   "scripts": {
     "prepare": "microbundle --no-compress",
-    "watch": "microbundle watch --no-compress"
+    "watch": "microbundle watch --no-compress",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@theme-ui/presets": "^0.4.0-rc.1",

--- a/packages/tachyons/package.json
+++ b/packages/tachyons/package.json
@@ -10,7 +10,8 @@
   "license": "MIT",
   "scripts": {
     "prepare": "microbundle --no-compress --tsconfig tsconfig.json",
-    "watch": "microbundle watch --no-compress --tsconfig tsconfig.json"
+    "watch": "microbundle watch --no-compress --tsconfig tsconfig.json",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@theme-ui/css": "^0.4.0-rc.1",

--- a/packages/tailwind/package.json
+++ b/packages/tailwind/package.json
@@ -10,7 +10,8 @@
   "license": "MIT",
   "scripts": {
     "prepare": "microbundle --no-compress --tsconfig tsconfig.json",
-    "watch": "microbundle watch --no-compress --tsconfig tsconfig.json"
+    "watch": "microbundle watch --no-compress --tsconfig tsconfig.json",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@theme-ui/css": "^0.4.0-rc.1",

--- a/packages/theme-provider/package.json
+++ b/packages/theme-provider/package.json
@@ -8,7 +8,8 @@
   "sideEffects": false,
   "scripts": {
     "prepare": "microbundle --no-compress --tsconfig tsconfig.json",
-    "watch": "microbundle watch --no-compress --tsconfig tsconfig.json"
+    "watch": "microbundle watch --no-compress --tsconfig tsconfig.json",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@emotion/core": "^10.0.0",

--- a/packages/theme-ui/package.json
+++ b/packages/theme-ui/package.json
@@ -5,6 +5,7 @@
   "source": "src/index.ts",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
+  "types": "dist/index.d.ts",
   "sideEffects": false,
   "author": "Brent Jackson <jxnblk@gmail.com>",
   "license": "MIT",

--- a/packages/theme-ui/package.json
+++ b/packages/theme-ui/package.json
@@ -11,7 +11,8 @@
   "repository": "system-ui/theme-ui",
   "scripts": {
     "prepare": "microbundle --no-compress",
-    "watch": "microbundle watch --no-compress"
+    "watch": "microbundle watch --no-compress",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@theme-ui/color-modes": "^0.4.0-rc.1",

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -9,7 +9,8 @@
   "license": "MIT",
   "scripts": {
     "prepare": "microbundle --no-compress --tsconfig tsconfig.json",
-    "watch": "microbundle watch --no-compress --tsconfig tsconfig.json"
+    "watch": "microbundle watch --no-compress --tsconfig tsconfig.json",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@theme-ui/css": "^0.4.0-rc.1",


### PR DESCRIPTION
:wave:

I added a _typecheck_ step as mentioned by @blainekasten in https://github.com/system-ui/theme-ui/issues/668#issuecomment-644978640.

It feels a bit wasteful to run this on every change, and it could be probably made faster with some TS `composite` projects and GitHub actions wizardry, but I guess it's not bad for now.

The .d.ts for for _@theme-ui/color-modes_ was needed to type values reexported from _theme-ui_.
This should make Theme UI TypeScript feel less "early access" for users.

---

BTW I tried using `lerna exec` instead of `lerna run` to leave the package.json files in packages intact, but it resulted in incomprehensible bash one-liner 😅