### PR TITLE
fix(core): reexport types

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,9 @@
     ],
     "transform": {
       "^.+\\.jsx?$": "<rootDir>/jest-preprocess.js"
+    },
+    "moduleNameMapper": {
+      "@theme-ui/css/dist/types": "@theme-ui/css/src/types"
     }
   },
   "husky": {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,6 +10,7 @@ import { version as __EMOTION_VERSION__ } from '@emotion/core/package.json'
 
 import './react-jsx'
 
+export * from '@theme-ui/css/dist/types'
 export * from './types'
 
 const getCSS = (props) => {


### PR DESCRIPTION
TLDR _@theme-ui/css_ is the __core__ package _@theme-ui/core_ is the __react__ package. This may be a little confusing for people expecting to find types for whole public API in  _@theme-ui/core_.

https://github.com/system-ui/theme-ui/issues/834#issuecomment-659175198
https://github.com/system-ui/theme-ui/issues/834#issuecomment-659852476