### PR TITLE
fix(components): add primary as default variant for Alert component

### DIFF
--- a/packages/components/src/Alert.js
+++ b/packages/components/src/Alert.js
@@ -4,6 +4,7 @@ import Box from './Box'
 export const Alert = React.forwardRef((props, ref) => (
   <Box
     ref={ref}
+    variant="primary"
     {...props}
     __themeKey="alerts"
     __css={{


### PR DESCRIPTION
This was doing my head in.

Now it matches the documentation: https://github.com/system-ui/theme-ui/blob/master/packages/docs/src/pages/components/alert.mdx#L29