### PR TITLE
fix(components): add primary as default variant for Badge component

### DIFF
--- a/packages/components/src/Badge.js
+++ b/packages/components/src/Badge.js
@@ -4,6 +4,7 @@ import Box from './Box'
 export const Badge = React.forwardRef((props, ref) => (
   <Box
     ref={ref}
+    variant="primary"
     {...props}
     __themeKey="badges"
     __css={{


### PR DESCRIPTION
To go along with #1102, use the primary variant by default for `Badge`. It confuses me every time & looks wrong since Button, etc use `primary` without specification.