### PR TITLE
fix(editor): Ensure combobox items are always readable

### DIFF
--- a/packages/editor/src/Combobox.tsx
+++ b/packages/editor/src/Combobox.tsx
@@ -192,6 +192,7 @@ const Combobox: <T extends string | number>(
           maxHeight: 512,
           overflowY: 'auto',
           bg: 'white',
+          color: 'black',
           border: '1px solid',
           borderTop: 0,
           borderColor: 'lightgray',

--- a/packages/editor/test/__snapshots__/Combobox.tsx.snap
+++ b/packages/editor/test/__snapshots__/Combobox.tsx.snap
@@ -71,6 +71,7 @@ exports[`renders 1`] = `
   max-height: 512px;
   overflow-y: auto;
   background-color: white;
+  color: black;
   border: 1px solid;
   border-top: 0;
   border-color: lightgray;


### PR DESCRIPTION
Closes #1066. This isn’t the most elegant, but since we don’t have a standard theme color for an “elevated” material, using white + black will ensure the items are always readable. 

After:
![4FB41B6D-4A54-498F-9CD0-73D88A999308](https://user-images.githubusercontent.com/5074763/89830971-1627b880-db2b-11ea-90fc-50cff7e05b0f.jpeg)

Before:
![DF7CD8FC-5FC9-4D79-A655-8AA315689E5D](https://user-images.githubusercontent.com/5074763/89830976-1758e580-db2b-11ea-8a8e-5b9df9917fcc.jpeg)
