### PR TITLE
feat(docs): Add filenames to code blocks, including MDX Layout page

### DIFF
--- a/packages/docs/src/components/code.js
+++ b/packages/docs/src/components/code.js
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { jsx, Styled, Alert } from 'theme-ui'
+import { jsx, Styled, Text } from 'theme-ui'
 import Prism from '@theme-ui/prism'
 import { LiveProvider, LiveEditor, LivePreview, LiveError } from 'react-live'
 import * as themeUI from 'theme-ui'
@@ -47,7 +47,7 @@ const images = {
 
 const scope = {
   ...themeUI,
-  Link: (props) => {
+  Link: props => {
     if (props.activeClassName)
       return <span className={props.activeClassName} {...props} />
     return <span {...props} sx={{ cursor: 'pointer' }} />
@@ -56,7 +56,7 @@ const scope = {
   images,
 }
 
-const transformCode = (src) => `/** @jsx jsx */\n<>${src}</>`
+const transformCode = src => `/** @jsx jsx */\n<>${src}</>`
 
 const liveTheme = { styles: [] }
 
@@ -83,7 +83,7 @@ export const LiveCode = ({ children, preview, xray }) => {
         sx={{
           p: 3,
           variant: xray ? 'styles.xray' : null,
-          border: (t) => `1px solid ${t.colors.muted}`,
+          border: t => `1px solid ${t.colors.muted}`,
         }}>
         <LivePreview />
         <LiveError
@@ -108,19 +108,30 @@ export const LiveCode = ({ children, preview, xray }) => {
   )
 }
 
-export default (props) => {
+const Code = props => {
   if (props.live) {
     return <LiveCode {...props} />
   }
   if (props.filename) {
     return (
       <section>
-        <Alert sx={{ bg: 'gray', color: 'background', borderRadius: 0 }}>
+        <Text
+          as="span"
+          sx={{
+            display: 'block',
+            bg: 'gray',
+            color: 'background',
+            px: 3,
+            py: 2,
+            fontWeight: 'bold',
+          }}>
           {props.filename}
-        </Alert>
+        </Text>
         <Prism {...props} sx={{ mt: 0 }} />
       </section>
     )
   }
-  return <Prism {...props} />
+  return <div {...props} />
 }
+
+export default Code

--- a/packages/docs/src/components/code.js
+++ b/packages/docs/src/components/code.js
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { jsx, Styled } from 'theme-ui'
+import { jsx, Styled, Alert } from 'theme-ui'
 import Prism from '@theme-ui/prism'
 import { LiveProvider, LiveEditor, LivePreview, LiveError } from 'react-live'
 import * as themeUI from 'theme-ui'
@@ -111,6 +111,16 @@ export const LiveCode = ({ children, preview, xray }) => {
 export default (props) => {
   if (props.live) {
     return <LiveCode {...props} />
+  }
+  if (props.filename) {
+    return (
+      <section>
+        <Alert sx={{ bg: 'gray', color: 'background', borderRadius: 0 }}>
+          {props.filename}
+        </Alert>
+        <Prism {...props} sx={{ mt: 0 }} />
+      </section>
+    )
   }
   return <Prism {...props} />
 }

--- a/packages/docs/src/pages/guides/mdx-layout-components.mdx
+++ b/packages/docs/src/pages/guides/mdx-layout-components.mdx
@@ -13,7 +13,7 @@ which is written in MDX.
 
 As an example, create a new component with the `ThemeProvider` and a wrapping `<div>`.
 
-```jsx
+```jsx filename=Layout.js
 /** @jsx jsx */
 import { jsx, ThemeProvider } from 'theme-ui'
 
@@ -26,7 +26,7 @@ export default props => (
 
 To add styles to this component, add a `theme` prop to the `ThemeProvider` and an `sx` prop to the `div`.
 
-```jsx
+```jsx filename=Layout.js
 /** @jsx jsx */
 import { jsx, ThemeProvider } from 'theme-ui'
 


### PR DESCRIPTION
Closes #749. Using an MDX [code block meta string](https://mdxjs.com/guides/live-code#code-block-meta-string ), allows displaying file names on code blocks in the docs. This is implemented on the MDX Layout Component guide page, to clarify they’re the same file iterated on.

| Deep | Swiss |
|:--|:--|
| ![IMG_2164](https://user-images.githubusercontent.com/5074763/89842135-c3f29180-db42-11ea-9d50-883782c28705.jpeg) | ![IMG_2165](https://user-images.githubusercontent.com/5074763/89842092-a6252c80-db42-11ea-9484-52d92e7074f6.jpeg) |
