### PR TITLE
fix(docs): Fix 9 jsx-a11y console warnings

### DIFF
--- a/packages/docs/src/components/graph.js
+++ b/packages/docs/src/components/graph.js
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx, get, useThemeUI } from 'theme-ui'
-import { useState, useEffect, Fragment } from 'react'
+import { useState, useEffect } from 'react'
 import merge from 'deepmerge'
 import Logo from './logo'
 
@@ -65,7 +65,7 @@ const Node = ({ x, y, color = 0, ...props }) => {
         transitionTimingFunction: 'ease-out',
         transitionDuration: '.4s',
         '&:hover': {
-          stroke: t => t.colors.highlight,
+          stroke: (t) => t.colors.highlight,
         },
       }}
     />
@@ -102,7 +102,7 @@ const Edges = ({ x, y, state }) => {
 
   return (
     <g transform={transform}>
-      {angles.map(n => (
+      {angles.map((n) => (
         <path
           key={n}
           d={paths[n]}
@@ -121,8 +121,8 @@ const Edges = ({ x, y, state }) => {
   )
 }
 
-const rand = l => Math.floor(Math.random() * (l + 1))
-const randomizeColors = state => {
+const rand = (l) => Math.floor(Math.random() * (l + 1))
+const randomizeColors = (state) => {
   const color = rand(colors.length - 1)
   return merge(state, {
     [rand(2)]: {
@@ -131,7 +131,7 @@ const randomizeColors = state => {
   })
 }
 
-export default ({ width = 32, height = 9, scale = 32 }) => {
+const Graph = ({ width = 32, height = 9, scale = 32 }) => {
   const { theme } = useThemeUI()
   const rows = Array.from({ length: height / 3 }).map((n, y) =>
     Array.from({
@@ -139,11 +139,6 @@ export default ({ width = 32, height = 9, scale = 32 }) => {
     }).map((o, x) => ({ x, y }))
   )
   const [state, setState] = useState(initialState)
-  const viewBox = `0 0 ${width} ${height}`
-  const dimensions = {
-    width: width * scale,
-    height: height * scale,
-  }
 
   useEffect(() => {
     const tick = () => {
@@ -155,10 +150,10 @@ export default ({ width = 32, height = 9, scale = 32 }) => {
     }
   }, [])
 
-  const handleClick = ({ x, y }) => e => {
+  const handleClick = ({ x, y }) => (e) => {
     const i = get(state, [y, x].join('.'), 0)
     const n = (i + 1) % colors.length
-    setState(s =>
+    setState((s) =>
       merge(s, {
         [y]: {
           [x]: n,
@@ -189,7 +184,7 @@ export default ({ width = 32, height = 9, scale = 32 }) => {
         userSelect: 'none',
       }}>
       <rect width={width} height={height} fill="none" />
-      {rows.map(row =>
+      {rows.map((row) =>
         row.map(({ x, y }) => (
           <g key={x + y}>
             <Edges x={x} y={y} state={state} />
@@ -208,3 +203,5 @@ export default ({ width = 32, height = 9, scale = 32 }) => {
     </svg>
   )
 }
+
+export default Graph

--- a/packages/docs/src/components/layout.js
+++ b/packages/docs/src/components/layout.js
@@ -100,51 +100,51 @@ export default (props) => {
         <Box
           sx={{
             flex: '1 1 auto',
+            display: ['block', 'flex'],
           }}>
           <div
-            sx={{
-              display: ['block', 'flex'],
+            ref={nav}
+            role="navigation"
+            onFocus={(e) => {
+              setMenuOpen(true)
+            }}
+            onBlur={(e) => {
+              setMenuOpen(false)
+            }}
+            onClick={(e) => {
+              setMenuOpen(false)
+            }}
+            onKeyPress={(e) => {
+              setMenuOpen(false)
             }}>
-            <div
-              ref={nav}
-              onFocus={(e) => {
-                setMenuOpen(true)
-              }}
-              onBlur={(e) => {
-                setMenuOpen(false)
-              }}
-              onClick={(e) => {
-                setMenuOpen(false)
-              }}>
-              <Sidebar
-                open={menuOpen}
-                components={sidebar}
-                pathname={props.location.pathname}
-                sx={{
-                  display: [null, fullwidth ? 'none' : 'block'],
-                  width: 256,
-                  flex: 'none',
-                  px: 3,
-                  pt: 3,
-                  pb: 4,
-                  mt: [64, 0],
-                }}
-              />
-            </div>
-            <main
-              id="content"
+            <Sidebar
+              open={menuOpen}
+              components={sidebar}
+              pathname={props.location.pathname}
               sx={{
-                width: '100%',
-                minWidth: 0,
-                maxWidth: fullwidth ? 'none' : 768,
-                mx: 'auto',
-                px: fullwidth ? 0 : 3,
-              }}>
-              {props.children}
-              <EditLink />
-              {!fullwidth && <Pagination />}
-            </main>
+                display: [null, fullwidth ? 'none' : 'block'],
+                width: 256,
+                flex: 'none',
+                px: 3,
+                pt: 3,
+                pb: 4,
+                mt: [64, 0],
+              }}
+            />
           </div>
+          <main
+            id="content"
+            sx={{
+              width: '100%',
+              minWidth: 0,
+              maxWidth: fullwidth ? 'none' : 768,
+              mx: 'auto',
+              px: fullwidth ? 0 : 3,
+            }}>
+            {props.children}
+            <EditLink />
+            {!fullwidth && <Pagination />}
+          </main>
         </Box>
       </Flex>
     </Styled.root>

--- a/packages/docs/src/components/preset.js
+++ b/packages/docs/src/components/preset.js
@@ -37,11 +37,12 @@ export default ({ preset: presetName }) => {
           <MDXProvider components={components}>
             <Lorem />
           </MDXProvider>
-          <Styled.h2>Raw JSON</Styled.h2>
+          <Styled.h2 id="json">Raw JSON</Styled.h2>
           <textarea
             value={JSON.stringify(preset, null, 2)}
             rows={16}
             readOnly
+            aria-labelledby="json"
             sx={{
               width: '100%',
               fontFamily: 'monospace',

--- a/packages/docs/src/components/presets-demo.js
+++ b/packages/docs/src/components/presets-demo.js
@@ -34,12 +34,14 @@ export default () => {
           },
         }}>
         <label
+          htmlFor="theme"
           sx={{
             display: 'block',
             mb: 4,
           }}>
-          Preset:{' '}
+          Preset:
           <Select
+            id="theme"
             value={theme}
             onChange={(e) => {
               setTheme(e.target.value)
@@ -69,11 +71,12 @@ export default () => {
             <MDXProvider components={components}>
               <Lorem />
             </MDXProvider>
-            <Styled.h2>Raw JSON</Styled.h2>
+            <Styled.h2 id="json">Raw JSON</Styled.h2>
             <textarea
               value={JSON.stringify(preset, null, 2)}
               rows={16}
               readOnly
+              aria-labelledby="json"
               sx={{
                 width: '100%',
                 fontFamily: 'monospace',

--- a/packages/docs/src/pages/customize.js
+++ b/packages/docs/src/pages/customize.js
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { jsx, Styled, ThemeProvider, Grid } from 'theme-ui'
+import { jsx, Styled, Grid } from 'theme-ui'
 import {
   EditorProvider,
   Theme,
@@ -21,8 +21,8 @@ import Button from '../components/button'
 
 const reducer = (state, next) => merge({}, state, next)
 
-export default props => {
-  const [theme, setTheme] = useReducer(reducer, { ...presets.base })
+export default (props) => {
+  const [theme] = useReducer(reducer, { ...presets.base })
   const json = stringify(theme, { indent: '  ' })
 
   return (
@@ -83,7 +83,7 @@ export default props => {
         <p>Note: some web fonts may not render unless installed locally.</p>
       </EditorProvider>
       <Button
-        onClick={e => {
+        onClick={(e) => {
           copy(json)
         }}>
         Copy Theme

--- a/packages/docs/src/pages/random.js
+++ b/packages/docs/src/pages/random.js
@@ -91,11 +91,12 @@ export default () => {
             <MDXProvider components={components}>
               <Lorem />
             </MDXProvider>
-            <Styled.h2>Raw JSON</Styled.h2>
+            <Styled.h2 id="json">Raw JSON</Styled.h2>
             <textarea
               value={JSON.stringify(theme, null, 2)}
               rows={16}
               readOnly
+              aria-labelledby="json"
               css={{
                 width: '100%',
                 fontFamily: 'monospace',


### PR DESCRIPTION
![E58F3CAE-6B41-4A82-9094-ABF0CD72B12C](https://user-images.githubusercontent.com/5074763/90053032-f23db180-dca7-11ea-8613-51f4e92f5c61.jpeg)

Working on the docs, 11 console warnings always print out, so this PR fixes 9 of them!

- One remaining one is the events on noninteractive elements; I spent awhile researching & I can’t find a solution that doesn’t worsen accessibility to make the warning go away
- The other remaining one seems to be [a bug in the library](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/477), reporting that the `<option>` tags inside a `<select>` aren’t labeled (but they are)