### PR TITLE
Fix small typo in 'sketchy' line

### DIFF
--- a/packages/presets/README.md
+++ b/packages/presets/README.md
@@ -36,7 +36,7 @@ Currently, the following presets are available for use:
 - [`bootstrap`](https://theme-ui.com/presets/bootstrap)
 - [`bulma`](https://theme-ui.com/presets/bulma) (WIP)
 - [`tailwind`](https://theme-ui.com/presets/tailwind)
-- `sketchy`: [Demo webiste](https://themeui-sketchy.netlify.app/), [Theme UI docs](https://theme-ui.com/presets/sketchy)
+- [`sketchy`](https://theme-ui.com/presets/sketchy), [Demo website](https://themeui-sketchy.netlify.app/)
 
 ## Contributing
 


### PR DESCRIPTION
And also bring 'sketchy' theme in line with other preset examples (theme name takes you to its docs). 