### PR TITLE
fix: opt out of typechecking styled.X when `as` prop is given

### DIFF
--- a/packages/mdx/src/index.ts
+++ b/packages/mdx/src/index.ts
@@ -98,7 +98,7 @@ export type WithPoorAsProp<
 } & (As extends undefined ? Props : { [key: string]: unknown })
 
 export interface ThemedComponent<Name extends ElementType> {
-  <As extends ElementType | undefined>(
+  <As extends ElementType | undefined = undefined>(
     props: WithPoorAsProp<ComponentProps<Name>, As>
   ): JSX.Element
 }

--- a/packages/mdx/src/index.ts
+++ b/packages/mdx/src/index.ts
@@ -90,12 +90,16 @@ export const themed = (key: StyledComponentName) => (props: ThemedProps) =>
   css(get(props.theme, `styles.${key}`))(props.theme)
 
 // opt out of typechecking whenever `as` prop is used
+interface AnyComponentProps extends JSX.IntrinsicAttributes {
+    [key: string]: unknown
+}
+
 export type WithPoorAsProp<
   Props,
   As extends ElementType | undefined = undefined
 > = {
   as?: As
-} & (As extends undefined ? Props : { [key: string]: unknown })
+} & (As extends undefined ? Props : AnyComponentProps)
 
 export interface ThemedComponent<Name extends ElementType> {
   <As extends ElementType | undefined = undefined>(

--- a/packages/mdx/test/index.tsx
+++ b/packages/mdx/test/index.tsx
@@ -63,6 +63,7 @@ test('components with `as` prop receive all props', () => {
 
 test('cleans up style props', () => {
   const json = renderJSON(
+    // @ts-expect-error
     <Styled.h1 mx={2} id="test">
       Hello
     </Styled.h1>
@@ -112,5 +113,44 @@ test('keys of components match snapshot', () => {
       "div",
       "root",
     ]
+  `)
+})
+
+test('opt out of typechecking props whenever `as` prop is used', () => {
+  expect(
+    renderJSON(
+      <div>
+        {/* no error */}
+        <Styled.img
+          as="button"
+          src={2}
+          onClick={(_event) => {
+            // @ts-ignore todo: this fails in tests, but it shouldn't.
+            _event.x = 2
+          }}
+        />
+        <Styled.img
+          // @ts-expect-error Type 'number' is not assignable to type 'string'.ts(2322)
+          src={2}
+          onClick={(_event) => {
+            // @ts-expect-error Property 'y' does not exist on type 'MouseEvent<HTMLImageElement, MouseEvent>'.ts(2339)
+            _event.y = 2
+          }}
+        />
+      </div>
+    )
+  ).toMatchInlineSnapshot(`
+    <div>
+      <button
+        className="emotion-0"
+        onClick={[Function]}
+        src={2}
+      />
+      <img
+        className="emotion-0"
+        onClick={[Function]}
+        src={2}
+      />
+    </div>
   `)
 })


### PR DESCRIPTION
The type definition for `ThemedComponent` was missing a default ` = undefined`.

This fixes a bug for TS users in 0.4.0-rc.3.

`AnyComponentProps` is a fix for props spreading bug we have, i.e. one can't spread `props: ComponentPropsWithoutRef<typeof Styled.p>` onto `Styled.p`. It can be worked around with `ComponentPropsWithoutRef<"p">`, but it's still inconvenient. 