### PR TITLE
fix: Use default export from package instead of named export version

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,12 +6,14 @@ import {
 import { css, Theme } from '@theme-ui/css'
 import * as React from 'react'
 import deepmerge from 'deepmerge'
-import { version as __EMOTION_VERSION__ } from '@emotion/core/package.json'
+import packageInfo from '@emotion/core/package.json'
 
 import './react-jsx'
 
 export * from '@theme-ui/css/dist/types'
 export * from './types'
+
+const __EMOTION_VERSION__ = packageInfo.version
 
 const getCSS = (props) => {
   if (!props.sx && !props.css) return undefined

--- a/packages/theme-ui/test/color-modes.tsx
+++ b/packages/theme-ui/test/color-modes.tsx
@@ -4,9 +4,10 @@ import renderer from 'react-test-renderer'
 import { render, fireEvent, cleanup, act } from '@testing-library/react'
 import { matchers } from 'jest-emotion'
 import mockConsole from 'jest-mock-console'
-import { version as emotionVersion } from '@emotion/core/package.json'
+import packageInfo from '@emotion/core/package.json'
 import { jsx, ThemeProvider, useColorMode, useThemeUI } from '../src/index'
 
+const emotionVersion = packageInfo.version
 const STORAGE_KEY = 'theme-ui-color-mode'
 
 afterEach(cleanup)


### PR DESCRIPTION
Fix #1097 