### PR TITLE
chore(docs): fix typo in gatsby config example

### DIFF
--- a/packages/gatsby-plugin-theme-ui/README.md
+++ b/packages/gatsby-plugin-theme-ui/README.md
@@ -33,12 +33,14 @@ The theme module you include in options is considered your base theme. Any furth
 // gatsby-config.js
 module.exports = {
   plugins: [
-    { resolve: 'gatsby-plugin-theme-ui',
+    {
+      resolve: 'gatsby-plugin-theme-ui',
       options: {
-        prismPreset: 'night-owl'
-        preset: '@theme-ui/preset-funk'
-      }
-    }],
+        prismPreset: 'night-owl',
+        preset: '@theme-ui/preset-funk',
+      },
+    },
+  ],
 }
 ```
 


### PR DESCRIPTION
This part of the documentation has invalid javascript. This change fixes it and formats it more consistently with the other code snippets.