### PR TITLE
fix(docs): Fix example logo on Avatar & Image component docs

### DIFF
--- a/packages/docs/src/components/code.js
+++ b/packages/docs/src/components/code.js
@@ -42,7 +42,7 @@ const images = {
   flatiron:
     'https://images.unsplash.com/photo-1520222984843-df35ebc0f24d?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=1080&fit=max&ixid=eyJhcHBfaWQiOjF9',
   logo:
-    'https://contrast.now.sh/fff/000?text=UI&size=96&fontSize=1.5&baseline=1',
+    'https://logo.clearbit.com/gatsbyjs.com',
 }
 
 const scope = {


### PR DESCRIPTION
Closes #1222. https://contrast.now.sh/ seems to have disappeared :(