### PR TITLE
Pass size prop down to IconButton

### DIFF
--- a/packages/components/src/Close.js
+++ b/packages/components/src/Close.js
@@ -15,6 +15,7 @@ const x = (
 export const Close = React.forwardRef(({ size = 32, ...props }, ref) => (
   <IconButton
     ref={ref}
+    size={size}
     title="Close"
     aria-label="Close"
     variant="close"


### PR DESCRIPTION
Close and IconButton both accept the size prop, but it's not pass down.