### PR TITLE
fix: field component should use id if passed

### DIFF
--- a/packages/components/src/Field.js
+++ b/packages/components/src/Field.js
@@ -5,11 +5,18 @@ import { Input } from './Input'
 import { getMargin, omitMargin } from './util'
 
 export const Field = React.forwardRef(
-  ({ as: Control = Input, label, name, ...props }, ref) => {
+  ({ as: Control = Input, label, id, name, ...props }, ref) => {
+    const fieldIdentifier = id || name
+
     return (
       <Box {...getMargin(props)}>
-        <Label htmlFor={name}>{label}</Label>
-        <Control ref={ref} id={name} name={name} {...omitMargin(props)} />
+        <Label htmlFor={fieldIdentifier}>{label}</Label>
+        <Control
+          ref={ref}
+          id={fieldIdentifier}
+          name={name}
+          {...omitMargin(props)}
+        />
       </Box>
     )
   }

--- a/packages/components/test/__snapshots__/index.js.snap
+++ b/packages/components/test/__snapshots__/index.js.snap
@@ -545,6 +545,56 @@ exports[`Field renders 1`] = `
 </div>
 `;
 
+exports[`Field renders with id prop 1`] = `
+.emotion-0 {
+  box-sizing: border-box;
+  margin: 0;
+  min-width: 0;
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-1 {
+  box-sizing: border-box;
+  margin: 0;
+  min-width: 0;
+  display: block;
+  width: 100%;
+  padding: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  font-size: inherit;
+  line-height: inherit;
+  border: 1px solid;
+  border-radius: 4px;
+  color: inherit;
+  background-color: transparent;
+}
+
+.emotion-2 {
+  box-sizing: border-box;
+  margin: 0;
+  min-width: 0;
+}
+
+<div
+  className="emotion-2"
+>
+  <label
+    className="emotion-0"
+    htmlFor="test-field"
+  />
+  <input
+    className="emotion-1"
+    id="test-field"
+  />
+</div>
+`;
+
 exports[`Flex renders 1`] = `
 .emotion-0 {
   box-sizing: border-box;

--- a/packages/components/test/index.js
+++ b/packages/components/test/index.js
@@ -388,6 +388,14 @@ describe('Field', () => {
     )
     expect(json).toMatchSnapshot()
   })
+  test('renders with id prop', () => {
+    const json = renderJSON(
+      <ThemeProvider theme={theme}>
+        <Field id="test-field" />
+      </ThemeProvider>
+    )
+    expect(json).toMatchSnapshot()
+  })
 })
 
 describe('Progress', () => {


### PR DESCRIPTION
Sometimes a field name is not unique enough. This PR allows passing an id to the field and the related label `htmlFor`