### PR TITLE
fix: min-content on checkbox root

### DIFF
--- a/packages/components/src/Checkbox.js
+++ b/packages/components/src/Checkbox.js
@@ -39,7 +39,7 @@ const CheckboxIcon = (props) => (
 
 export const Checkbox = React.forwardRef(
   ({ className, sx, variant = 'checkbox', children, ...props }, ref) => (
-    <Box>
+    <Box sx={{ minWidth: 'min-content' }}>
       <Box
         ref={ref}
         as="input"

--- a/packages/components/src/Radio.js
+++ b/packages/components/src/Radio.js
@@ -39,7 +39,7 @@ const RadioIcon = (props) => (
 
 export const Radio = React.forwardRef(
   ({ className, sx, variant = 'radio', ...props }, ref) => (
-    <Box>
+    <Box sx={{ minWidth: 'min-content' }}>
       <Box
         ref={ref}
         as="input"

--- a/packages/components/test/__snapshots__/index.js.snap
+++ b/packages/components/test/__snapshots__/index.js.snap
@@ -227,12 +227,6 @@ exports[`Card renders 1`] = `
 `;
 
 exports[`Checkbox renders 1`] = `
-.emotion-3 {
-  box-sizing: border-box;
-  margin: 0;
-  min-width: 0;
-}
-
 .emotion-0 {
   box-sizing: border-box;
   margin: 0;
@@ -243,6 +237,15 @@ exports[`Checkbox renders 1`] = `
   width: 1px;
   height: 1px;
   overflow: hidden;
+}
+
+.emotion-3 {
+  box-sizing: border-box;
+  margin: 0;
+  min-width: 0;
+  min-width: -webkit-min-content;
+  min-width: -moz-min-content;
+  min-width: min-content;
 }
 
 .emotion-1 {

--- a/packages/components/test/__snapshots__/index.js.snap
+++ b/packages/components/test/__snapshots__/index.js.snap
@@ -227,6 +227,15 @@ exports[`Card renders 1`] = `
 `;
 
 exports[`Checkbox renders 1`] = `
+.emotion-3 {
+  box-sizing: border-box;
+  margin: 0;
+  min-width: 0;
+  min-width: -webkit-min-content;
+  min-width: -moz-min-content;
+  min-width: min-content;
+}
+
 .emotion-0 {
   box-sizing: border-box;
   margin: 0;
@@ -237,15 +246,6 @@ exports[`Checkbox renders 1`] = `
   width: 1px;
   height: 1px;
   overflow: hidden;
-}
-
-.emotion-3 {
-  box-sizing: border-box;
-  margin: 0;
-  min-width: 0;
-  min-width: -webkit-min-content;
-  min-width: -moz-min-content;
-  min-width: min-content;
 }
 
 .emotion-1 {
@@ -996,6 +996,9 @@ exports[`Radio renders 1`] = `
   box-sizing: border-box;
   margin: 0;
   min-width: 0;
+  min-width: -webkit-min-content;
+  min-width: -moz-min-content;
+  min-width: min-content;
 }
 
 .emotion-0 {


### PR DESCRIPTION
Adding `min-content` as `minWidth` to checkbox root element prevents clipping on narrow width parents.﻿
