### PR TITLE
feat(color-modes): Add configuration option for printing color mode

### DIFF
--- a/packages/color-modes/src/custom-properties.ts
+++ b/packages/color-modes/src/custom-properties.ts
@@ -13,6 +13,7 @@ const numberScales = {
 const reservedKeys = {
   useCustomProperties: true,
   initialColorModeName: true,
+  printColorModeName: true,
   initialColorMode: true,
   useLocalStorage: true,
 }
@@ -78,14 +79,23 @@ export const createColorStyles = (theme: Theme = {}) => {
       },
     })(theme)
   }
-  const { colors } = theme
+  const { colors, initialColorModeName, printColorModeName } = theme
   const modes = colors.modes || {}
   const styles = objectToVars('colors', colors)
 
-  Object.keys(modes).forEach((mode) => {
+  Object.keys(modes).forEach(mode => {
     const key = `&.theme-ui-${mode}`
     styles[key] = objectToVars('colors', modes[mode])
   })
+
+  if (printColorModeName) {
+    const mode =
+      printColorModeName === 'initial' ||
+      printColorModeName === initialColorModeName
+        ? colors
+        : modes[printColorModeName]
+    styles['@media (print)'] = objectToVars('colors', mode)
+  }
 
   return css({
     body: {

--- a/packages/color-modes/test/custom-properties.tsx
+++ b/packages/color-modes/test/custom-properties.tsx
@@ -70,4 +70,69 @@ describe('createColorStyles', () => {
       },
     })
   })
+
+  test('creates styles for print color mode', () => {
+    const styles = createColorStyles({
+      printColorModeName: 'light',
+      colors: {
+        text: 'white',
+        background: 'tomato',
+        modes: {
+          light: {
+            text: 'tomato',
+            background: 'white',
+          },
+        },
+      },
+    })
+    expect(styles).toEqual({
+      body: {
+        color: 'white',
+        backgroundColor: 'tomato',
+        '--theme-ui-colors-text': 'white',
+        '--theme-ui-colors-background': 'tomato',
+        '&.theme-ui-light': {
+          '--theme-ui-colors-text': 'tomato',
+          '--theme-ui-colors-background': 'white',
+        },
+        '@media (print)': {
+          '--theme-ui-colors-text': 'tomato',
+          '--theme-ui-colors-background': 'white',
+        },
+      },
+    })
+  })
+
+  test('creates styles for initial print color mode', () => {
+    const styles = createColorStyles({
+      initialColorModeName: 'tomato',
+      printColorModeName: 'tomato',
+      colors: {
+        text: 'tomato',
+        background: 'white',
+        modes: {
+          dark: {
+            text: 'white',
+            background: 'black',
+          },
+        },
+      },
+    })
+    expect(styles).toEqual({
+      body: {
+        color: 'tomato',
+        backgroundColor: 'white',
+        '--theme-ui-colors-text': 'tomato',
+        '--theme-ui-colors-background': 'white',
+        '&.theme-ui-dark': {
+          '--theme-ui-colors-text': 'white',
+          '--theme-ui-colors-background': 'black',
+        },
+        '@media (print)': {
+          '--theme-ui-colors-text': 'tomato',
+          '--theme-ui-colors-background': 'white',
+        },
+      },
+    })
+  })
 })

--- a/packages/css/src/types.ts
+++ b/packages/css/src/types.ts
@@ -618,6 +618,11 @@ export interface Theme {
   initialColorModeName?: string
 
   /**
+   * Provide a value here to set a color mode for printing
+   */
+  printColorModeName?: string
+
+  /**
    * Adds styles defined in theme.styles.root to the <body> element along with color and background-color
    */
   useBodyStyles?: boolean

--- a/packages/docs/src/pages/color-modes.mdx
+++ b/packages/docs/src/pages/color-modes.mdx
@@ -2,7 +2,6 @@
 title: Color Modes
 ---
 
-
 # Color Modes
 
 Color modes can be used to create a user-configurable _dark mode_ or any number of other color modes.
@@ -66,9 +65,7 @@ import { ThemeProvider } from 'theme-ui'
 import theme from './theme'
 
 export default props => (
-  <ThemeProvider theme={theme}>
-    {props.children}
-  </ThemeProvider>
+  <ThemeProvider theme={theme}>{props.children}</ThemeProvider>
 )
 ```
 
@@ -155,6 +152,35 @@ To disable `localStorage` add the `useLocalStorage: false` flag to your theme.
 ```js
 {
   useLocalStorage: false,
+  colors: {
+    text: '#000',
+    background: '#fff',
+    modes: {
+      dark: {
+        text: '#fff',
+        background: '#000',
+      }
+    }
+  }
+}
+```
+
+### Set a custom color mode for printing
+
+By default, when printing a webpage, browsers will use the current color mode
+enabled. (This means if a user is currently using a dark or colored-background
+mode, their printed page will share that styling). If you’d like to set a color
+mode to be used on printing, set that color mode with the configuration option
+`printColorModeName`, set to one of your `colors.modes` names, the
+`initialColorModeName` value, or the string `'initial'`.
+
+This option sets your color mode in the `@media (print)` media query, so there’s no
+additional client-side JavaScript for printing.
+
+```js
+{
+  initialColorModeName: 'light',
+  printColorModeName: 'light',
   colors: {
     text: '#000',
     background: '#fff',


### PR DESCRIPTION
Closes #1144, adding a configuration option `printColorModeName` for setting a color mode to be used in `@media (print)` (so users don’t print out in dark mode). By using the media query & custom properties, there’s no client-side JavaScript event listeners, so it should work even on a static-exported site.

PR includes updated TypeScript type, documentation, & two tests.