### PR TITLE
fix(tests): Add babel-preset-gatsby to fix testing issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@types/lodash.merge": "^4.6.6",
     "@types/react-test-renderer": "^16.9.2",
     "babel-jest": "^26.0.1",
+    "babel-preset-gatsby": "^0.6.0",
     "husky": ">=4.0.7",
     "jest": "^26.0.1",
     "jest-canvas-mock": "^2.2.0",


### PR DESCRIPTION
#1249 & #1267, as well as the latest commit on master, have failing tests due to the missing `babel-preset-gatsby` package. There are still more failing tests, but this gets us closer.