### PR TITLE
(docs): Add documentation on CSS keyframes

### DIFF
--- a/packages/docs/src/pages/guides/keyframes.mdx
+++ b/packages/docs/src/pages/guides/keyframes.mdx
@@ -1,0 +1,69 @@
+---
+title: 'Keyframes'
+---
+
+# CSS Keyframes
+
+Using keyframes with Theme UI is fully supported, but not part of the Theme UI
+library itself. Instead, use [the `keyframes` helper from Emotion](https://emotion.sh/docs/keyframes).
+
+## Usage
+
+1. `import { keyframes } from '@emotion/core'`
+2. Create a variable using `keyframes` for your animation (examples below)
+3. Use the variable as the animation name, in an `animation` or `animationName`
+   declaration
+
+<Note>
+
+Because `@emotion/core` is a dependency of Theme UI, it’s available in your
+project without manual installation. Installing it separately can cause configuration issues due to
+multiple copies with conflicting versions.
+
+</Note>
+
+## Examples
+
+Using object syntax:
+
+```js
+import { Box } from 'theme-ui'
+import { keyframes } from '@emotion/core'
+
+const fadeIn = keyframes({ from: { opacity: 0 }, to: { opacity: 1 } })
+
+export default props => (
+  <Box
+    {...props}
+    sx={{
+      animationName: fadeIn,
+      animationDuration: '1s',
+      animationFillMode: 'backwards',
+    }}
+  />
+)
+```
+
+Using template literal syntax:
+
+```js
+/** @jsx jsx */
+import { jsx } from 'theme-ui'
+import { keyframes } from '@emotion/core'
+
+const wave = keyframes`
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(-5deg);
+  }
+`
+
+export default props => (
+  <div
+    {...props}
+    sx={{ animation: `${wave} 0.5s linear infinite alternate` }}
+  />
+)
+```

--- a/packages/docs/src/sidebar.mdx
+++ b/packages/docs/src/sidebar.mdx
@@ -72,6 +72,7 @@
   - [Object Styles](/guides/object-styles)
   - [Variants](/guides/variants)
   - [Layouts](/guides/layouts)
+  - [Keyframes](/guides/keyframes)
   - [Styled Components](/guides/styled-components)
   - [MDX Layout Components](/guides/mdx-layout-components)
   - [Responsive Typography](/guides/responsive-typography)


### PR DESCRIPTION
Closes #656, adding a documentation page on using `@emotion/core` for CSS keyframe animations with examples.