### PR TITLE
fix: sx variant responsive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.5.0 UNRELEASED
 
+- Fix sx prop variant responsive. Issue: #1030
 ## v0.5.0-alpha.0 2020-11-20
 
 - BREAKING: Upgrade to Emotion 11, and `csstype` 3. PR #1261

--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -262,11 +262,10 @@ const responsive = (
         continue
       }
       next[media] = next[media] || {}
-      if (value[i] == null) continue
-      ;(next[media] as Record<string, any>)[key] = value[i]
+      if (value[i] == null) continue;
+      (next[media] as Record<string, any>)[key] = value[i]
     }
   }
-
   return next
 }
 
@@ -280,18 +279,17 @@ export const css = (args: ThemeUIStyleObject = {}) => (
     ...('theme' in props ? props.theme : props),
   }
   let result: CSSObject = {}
-  const obj = typeof args === 'function' ? args(theme) : args
+  let obj = typeof args === 'function' ? args(theme) : args
+  // insert variant props before responsive styles, so they can be merged
+  if (obj['variant']) {
+    obj = { ...obj, ...get(theme, obj['variant']) }
+    delete obj['variant'];
+  }
   const styles = responsive(obj)(theme)
 
   for (const key in styles) {
     const x = styles[key as keyof typeof styles]
     const val = typeof x === 'function' ? x(theme) : x
-
-    if (key === 'variant') {
-      const variant = css(get(theme, val as string))(theme)
-      result = { ...result, ...variant }
-      continue
-    }
 
     if (val && typeof val === 'object') {
       // TODO: val can also be an array here. Is this a bug? Can it be reproduced?

--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -282,7 +282,7 @@ export const css = (args: ThemeUIStyleObject = {}) => (
   let obj = typeof args === 'function' ? args(theme) : args
   // insert variant props before responsive styles, so they can be merged
   if (obj['variant']) {
-    obj = { ...obj, ...get(theme, obj['variant']) }
+    obj = { ...get(theme, obj['variant']), ...obj }
     delete obj['variant'];
   }
   const styles = responsive(obj)(theme)


### PR DESCRIPTION
issue: #1030

when a variant was used as an sx prop, its values were merged **after** applying responsive mods. This PR moves the variant props merging **before** applying responsive.

The original issue: https://codesandbox.io/s/nameless-sun-hspem-hspem?file=/src/App.js
After the fix (slightly modified): https://theme-ui-responsive-variants.netlify.app

I have seen some other similar issues related to responsive if you guys can check if they are being addressed with the PR @lachlanjc @hasparus 