### PR TITLE
(docs): Update sx page with full properties list

### DIFF
--- a/packages/docs/src/pages/sx-prop.mdx
+++ b/packages/docs/src/pages/sx-prop.mdx
@@ -52,36 +52,109 @@ Property  | Theme Key
 `lineHeight` | `lineHeights`
 `letterSpacing` | `letterSpacings`
 `color` | `colors`
-`backgroundColor`, `bg` | `colors`
+`bg`, `backgroundColor` | `colors`
+`borderColor` | `colors`
+`caretColor` | `colors`
+`columnRuleColor` | `colors`
+`outlineColor` | `colors`
 `opacity` | `opacities`
 `transition` | `transitions`
-`margin`, `m` | `space`
-`marginTop`, `mt` | `space`
-`marginRight`, `mr` | `space`
-`marginBottom`, `mb` | `space`
-`marginLeft`, `ml` | `space`
-`marginX`, `mx` | `space`
-`marginY`, `my` | `space`
-`padding`, `p` | `space`
-`paddingTop`, `pt` | `space`
-`paddingRight`, `pr` | `space`
-`paddingBottom`, `pb` | `space`
-`paddingLeft`, `pl` | `space`
-`paddingX`, `px` | `space`
-`paddingY`, `py` | `space`
+`m`, `margin` | `space`
+`mt`, `marginTop` | `space`
+`mr`, `marginRight` | `space`
+`mb`, `marginBottom` | `space`
+`ml`, `marginLeft` | `space`
+`mx`, `marginX` | `space`
+`my`, `marginY` | `space`
+`marginBlock` | `space`
+`marginBlockEnd` | `space`
+`marginBlockStart` | `space`
+`marginInline` | `space`
+`marginInlineEnd` | `space`
+`marginInlineStart` | `space`
+`p`, `padding` | `space`
+`pt`, `paddingTop` | `space`
+`pr`, `paddingRight` | `space`
+`pb`, `paddingBottom` | `space`
+`pl`, `paddingLeft` | `space`
+`px`, `paddingX` | `space`
+`py`, `paddingY` | `space`
+`paddingBlock` | `space`
+`paddingBlockEnd` | `space`
+`paddingBlockStart` | `space`
+`paddingInline` | `space`
+`paddingInlineEnd` | `space`
+`paddingInlineStart` | `space`
+`scrollPadding` | `space`
+`scrollPaddingTop` | `space`
+`scrollPaddingRight` | `space`
+`scrollPaddingBottom` | `space`
+`scrollPaddingLeft` | `space`
+`scrollPaddingX` | `space`
+`scrollPaddingY` | `space`
+`inset` | `space`
+`insetBlock` | `space`
+`insetBlockEnd` | `space`
+`insetBlockStart` | `space`
+`insetInline` | `space`
+`insetInlineEnd` | `space`
+`insetInlineStart` | `space`
 `top` | `space`
+`right` | `space`
 `bottom` | `space`
 `left` | `space`
-`right` | `space`
+`gridGap` | `space`
+`gridColumnGap` | `space`
+`gridRowGap` | `space`
+`gap` | `space`
+`columnGap` | `space`
+`rowGap` | `space`
 `border` | `borders`
 `borderTop` | `borders`
 `borderRight` | `borders`
 `borderBottom` | `borders`
 `borderLeft` | `borders`
-`borderColor` | `colors`
 `borderWidth` | `borderWidths`
 `borderStyle` | `borderStyles`
 `borderRadius` | `radii`
+`borderTopRightRadius` | `radii`
+`borderTopLeftRadius` | `radii`
+`borderBottomRightRadius` | `radii`
+`borderBottomLeftRadius` | `radii`
+`borderTopWidth` | `borderWidths`
+`borderTopColor` | `colors`
+`borderTopStyle` | `borderStyles`
+`borderBottomWidth` | `borderWidths`
+`borderBottomColor` | `colors`
+`borderBottomStyle` | `borderStyles`
+`borderLeftWidth` | `borderWidths`
+`borderLeftColor` | `colors`
+`borderLeftStyle` | `borderStyles`
+`borderRightWidth` | `borderWidths`
+`borderRightColor` | `colors`
+`borderRightStyle` | `borderStyles`
+`borderBlock` | `borders`
+`borderBlockEnd` | `borders`
+`borderBlockEndStyle` | `borderStyles`
+`borderBlockEndWidth` | `borderWidths`
+`borderBlockStart` | `borders`
+`borderBlockStartStyle` | `borderStyles`
+`borderBlockStartWidth` | `borderWidths`
+`borderBlockStyle` | `borderStyles`
+`borderBlockWidth` | `borderWidths`
+`borderEndEndRadius` | `radii`
+`borderEndStartRadius` | `radii`
+`borderInline` | `borders`
+`borderInlineEnd` | `borders`
+`borderInlineEndStyle` | `borderStyles`
+`borderInlineEndWidth` | `borderWidths`
+`borderInlineStart` | `borders`
+`borderInlineStartStyle` | `borderStyles`
+`borderInlineStartWidth` | `borderWidths`
+`borderInlineStyle` | `borderStyles`
+`borderInlineWidth` | `borderWidths`
+`borderStartEndRadius` | `radii`
+`borderStartStartRadius` | `radii`
 `boxShadow` | `shadows`
 `textShadow` | `shadows`
 `zIndex` | `zIndices`
@@ -91,7 +164,14 @@ Property  | Theme Key
 `height` | `sizes`
 `minHeight` | `sizes`
 `maxHeight` | `sizes`
+`flexBasis` | `sizes`
 `size` | `sizes`
+`blockSize` | `sizes`
+`inlineSize` | `sizes`
+`maxBlockSize` | `sizes`
+`maxInlineSize` | `sizes`
+`minBlockSize` | `sizes`
+`minInlineSize` | `sizes`
 `fill` | `colors`
 `stroke` | `colors`
 


### PR DESCRIPTION
We certainly lose some readability with this change, making it harder to digest the list & find the most common ones since there are just so many properties. If anyone has suggestions for shortening this or an elegant way of truncating some (the block/inline/inset properties are not used by a lot of folks afaik), that’d be very welcome, but I think we should give a thorough list somewhere.