### PR TITLE
(dev): Set arrowParens in Prettier config

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,4 +5,5 @@ yarn.lock
 node_modules
 dist
 coverage
+examples/next/.next
 docs/src/pages/index.mdx

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -5,4 +5,5 @@ module.exports = {
   printWidth: 80,
   semi: false,
   jsxBracketSameLine: true,
+  arrowParens: 'always',
 }


### PR DESCRIPTION
Since this default is different across various versions of Prettier, we’ve all had a bunch of commits going both ways across various files. Setting this in our Prettier config so our diffs are smaller/easier to read/more consistent.