### PR TITLE
(mdx): Rename Styled component to Themed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0 UNRELEASED
+
+- BREAKING: Rename `Styled` component to `Themed`
+
 ## v0.5.0 UNRELEASED
 
 ## v0.5.0-alpha.2 2020-11-30

--- a/examples/codesandbox-starter/src/index.js
+++ b/examples/codesandbox-starter/src/index.js
@@ -2,15 +2,15 @@
 
 import ReactDOM from 'react-dom'
 import ThemeProvider, { Reset } from './theme'
-import { jsx, Layout, Styled } from 'theme-ui'
+import { jsx, Layout, Themed } from 'theme-ui'
 
 function App() {
   return (
     <ThemeProvider theme={{}}>
       <Layout sx={{ p: 3 }}>
         <Reset />
-        <Styled.h1 sx={{ color: 'primary', mb: 3 }}>Hello Theme UI</Styled.h1>
-        <Styled.p>Start editing to see some magic happen!</Styled.p>
+        <Themed.h1 sx={{ color: 'primary', mb: 3 }}>Hello Theme UI</Themed.h1>
+        <Themed.p>Start editing to see some magic happen!</Themed.p>
       </Layout>
     </ThemeProvider>
   )

--- a/examples/codesandbox-starter/src/theme.js
+++ b/examples/codesandbox-starter/src/theme.js
@@ -2,12 +2,12 @@
 
 import { Global } from '@emotion/react'
 import React, { memo } from 'react'
-import { jsx, useThemeUI, ThemeProvider, Styled } from 'theme-ui'
+import { jsx, useThemeUI, ThemeProvider, Themed } from 'theme-ui'
 import { base } from '@theme-ui/presets'
 
 const CustomThemeProvider = memo(({ children, ...props }) => (
   <ThemeProvider theme={base} {...props}>
-    <Styled.root>{children}</Styled.root>
+    <Themed.root>{children}</Themed.root>
   </ThemeProvider>
 ))
 

--- a/examples/create-react-app/src/App.js
+++ b/examples/create-react-app/src/App.js
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { jsx, ThemeProvider, Styled } from 'theme-ui'
+import { jsx, ThemeProvider, Themed } from 'theme-ui'
 import theme from './theme'
 
 // does not currently work with MDX v1
@@ -14,9 +14,8 @@ function App() {
           fontFamily: 'body',
           color: 'text',
           bg: 'background',
-        }}
-      >
-        <Styled.h1>Theme UI + Create React App</Styled.h1>
+        }}>
+        <Themed.h1>Theme UI + Create React App</Themed.h1>
       </div>
     </ThemeProvider>
   )

--- a/examples/custom-pragma/src/index.js
+++ b/examples/custom-pragma/src/index.js
@@ -1,9 +1,9 @@
 import React from 'react'
-import { ThemeProvider, Styled } from 'theme-ui'
+import { ThemeProvider, Themed } from 'theme-ui'
 import theme from './theme'
 
 export const wrapRootElement = ({ element }) => (
   <ThemeProvider theme={theme}>
-    <Styled.root>{element}</Styled.root>
+    <Themed.root>{element}</Themed.root>
   </ThemeProvider>
 )

--- a/examples/custom-pragma/src/pages/index.js
+++ b/examples/custom-pragma/src/pages/index.js
@@ -1,7 +1,7 @@
 /** @jsx jsx */
-import { jsx, Styled } from 'theme-ui'
+import { jsx, Themed } from 'theme-ui'
 
-export default props => (
+export default (props) => (
   <div
     css={{
       fontFamily: 'body',
@@ -11,19 +11,17 @@ export default props => (
       maxWidth: 768,
       px: 4,
       mx: 'auto',
-    }}
-  >
+    }}>
     <h1
       css={{
         fontSize: [4, 5, 6],
-      }}
-    >
+      }}>
       Custom JSX pragma example
     </h1>
     <p>
-      This page uses the Theme UI <Styled.code>css</Styled.code> prop with a
+      This page uses the Theme UI <Themed.code>css</Themed.code> prop with a
       custom JSX pragma that allows you to use theme-based values directly in
-      the <Styled.code>css</Styled.code> prop with no additional imports. You
+      the <Themed.code>css</Themed.code> prop with no additional imports. You
       can also use arrays as values to apply responsive styles to any CSS
       property.
     </p>

--- a/examples/dark-mode/src/index.js
+++ b/examples/dark-mode/src/index.js
@@ -1,9 +1,9 @@
 import React from 'react'
-import { ThemeProvider, Styled } from 'theme-ui'
+import { ThemeProvider, Themed } from 'theme-ui'
 import theme from './theme'
 
 export const wrapRootElement = ({ element }) => (
   <ThemeProvider theme={theme}>
-    <Styled.root>{element}</Styled.root>
+    <Themed.root>{element}</Themed.root>
   </ThemeProvider>
 )

--- a/examples/gatsby-plugin/src/layout.js
+++ b/examples/gatsby-plugin/src/layout.js
@@ -1,13 +1,13 @@
 /** @jsx jsx */
-import { jsx, Styled } from 'theme-ui'
+import { jsx, Themed } from 'theme-ui'
 
-export default props => (
-  <Styled.root>
+export default (props) => (
+  <Themed.root>
     <header>
       <h2>Theme UI Gatsby Example</h2>
     </header>
     <main>
       <div sx={{ fontFamily: 'body' }}>{props.children}</div>
     </main>
-  </Styled.root>
+  </Themed.root>
 )

--- a/examples/gatsby/src/index.tsx
+++ b/examples/gatsby/src/index.tsx
@@ -1,9 +1,9 @@
 import React, { FC, ReactNode } from 'react'
-import { ThemeProvider, Styled } from 'theme-ui'
+import { ThemeProvider, Themed } from 'theme-ui'
 import theme from './theme'
 
 export const wrapRootElement: FC<{ element: ReactNode }> = ({ element }) => (
   <ThemeProvider theme={theme}>
-    <Styled.root>{element}</Styled.root>
+    <Themed.root>{element}</Themed.root>
   </ThemeProvider>
 )

--- a/examples/next/pages/hello.js
+++ b/examples/next/pages/hello.js
@@ -1,6 +1,6 @@
 /** @jsxRuntime classic */
 /** @jsx jsx */
-import { jsx, Styled } from 'theme-ui'
+import { jsx, Themed } from 'theme-ui'
 
 export default () => (
   <div
@@ -9,6 +9,6 @@ export default () => (
       mx: 'auto',
       p: 3,
     }}>
-    <Styled.h1>Hello</Styled.h1>
+    <Themed.h1>Hello</Themed.h1>
   </div>
 )

--- a/examples/prism/src/index.js
+++ b/examples/prism/src/index.js
@@ -1,9 +1,9 @@
 import React from 'react'
-import { ThemeProvider, Styled } from 'theme-ui'
+import { ThemeProvider, Themed } from 'theme-ui'
 import theme from './theme'
 
 export const wrapRootElement = ({ element }) => (
   <ThemeProvider theme={theme}>
-    <Styled.root>{element}</Styled.root>
+    <Themed.root>{element}</Themed.root>
   </ThemeProvider>
 )

--- a/examples/typography/src/index.js
+++ b/examples/typography/src/index.js
@@ -1,9 +1,9 @@
 import React from 'react'
-import { ThemeProvider, Styled } from 'theme-ui'
+import { ThemeProvider, Themed } from 'theme-ui'
 import theme from './theme'
 
 export const wrapRootElement = ({ element }) => (
   <ThemeProvider theme={theme}>
-    <Styled.root>{element}</Styled.root>
+    <Themed.root>{element}</Themed.root>
   </ThemeProvider>
 )

--- a/packages/docs/src/components/code.js
+++ b/packages/docs/src/components/code.js
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { jsx, Styled, Text } from 'theme-ui'
+import { jsx, Themed, Text } from 'theme-ui'
 import Prism from '@theme-ui/prism'
 import { LiveProvider, LiveEditor, LivePreview, LiveError } from 'react-live'
 import * as themeUI from 'theme-ui'
@@ -97,13 +97,13 @@ export const LiveCode = ({ children, preview, xray }) => {
           }}
         />
       </div>
-      <Styled.pre
+      <Themed.pre
         sx={{
           mt: 0,
           mb: 3,
         }}>
         <LiveEditor padding={0} />
-      </Styled.pre>
+      </Themed.pre>
     </LiveProvider>
   )
 }

--- a/packages/docs/src/components/layout.js
+++ b/packages/docs/src/components/layout.js
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { jsx, Styled, useColorMode } from 'theme-ui'
+import { jsx, Themed, useColorMode } from 'theme-ui'
 import { useState, useRef } from 'react'
 import { Flex, Box } from '@theme-ui/components'
 import { AccordionNav } from '@theme-ui/sidenav'
@@ -53,7 +53,7 @@ export default (props) => {
   }
 
   return (
-    <Styled.root>
+    <Themed.root>
       <Head {...props} />
       <SkipLink>Skip to content</SkipLink>
       <Flex
@@ -102,7 +102,7 @@ export default (props) => {
             flex: '1 1 auto',
             alignItems: 'flex-start',
             display: ['block', 'flex'],
-            height: '100%'
+            height: '100%',
           }}>
           <Sidebar
             ref={nav}
@@ -149,6 +149,6 @@ export default (props) => {
           </main>
         </Box>
       </Flex>
-    </Styled.root>
+    </Themed.root>
   )
 }

--- a/packages/docs/src/components/preset.js
+++ b/packages/docs/src/components/preset.js
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { jsx, Styled, components } from 'theme-ui'
+import { jsx, Themed, components } from 'theme-ui'
 import { ThemeContext } from '@emotion/react'
 import { MDXProvider } from '@mdx-js/react'
 import * as presets from '@theme-ui/presets'
@@ -18,10 +18,10 @@ export default ({ preset: presetName }) => {
   return (
     <div>
       <ThemeContext.Provider value={preset}>
-        <Styled.root>
-          <Styled.h2>Colors</Styled.h2>
+        <Themed.root>
+          <Themed.h2>Colors</Themed.h2>
           <ColorPalette omit={['modes', 'header']} />
-          <Styled.h2>Typography</Styled.h2>
+          <Themed.h2>Typography</Themed.h2>
           <TypeStyle fontSize={7}>
             Body: <FontFamily name="body" />
           </TypeStyle>
@@ -32,12 +32,12 @@ export default ({ preset: presetName }) => {
             fontSize={7}>
             Heading: <FontFamily name="heading" />
           </HeadingStyle>
-          <Styled.h2>Type Scale</Styled.h2>
+          <Themed.h2>Type Scale</Themed.h2>
           <TypeScale />
           <MDXProvider components={components}>
             <Lorem />
           </MDXProvider>
-          <Styled.h2 id="json">Raw JSON</Styled.h2>
+          <Themed.h2 id="json">Raw JSON</Themed.h2>
           <textarea
             value={JSON.stringify(preset, null, 2)}
             rows={16}
@@ -51,7 +51,7 @@ export default ({ preset: presetName }) => {
               borderRadius: 4,
             }}
           />
-        </Styled.root>
+        </Themed.root>
       </ThemeContext.Provider>
     </div>
   )

--- a/packages/docs/src/components/presets-demo.js
+++ b/packages/docs/src/components/presets-demo.js
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { jsx, Styled, components } from 'theme-ui'
+import { jsx, Themed, components } from 'theme-ui'
 import { ThemeContext } from '@emotion/react'
 import { MDXProvider } from '@mdx-js/react'
 import { useState } from 'react'
@@ -52,10 +52,10 @@ export default () => {
           </Select>
         </label>
         <ThemeContext.Provider value={preset}>
-          <Styled.root sx={{ bg: 'background', color: 'text', p: 3 }}>
-            <Styled.h2>Colors</Styled.h2>
+          <Themed.root sx={{ bg: 'background', color: 'text', p: 3 }}>
+            <Themed.h2>Colors</Themed.h2>
             <ColorPalette omit={['modes', 'header']} />
-            <Styled.h2>Typography</Styled.h2>
+            <Themed.h2>Typography</Themed.h2>
             <TypeStyle fontSize={7}>
               Body: <FontFamily name="body" />
             </TypeStyle>
@@ -66,12 +66,12 @@ export default () => {
               fontSize={7}>
               Heading: <FontFamily name="heading" />
             </HeadingStyle>
-            <Styled.h2>Type Scale</Styled.h2>
+            <Themed.h2>Type Scale</Themed.h2>
             <TypeScale />
             <MDXProvider components={components}>
               <Lorem />
             </MDXProvider>
-            <Styled.h2 id="json">Raw JSON</Styled.h2>
+            <Themed.h2 id="json">Raw JSON</Themed.h2>
             <textarea
               value={JSON.stringify(preset, null, 2)}
               rows={16}
@@ -85,7 +85,7 @@ export default () => {
                 borderRadius: 4,
               }}
             />
-          </Styled.root>
+          </Themed.root>
         </ThemeContext.Provider>
       </div>
     </div>

--- a/packages/docs/src/components/theme-scales.js
+++ b/packages/docs/src/components/theme-scales.js
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
 import { scales, multiples } from '@theme-ui/css'
-import { Styled } from 'theme-ui'
+import { Themed } from 'theme-ui'
 
 const camelDash = (string) =>
   string.replace(/([A-Z])/g, (g) => `-${g[0].toLowerCase()}`)
@@ -25,7 +25,7 @@ export default (props) => {
   }, {})
 
   return (
-    <Styled.table>
+    <Themed.table>
       <thead>
         <tr>
           <th>Theme Key</th>
@@ -38,22 +38,22 @@ export default (props) => {
           .map((key) => (
             <tr>
               <td>
-                <Styled.inlineCode>{key}</Styled.inlineCode>
+                <Themed.inlineCode>{key}</Themed.inlineCode>
               </td>
               <td>
                 {table[key].map((property, index) => (
-                  <Styled.inlineCode>
+                  <Themed.inlineCode>
                     {!!index && ', '}
-                    <Styled.a
+                    <Themed.a
                       href={`https://developer.mozilla.org/en-US/docs/Web/CSS/${property}`}>
                       {property}
-                    </Styled.a>
-                  </Styled.inlineCode>
+                    </Themed.a>
+                  </Themed.inlineCode>
                 ))}
               </td>
             </tr>
           ))}
       </tbody>
-    </Styled.table>
+    </Themed.table>
   )
 }

--- a/packages/docs/src/components/typography-layout.js
+++ b/packages/docs/src/components/typography-layout.js
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { jsx, ThemeProvider, Flex, Styled } from 'theme-ui'
+import { jsx, ThemeProvider, Flex, Themed } from 'theme-ui'
 import { useState } from 'react'
 import { toTheme } from '@theme-ui/typography'
 import GoogleFonts from './google-fonts'
@@ -9,7 +9,7 @@ import typographyThemes from './typography-themes'
 
 const themeNames = Object.keys(themes)
 
-const ThemeSelect = props => (
+const ThemeSelect = (props) => (
   <div>
     <label
       htmlFor={props.name}
@@ -27,7 +27,7 @@ const ThemeSelect = props => (
         fontSize: 16,
         p: 2,
       }}>
-      {themeNames.map(name => (
+      {themeNames.map((name) => (
         <option key={name} label={name} value={name}>
           {name}
         </option>
@@ -36,7 +36,7 @@ const ThemeSelect = props => (
   </div>
 )
 
-export default props => {
+export default (props) => {
   const [themeName, setTheme] = useState(themeNames[0])
 
   const typographyTheme = typographyThemes[themeName]
@@ -55,7 +55,7 @@ export default props => {
         <ThemeSelect
           name="theme"
           value={themeName}
-          onChange={e => {
+          onChange={(e) => {
             setTheme(e.target.value)
           }}
         />
@@ -63,7 +63,7 @@ export default props => {
           sx={{
             ml: 2,
           }}
-          onClick={e => {
+          onClick={(e) => {
             const i = (themeNames.indexOf(themeName) + 1) % themeNames.length
             setTheme(themeNames[i])
           }}>
@@ -72,7 +72,7 @@ export default props => {
       </Flex>
       <ThemeProvider theme={theme}>
         <GoogleFonts />
-        <Styled.root>{props.children}</Styled.root>
+        <Themed.root>{props.children}</Themed.root>
       </ThemeProvider>
     </div>
   )

--- a/packages/docs/src/gatsby-theme-code-recipes/recipe.js
+++ b/packages/docs/src/gatsby-theme-code-recipes/recipe.js
@@ -1,17 +1,17 @@
 /** @jsx jsx */
-import { jsx, Styled } from 'theme-ui'
+import { jsx, Themed } from 'theme-ui'
 import { Link } from 'gatsby'
 
-export default props => (
+export default (props) => (
   <div>
     <div
       sx={{
         fontWeight: 'bold',
         mb: 3,
       }}>
-      <Styled.a as={Link} to="/recipes">
+      <Themed.a as={Link} to="/recipes">
         Recipes
-      </Styled.a>
+      </Themed.a>
       {' / '}
       <span>{props.name}</span>
     </div>

--- a/packages/docs/src/pages/api.mdx
+++ b/packages/docs/src/pages/api.mdx
@@ -141,7 +141,7 @@ css(styleObject)(theme)
 
 | Argument      | Type   | Description                                                                                          |
 | ------------- | ------ | ---------------------------------------------------------------------------------------------------- |
-| `styleObject` | Object | a theme-aware style object with support for responsive array values and Themed System prop shortcuts |
+| `styleObject` | Object | a theme-aware style object with support for responsive array values and Styled System prop shortcuts |
 | `theme`       | Object | the Emotion theming context object                                                                   |
 
 ### `get`

--- a/packages/docs/src/pages/api.mdx
+++ b/packages/docs/src/pages/api.mdx
@@ -89,15 +89,15 @@ The color mode state can be any string and should match the name of a color mode
 const [colorMode, setColorMode] = useColorMode()
 ```
 
-### `Styled`
+### `Themed`
 
-The [`Styled`](/styled) export is an object of Emotion styled components that map to keys in the `theme.styles` object.
+The [`Themed`](/themed) export is an object of Emotion styled components that map to keys in the `theme.styles` object.
 Each component will pick up styles from its corresponding theme object.
 These are primarily meant to be used as a mechanism to use styles defined in a `theme` object outside of MDX.
 
 ```jsx
 // picks up styles from `theme.styles.h1`
-<Styled.h1 />
+<Themed.h1 />
 ```
 
 | Prop | Type                | Description                             |
@@ -141,7 +141,7 @@ css(styleObject)(theme)
 
 | Argument      | Type   | Description                                                                                          |
 | ------------- | ------ | ---------------------------------------------------------------------------------------------------- |
-| `styleObject` | Object | a theme-aware style object with support for responsive array values and Styled System prop shortcuts |
+| `styleObject` | Object | a theme-aware style object with support for responsive array values and Themed System prop shortcuts |
 | `theme`       | Object | the Emotion theming context object                                                                   |
 
 ### `get`

--- a/packages/docs/src/pages/customize.js
+++ b/packages/docs/src/pages/customize.js
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { jsx, Styled, Grid } from 'theme-ui'
+import { jsx, Themed, Grid } from 'theme-ui'
 import {
   EditorProvider,
   Theme,
@@ -27,7 +27,7 @@ export default (props) => {
 
   return (
     <div>
-      <Styled.h1>Create a Custom Theme</Styled.h1>
+      <Themed.h1>Create a Custom Theme</Themed.h1>
       <EditorProvider theme={theme}>
         <b>Colors</b>
         <Theme.Colors size={64} />
@@ -88,7 +88,7 @@ export default (props) => {
         }}>
         Copy Theme
       </Button>
-      <Styled.pre
+      <Themed.pre
         children={json}
         sx={{
           maxHeight: 512,

--- a/packages/docs/src/pages/guides/responsive-typography.mdx
+++ b/packages/docs/src/pages/guides/responsive-typography.mdx
@@ -77,7 +77,7 @@ For example, with the following, the `fontSize` style will only apply at the sma
 ```
 
 ```jsx
-<Styled.h1
+<Themed.h1
   sx={{
     // styles for larger breakpoints will still apply
     // due to CSS specificity in media queries
@@ -90,14 +90,14 @@ For example, with the following, the `fontSize` style will only apply at the sma
 
 ## Non-MDX content
 
-The [`Styled`][] components can be used to pick up responsive styles outside of MDX,
+The [`Themed`][] components can be used to pick up responsive styles outside of MDX,
 but if you'd like to apply styles to other markdown or user generated content,
 you can use the `sx` prop with a variant to style child elements.
 What this does is take the entire `theme.styles` object, adds a scoped classname to the `<div>`,
 and injects CSS with child selectors based on the keys in `theme.styles`.
 
 ```jsx
-export default props => (
+export default (props) => (
   <div
     sx={{
       variant: 'styles',
@@ -107,17 +107,17 @@ export default props => (
 )
 ```
 
-Optionally, the `Styled.root` component can be used to set base styles within the `<div>`.
+Optionally, the `Themed.root` component can be used to set base styles within the `<div>`.
 
 ```jsx
-export default props => (
+export default (props) => (
   <div
     sx={{
       variant: 'styles',
     }}>
-    <Styled.root>{props.children}</Styled.root>
+    <Themed.root>{props.children}</Themed.root>
   </div>
 )
 ```
 
-[`styled`]: /styled
+[`themed`]: /themed

--- a/packages/docs/src/pages/recipes/index.js
+++ b/packages/docs/src/pages/recipes/index.js
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { jsx, Styled } from 'theme-ui'
+import { jsx, Themed } from 'theme-ui'
 import { graphql, Link } from 'gatsby'
 import { LiveCode } from '../../components/code'
 
@@ -33,9 +33,9 @@ const Card = ({ name, slug, snippets }) => {
         textDecoration: 'none',
         p: 2,
         borderRadius: 4,
-        boxShadow: t => `0 0 3px ${t.colors.darken}`,
+        boxShadow: (t) => `0 0 3px ${t.colors.darken}`,
         ':hover': {
-          boxShadow: t => `0 0 8px 1px ${t.colors.darken}`,
+          boxShadow: (t) => `0 0 8px 1px ${t.colors.darken}`,
         },
       }}>
       {props.live && (
@@ -62,12 +62,12 @@ const Card = ({ name, slug, snippets }) => {
   )
 }
 
-export default props => {
+export default (props) => {
   const recipes = props.data.recipes.nodes
 
   return (
     <div sx={{}}>
-      <Styled.h1>Recipes</Styled.h1>
+      <Themed.h1>Recipes</Themed.h1>
       <ul
         sx={{
           listStyle: 'none',
@@ -77,7 +77,7 @@ export default props => {
           gridGap: 4,
           gridTemplateColumns: 'repeat(auto-fit, minmax(256px, 1fr))',
         }}>
-        {recipes.map(r => (
+        {recipes.map((r) => (
           <li key={r.id}>
             <Card {...r} />
           </li>

--- a/packages/docs/src/pages/styling-mdx.mdx
+++ b/packages/docs/src/pages/styling-mdx.mdx
@@ -41,7 +41,7 @@ Any MDX document rendered as a child of the `ThemeProvider` will pick up the sty
 
 <Note>
 
-These styles will **not** apply to HTML elements used outside of MDX. To reuse these styles outside of MDX, see the [Styled component](/styled) docs.
+These styles will **not** apply to HTML elements used outside of MDX. To reuse these styles outside of MDX, see the [Themed component](/themed) docs.
 
 </Note>
 
@@ -85,7 +85,6 @@ Theme UI does not currently use colors from Typography.js.
 To support syntax highlighting libraries like [Prism.js][],
 colors and other styles can be added to `theme.styles.pre` to target child elements with class selectors.
 Prism.js adds `<span>` elements with class names that can be used as child selectors.
-
 
 To enable syntax highlighting in MDX, see the [`@theme-ui/prism`](/packages/prism) package.
 

--- a/packages/docs/src/pages/theme-spec.mdx
+++ b/packages/docs/src/pages/theme-spec.mdx
@@ -12,9 +12,9 @@ This specification is also intended to help ensure that themes created for Theme
 
 The theme object is made up of the following data types:
 
-- *Scales:* plain objects or arrays of values for related CSS properties
-- *Variants:* partial style objects that can be used for stylistic component variants or making part of an application themeable
-- *Styles:* a collection of styles for MDX content
+- _Scales:_ plain objects or arrays of values for related CSS properties
+- _Variants:_ partial style objects that can be used for stylistic component variants or making part of an application themeable
+- _Styles:_ a collection of styles for MDX content
 
 ## Theme Scales
 
@@ -106,7 +106,6 @@ Any undefined color keys in the nested color modes objects will fallback to valu
 
 </Note>
 
-
 ## Typography
 
 To ensure that themes built for Theme UI are as portable and interoperable as possible, the following keys should be defined within each theme scale.
@@ -145,9 +144,8 @@ Arrays are _not_ required, and plain objects will work as well.
 
 </Note>
 
-
 For illustration purposes, the index values of the array can be thought of as loosely mapping to heading levels,
-but these values are *not* in any way tied to HTML elements.
+but these values are _not_ in any way tied to HTML elements.
 
 | Index | Heading-Level Equivalent |
 | ----- | ------------------------ |
@@ -238,11 +236,11 @@ Variants support the same style objects as the `sx` prop, which means responsive
 
 The Theme UI `styles` object is primarily used as a way to style MDX content
 and helps avoid the need to use global CSS.
-The styles defined within this object can also be used with the [`Styled`](/styled) component.
+The styles defined within this object can also be used with the [`Themed`](/themed) component.
 
 <Note>
 
-The `styles` object is essentially an MDX-specific *variant*
+The `styles` object is essentially an MDX-specific _variant_
 that maps directly to each MDX component.
 
 </Note>
@@ -330,8 +328,7 @@ Variants can also be used within the `theme.styles` object.
 ## Aliasing Colors and Other Scales
 
 In many design systems, developers choose to create an additional layer of abstraction for mapping individual components to specific scale values.
-With Theme UI, *variants* are the mechanism to use for such abstractions.
-
+With Theme UI, _variants_ are the mechanism to use for such abstractions.
 
 ## Breakpoints
 

--- a/packages/docs/src/pages/themed.mdx
+++ b/packages/docs/src/pages/themed.mdx
@@ -1,20 +1,20 @@
 ---
-title: Styled
+title: Themed
 ---
 
-# Styled component
+# Themed component
 
-Use the `Styled` component to render UI with styles from [`theme.styles`](/theming#styles) _outside_ of MDX.
+Use the `Themed` component to render UI with styles from [`theme.styles`](/theming#styles) _outside_ of MDX.
 For example, if you'd like to reuse heading styles in a React component,
-you can use the `Styled.h1` component to render an `<h1>` element with styles from `theme.styles.h1`.
+you can use the `Themed.h1` component to render an `<h1>` element with styles from `theme.styles.h1`.
 
 ```jsx
 // example
-import { Styled } from 'theme-ui'
+import { Themed } from 'theme-ui'
 
 export default (props) => (
   <div>
-    <Styled.h1>Hello, styled heading!</Styled.h1>
+    <Themed.h1>Hello, styled heading!</Themed.h1>
   </div>
 )
 ```
@@ -23,7 +23,7 @@ For a full list of keys available, see the [Theme Specification docs](/theme-spe
 
 ## Changing the HTML element or component
 
-The rendered HTML element can be changed for each `Styled` component.
+The rendered HTML element can be changed for each `Themed` component.
 This can be useful for ensuring accessible, SEO-friendly, and semantically-correct HTML is rendered while leveraging styles from the theme.
 This API originated in Rebass and is similar to the `@emotion/styled` API.
 
@@ -31,19 +31,19 @@ The following example renders a `<div>` that is styled like an `<h2>` element.
 
 ```jsx
 // example
-<Styled.h2 as="div">Hello!</Styled.h2>
+<Themed.h2 as="div">Hello!</Themed.h2>
 ```
 
 This can also be used to style components like the Gatsby `Link` component to match other links.
 
 ```jsx
-<Styled.a as={Link} to="/about">
+<Themed.a as={Link} to="/about">
   About
-</Styled.a>
+</Themed.a>
 ```
 
 ## Body Styles
 
 To add base typographic styles to the `<body>` element, add styles to `theme.styles.root`.
-Previous versions of Theme UI used the `Styled.root` component.
+Previous versions of Theme UI used the `Themed.root` component.
 See the [theming docs](/theming/#body-styles) for more information.

--- a/packages/docs/src/recipes/post-list-a1.mdx
+++ b/packages/docs/src/recipes/post-list-a1.mdx
@@ -13,31 +13,31 @@ component: post-list
     px: 3,
     py: 4,
   }}>
-  {posts.map(post => (
-    <li key={post.id}
+  {posts.map((post) => (
+    <li
+      key={post.id}
       sx={{
         mb: 4,
       }}>
-      <Styled.h2
+      <Themed.h2
         sx={{
           m: 0,
         }}>
-        <Link to={post.slug}
+        <Link
+          to={post.slug}
           sx={{
             color: 'inherit',
             textDecoration: 'none',
             ':hover,:focus': {
               color: 'primary',
               textDecoration: 'underline',
-            }
+            },
           }}>
           {post.title}
         </Link>
-      </Styled.h2>
+      </Themed.h2>
       <small sx={{ fontWeight: 'bold' }}>{post.date}</small>
-      <Styled.p>
-        {post.excerpt}
-      </Styled.p>
+      <Themed.p>{post.excerpt}</Themed.p>
     </li>
   ))}
 </ul>

--- a/packages/docs/src/recipes/post-list-a2.mdx
+++ b/packages/docs/src/recipes/post-list-a2.mdx
@@ -16,33 +16,32 @@ component: post-list
     px: 3,
     py: 4,
   }}>
-  {posts.map(post => (
-    <li key={post.id}
-      sx={{
-      }}>
-      <Styled.h2
+  {posts.map((post) => (
+    <li key={post.id} sx={{}}>
+      <Themed.h2
         sx={{
           m: 0,
         }}>
-        <Link to={post.slug}
+        <Link
+          to={post.slug}
           sx={{
             color: 'inherit',
             textDecoration: 'none',
             ':hover,:focus': {
               color: 'primary',
               textDecoration: 'underline',
-            }
+            },
           }}>
           {post.title}
         </Link>
-      </Styled.h2>
+      </Themed.h2>
       <small sx={{ fontWeight: 'bold' }}>{post.date}</small>
-      <Styled.p
+      <Themed.p
         sx={{
           m: 0,
         }}>
         {post.excerpt}
-      </Styled.p>
+      </Themed.p>
     </li>
   ))}
 </ul>

--- a/packages/docs/src/sidebar.mdx
+++ b/packages/docs/src/sidebar.mdx
@@ -4,7 +4,7 @@
 - [The `sx` Prop](/sx-prop)
 - [Styling MDX](/styling-mdx)
 - [Color Modes](/color-modes)
-- [Styled](/styled)
+- [Themed](/themed)
 - [MDX Components](/mdx-components)
 - [useThemeUI](/use-theme-ui)
 - [API](/api)

--- a/packages/docs/static/_redirects
+++ b/packages/docs/static/_redirects
@@ -1,3 +1,4 @@
+/styled /themed
 
 /how-it-works /guides/how-it-works
 /jsx-pragma /guides/jsx-pragma

--- a/packages/gatsby-theme-style-guide/src/colors.js
+++ b/packages/gatsby-theme-style-guide/src/colors.js
@@ -1,11 +1,11 @@
 import React from 'react'
-import { Styled } from 'theme-ui'
+import { Themed } from 'theme-ui'
 import { ColorPalette } from '@theme-ui/style-guide'
 
 export default () => {
   return (
     <section id="colors">
-      <Styled.h2>Colors</Styled.h2>
+      <Themed.h2>Colors</Themed.h2>
       <ColorPalette omit={[]} />
     </section>
   )

--- a/packages/gatsby-theme-style-guide/src/header.js
+++ b/packages/gatsby-theme-style-guide/src/header.js
@@ -1,8 +1,8 @@
 import React from 'react'
-import { Styled } from 'theme-ui'
+import { Themed } from 'theme-ui'
 
 export default () => (
   <header>
-    <Styled.h1>Style Guide</Styled.h1>
+    <Themed.h1>Style Guide</Themed.h1>
   </header>
 )

--- a/packages/gatsby-theme-style-guide/src/typography.js
+++ b/packages/gatsby-theme-style-guide/src/typography.js
@@ -1,11 +1,8 @@
 /** @jsx jsx */
-import { jsx, Styled, useThemeUI } from 'theme-ui'
-import {
-  TypeScale,
-  TypeStyle,
-} from '@theme-ui/style-guide'
+import { jsx, Themed, useThemeUI } from 'theme-ui'
+import { TypeScale, TypeStyle } from '@theme-ui/style-guide'
 
-const Row = props => (
+const Row = (props) => (
   <div
     {...props}
     sx={{
@@ -20,40 +17,40 @@ const Row = props => (
   />
 )
 
-export default props => {
+export default (props) => {
   const { theme } = useThemeUI()
   const { fonts, fontWeights, lineHeights } = theme
 
   return (
     <section id="typography">
-      <Styled.h2>Typography</Styled.h2>
+      <Themed.h2>Typography</Themed.h2>
       {fonts && (
         <div>
-          <Styled.h3>Font Families</Styled.h3>
+          <Themed.h3>Font Families</Themed.h3>
           <Row>
-            {Object.keys(fonts).map(name => (
+            {Object.keys(fonts).map((name) => (
               <div key={name}>
                 <TypeStyle fontFamily={name} fontSize={6}>
                   Aa
                 </TypeStyle>
-                <Styled.code title={fonts[name]}>{name}</Styled.code>
+                <Themed.code title={fonts[name]}>{name}</Themed.code>
               </div>
             ))}
           </Row>
         </div>
       )}
-      <Styled.h3>Font Sizes</Styled.h3>
+      <Themed.h3>Font Sizes</Themed.h3>
       <TypeScale />
       {fontWeights && (
         <div>
-          <Styled.h3>Font Weights</Styled.h3>
+          <Themed.h3>Font Weights</Themed.h3>
           <Row>
-            {Object.keys(fontWeights).map(name => (
+            {Object.keys(fontWeights).map((name) => (
               <div key={name}>
                 <TypeStyle fontSize={6} fontWeight={name}>
                   {fontWeights[name]}
                 </TypeStyle>
-                <Styled.code>{name}</Styled.code>
+                <Themed.code>{name}</Themed.code>
               </div>
             ))}
           </Row>
@@ -61,14 +58,14 @@ export default props => {
       )}
       {lineHeights && (
         <div>
-          <Styled.h3>Line Heights</Styled.h3>
+          <Themed.h3>Line Heights</Themed.h3>
           <Row>
-            {Object.keys(lineHeights).map(name => (
+            {Object.keys(lineHeights).map((name) => (
               <div key={name}>
                 <TypeStyle fontSize={6} lineHeight={name}>
                   {lineHeights[name]}
                 </TypeStyle>
-                <Styled.code>{name}</Styled.code>
+                <Themed.code>{name}</Themed.code>
               </div>
             ))}
           </Row>

--- a/packages/mdx/README.md
+++ b/packages/mdx/README.md
@@ -1,11 +1,10 @@
-
 # @theme-ui/mdx
 
 MDX component context for Theme UI
 
 https://theme-ui.com
 
-**Note:** *This package is included in the main `theme-ui` package and a separate installation is not required.*
+**Note:** _This package is included in the main `theme-ui` package and a separate installation is not required._
 
 ```sh
 npm i @theme-ui/mdx
@@ -14,7 +13,6 @@ npm i @theme-ui/mdx
 ## API
 
 - `themed`
-- `Styled`
+- `Themed`
 - `components`
 - `MDXProvider`
-

--- a/packages/mdx/src/index.ts
+++ b/packages/mdx/src/index.ts
@@ -79,19 +79,19 @@ const aliases = {
 type Aliases = typeof aliases
 const isAlias = (x: string): x is keyof Aliases => x in aliases
 
-export type StyledComponentName =
+export type ThemedComponentName =
   | keyof IntrinsicSxElements
   | keyof JSX.IntrinsicElements
 
-const alias = (n: StyledComponentName): keyof JSX.IntrinsicElements =>
+const alias = (n: ThemedComponentName): keyof JSX.IntrinsicElements =>
   isAlias(n) ? aliases[n] : n
 
-export const themed = (key: StyledComponentName) => (props: ThemedProps) =>
+export const themed = (key: ThemedComponentName) => (props: ThemedProps) =>
   css(get(props.theme, `styles.${key}`))(props.theme)
 
 // opt out of typechecking whenever `as` prop is used
 interface AnyComponentProps extends JSX.IntrinsicAttributes {
-    [key: string]: unknown
+  [key: string]: unknown
 }
 
 export type WithPoorAsProp<
@@ -107,7 +107,7 @@ export interface ThemedComponent<Name extends ElementType> {
   ): JSX.Element
 }
 
-export type StyledComponentsDict = {
+export type ThemedComponentsDict = {
   [K in keyof IntrinsicSxElements]: K extends keyof Aliases
     ? ThemedComponent<Aliases[K]>
     : K extends keyof JSX.IntrinsicElements
@@ -115,17 +115,17 @@ export type StyledComponentsDict = {
     : never
 }
 
-type StyledDiv = StyledComponent<
+type ThemedDiv = StyledComponent<
   DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>,
   ThemedProps,
   Theme
 >
 
-export const Styled: StyledDiv & StyledComponentsDict = styled('div')(
+export const Themed: ThemedDiv & ThemedComponentsDict = styled('div')(
   themed('div')
-) as StyledDiv & StyledComponentsDict
+) as ThemedDiv & ThemedComponentsDict
 
-export const components = {} as StyledComponentsDict
+export const components = {} as ThemedComponentsDict
 
 tags.forEach((tag) => {
   // fixme?
@@ -139,9 +139,9 @@ const createComponents = (comps: MDXProviderComponents) => {
   const componentKeys = Object.keys(comps) as Array<keyof IntrinsicSxElements>
 
   componentKeys.forEach((key) => {
-    ;(next[key] as StyledComponentsDict[typeof key]) = styled<any>(comps[key])(
+    ;(next[key] as ThemedComponentsDict[typeof key]) = styled<any>(comps[key])(
       themed(key)
-    ) as StyledComponentsDict[typeof key]
+    ) as ThemedComponentsDict[typeof key]
   })
   return next
 }

--- a/packages/mdx/test/index.tsx
+++ b/packages/mdx/test/index.tsx
@@ -5,7 +5,7 @@ import { matchers } from '@emotion/jest'
 import { ThemeProvider } from '@theme-ui/core'
 import { renderJSON } from '@theme-ui/test-utils'
 
-import { themed, Styled, components, MDXProvider } from '../src'
+import { themed, Themed, components, MDXProvider } from '../src'
 
 expect.extend(matchers)
 
@@ -46,7 +46,7 @@ test('components accept an `as` prop', () => {
         },
       }}>
       <MDXProvider>
-        <Styled.h1 as={Beep}>Beep boop</Styled.h1>
+        <Themed.h1 as={Beep}>Beep boop</Themed.h1>
       </MDXProvider>
     </ThemeProvider>
   )!
@@ -56,7 +56,7 @@ test('components accept an `as` prop', () => {
 
 test('components with `as` prop receive all props', () => {
   const Beep = (props) => <div {...props} />
-  const json = renderJSON(<Styled.a as={Beep} activeClassName="active" />)!
+  const json = renderJSON(<Themed.a as={Beep} activeClassName="active" />)!
   expect(json.type).toBe('div')
   expect(json.props.activeClassName).toBe('active')
 })
@@ -64,9 +64,9 @@ test('components with `as` prop receive all props', () => {
 test('cleans up style props', () => {
   const json = renderJSON(
     // @ts-expect-error
-    <Styled.h1 mx={2} id="test">
+    <Themed.h1 mx={2} id="test">
       Hello
-    </Styled.h1>
+    </Themed.h1>
   )!
   expect(json.props.id).toBe('test')
   expect(json.props.mx).not.toBeDefined()
@@ -121,7 +121,7 @@ test('opt out of typechecking props whenever `as` prop is used', () => {
     renderJSON(
       <div>
         {/* no error */}
-        <Styled.img
+        <Themed.img
           as="button"
           src={2}
           onClick={(_event) => {
@@ -129,7 +129,7 @@ test('opt out of typechecking props whenever `as` prop is used', () => {
             _event.x = 2
           }}
         />
-        <Styled.img
+        <Themed.img
           // @ts-expect-error Type 'number' is not assignable to type 'string'.ts(2322)
           src={2}
           onClick={(_event) => {

--- a/packages/prism/src/index.tsx
+++ b/packages/prism/src/index.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import Highlight, { defaultProps, Language } from 'prism-react-renderer'
-import { jsx, Styled } from 'theme-ui'
+import { jsx, Themed } from 'theme-ui'
 
 const aliases: Record<string, Language | undefined> = {
   js: 'javascript',
@@ -97,7 +97,7 @@ export default function ThemeUIPrism({
       {({ className, style, tokens, getLineProps, getTokenProps }) => {
         const tokensWithoutHighlightComments = findStartAndEndHighlights(tokens)
         return (
-          <Styled.pre
+          <Themed.pre
             className={`${outerClassName} ${className}`}
             style={style}>
             {tokensWithoutHighlightComments.map((line, i) => {
@@ -116,7 +116,7 @@ export default function ThemeUIPrism({
                 </div>
               )
             })}
-          </Styled.pre>
+          </Themed.pre>
         )
       }}
     </Highlight>

--- a/packages/style-guide/README.md
+++ b/packages/style-guide/README.md
@@ -7,12 +7,12 @@ npm i @theme-ui/style-guide
 ```
 
 ```jsx
-import { Styled } from 'theme-ui'
+import { Themed } from 'theme-ui'
 import { TypeScale, TypeStyle, ColorPalette } from '@theme-ui/style-guide'
 
 export default (props) => (
   <>
-    <Styled.h1>Style Guide</Styled.h1>
+    <Themed.h1>Style Guide</Themed.h1>
     <ColorPalette />
     <TypeScale />
     <TypeStyle fontFamily="heading" fontWeight="heading" lineHeight="heading" />

--- a/packages/theme-ui/README.md
+++ b/packages/theme-ui/README.md
@@ -192,7 +192,7 @@ export default (props) => (
 - [The `sx` Prop](https://theme-ui.com/sx-prop)
 - [Layout](https://theme-ui.com/layout)
 - [Color Modes](https://theme-ui.com/color-modes)
-- [Styled](https://theme-ui.com/styled)
+- [Themed](https://theme-ui.com/themed)
 - [MDX Components](https://theme-ui.com/mdx-components)
 - [Theme Spec](https://theme-ui.com/theme-spec)
 - [Gatsby Plugin](https://theme-ui.com/packages/gatsby-plugin)

--- a/packages/theme-ui/src/index.ts
+++ b/packages/theme-ui/src/index.ts
@@ -20,7 +20,7 @@ export type {
   StylePropertyValue,
 } from '@theme-ui/core'
 export { useColorMode, InitializeColorMode } from '@theme-ui/color-modes'
-export { Styled, components } from '@theme-ui/mdx'
+export { Themed, components } from '@theme-ui/mdx'
 export { ThemeProvider } from '@theme-ui/theme-provider'
 export * from '@theme-ui/components'
 export { css, get } from '@theme-ui/css'


### PR DESCRIPTION
Following #1312, making this breaking change to use a clearer name for `Styled`. I did my absolute best to make the change everywhere across docs, code, docs code, & examples, & I added a redirect on the docs site from /styled to /themed. Lmk if anything looks off!