### PR TITLE
fix: preserve order of variant expansion props

### DIFF
--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -280,13 +280,24 @@ export const css = (args: ThemeUIStyleObject = {}) => (
   }
   let result: CSSObject = {}
   let obj = typeof args === 'function' ? args(theme) : args
+ 
   // insert variant props before responsive styles, so they can be merged
-  if (obj && obj['variant']) {
-    obj = { ...get(theme, obj['variant']), ...obj }
-    delete obj['variant'];
+  // we need to maintain order of the style props, so if a variant is place in the middle
+  // of other props, it will extends its props at that same location order.
+  if (obj) {
+    for (const key in obj) {
+      const x = obj[key as keyof typeof styles]
+      if (key === 'variant') {
+        const val = typeof x === 'function' ? x(theme) : x;
+        const variant = css(get(theme, val as string))(theme);
+        result = { ...result, ...variant };
+      } else {
+        result[key] = x as CSSObject;
+      }  
+    }
   }
-  const styles = responsive(obj)(theme)
-
+  const styles = responsive(result as ThemeUICSSObject)(theme)
+  result = {}
   for (const key in styles) {
     const x = styles[key as keyof typeof styles]
     const val = typeof x === 'function' ? x(theme) : x

--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -280,7 +280,7 @@ export const css = (args: ThemeUIStyleObject = {}) => (
   }
   let obj = typeof args === 'function' ? args(theme) : args
   let result: CSSObject = {}
- 
+
   // insert variant props before responsive styles, so they can be merged
   // we need to maintain order of the style props, so if a variant is place in the middle
   // of other props, it will extends its props at that same location order.
@@ -289,7 +289,7 @@ export const css = (args: ThemeUIStyleObject = {}) => (
       const x = obj[key as keyof typeof styles]
       if (key === 'variant') {
         const val = typeof x === 'function' ? x(theme) : x;
-        const variant = css(get(theme, val as string))(theme);
+        const variant = get(theme, val as string);
         result = { ...result, ...variant };
       } else {
         result[key] = x as CSSObject;

--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -278,13 +278,13 @@ export const css = (args: ThemeUIStyleObject = {}) => (
     ...defaultTheme,
     ...('theme' in props ? props.theme : props),
   }
-  let result: CSSObject = {}
   let obj = typeof args === 'function' ? args(theme) : args
+  let result: CSSObject = {}
  
   // insert variant props before responsive styles, so they can be merged
   // we need to maintain order of the style props, so if a variant is place in the middle
   // of other props, it will extends its props at that same location order.
-  if (obj) {
+  if (obj && obj['variant']) {
     for (const key in obj) {
       const x = obj[key as keyof typeof styles]
       if (key === 'variant') {
@@ -295,6 +295,8 @@ export const css = (args: ThemeUIStyleObject = {}) => (
         result[key] = x as CSSObject;
       }  
     }
+  } else {
+    result = obj as CSSObject ;
   }
   const styles = responsive(result as ThemeUICSSObject)(theme)
   result = {}


### PR DESCRIPTION
issue: #1319 

#1273 changed the order of variant props expansion - where local sx props were overwriting any props inherited from variants. This led to incompatibility with older code relying on props order.

Now the variant props are expanded during a loop to place them at the same order where the variant itself was declared.