### PR TITLE
perf: remove default values for css custom vars

### DIFF
--- a/packages/color-modes/src/custom-properties.ts
+++ b/packages/color-modes/src/custom-properties.ts
@@ -1,8 +1,8 @@
 import { css, get, Theme } from '@theme-ui/css'
 
 const toVarName = (key: string) => `--theme-ui-${key}`
-const toVarValue = (key: string, value: string | number) =>
-  `var(${toVarName(key)}, ${value})`
+const toVarValue = (key: string) =>
+  `var(${toVarName(key)})`
 
 const join = (...args: (string | undefined)[]) => args.filter(Boolean).join('-')
 
@@ -43,8 +43,7 @@ export const toCustomProperties = (
       next[key] = value
       continue
     }
-    const val = toPixel(themeKey || key, value)
-    next[key] = toVarValue(name, val)
+    next[key] = toVarValue(name)
   }
 
   return next
@@ -95,7 +94,7 @@ export const createColorStyles = (theme: Theme = {}) => {
         : modes[printColorModeName]
     styles['@media (print)'] = objectToVars('colors', mode)
   }
-  const colorToVarValue = (color: string) => toVarValue(`colors-${color}`, get(theme, `colors.${color}`));
+  const colorToVarValue = (color: string) => toVarValue(`colors-${color}`);
 
   return css({
     body: {

--- a/packages/color-modes/test/custom-properties.tsx
+++ b/packages/color-modes/test/custom-properties.tsx
@@ -18,20 +18,20 @@ describe('toCustomProperties', () => {
     expect(result).toEqual({
       initialColorModeName: 'light',
       colors: {
-        text: 'var(--theme-ui-colors-text, black)',
+        text: 'var(--theme-ui-colors-text)',
       },
       space: [
-        'var(--theme-ui-space-0, 0px)',
-        'var(--theme-ui-space-1, 4px)',
-        'var(--theme-ui-space-2, 8px)',
-        'var(--theme-ui-space-3, 16px)',
-        'var(--theme-ui-space-4, 32px)',
+        'var(--theme-ui-space-0)',
+        'var(--theme-ui-space-1)',
+        'var(--theme-ui-space-2)',
+        'var(--theme-ui-space-3)',
+        'var(--theme-ui-space-4)',
       ],
       fonts: {
-        body: 'var(--theme-ui-fonts-body, system-ui, sans-serif)',
+        body: 'var(--theme-ui-fonts-body)',
       },
       fontWeights: {
-        body: 'var(--theme-ui-fontWeights-body, 400)',
+        body: 'var(--theme-ui-fontWeights-body)',
       },
     })
   })
@@ -59,8 +59,8 @@ describe('createColorStyles', () => {
     })
     expect(styles).toEqual({
       body: {
-        color: 'var(--theme-ui-colors-text, tomato)',
-        backgroundColor: 'var(--theme-ui-colors-background, white)',
+        color: 'var(--theme-ui-colors-text)',
+        backgroundColor: 'var(--theme-ui-colors-background)',
         '--theme-ui-colors-text': 'tomato',
         '--theme-ui-colors-background': 'white',
         '&.theme-ui-dark': {
@@ -87,8 +87,8 @@ describe('createColorStyles', () => {
     })
     expect(styles).toEqual({
       body: {
-        color: 'var(--theme-ui-colors-text, white)',
-        backgroundColor: 'var(--theme-ui-colors-background, tomato)',
+        color: 'var(--theme-ui-colors-text)',
+        backgroundColor: 'var(--theme-ui-colors-background)',
         '--theme-ui-colors-text': 'white',
         '--theme-ui-colors-background': 'tomato',
         '&.theme-ui-light': {
@@ -120,8 +120,8 @@ describe('createColorStyles', () => {
     })
     expect(styles).toEqual({
       body: {
-        color: 'var(--theme-ui-colors-text, tomato)',
-        backgroundColor: 'var(--theme-ui-colors-background, white)',
+        color: 'var(--theme-ui-colors-text)',
+        backgroundColor: 'var(--theme-ui-colors-background)',
         '--theme-ui-colors-text': 'tomato',
         '--theme-ui-colors-background': 'white',
         '&.theme-ui-dark': {

--- a/packages/color-modes/test/index.tsx
+++ b/packages/color-modes/test/index.tsx
@@ -168,7 +168,7 @@ test('converts color modes to css custom properties', () => {
   )
   expect(tree.getByText('test')).toHaveStyleRule(
     'color',
-    'var(--theme-ui-colors-text, #000)'
+    'var(--theme-ui-colors-text)'
   )
 })
 
@@ -553,7 +553,7 @@ test('dot notation works with color modes and custom properties', () => {
   button.click()
   expect(button).toHaveStyleRule(
     'color',
-    'var(--theme-ui-colors-header-title, tomato)'
+    'var(--theme-ui-colors-header-title)'
   )
 })
 

--- a/packages/theme-ui/test/color-modes.tsx
+++ b/packages/theme-ui/test/color-modes.tsx
@@ -159,7 +159,7 @@ test('converts color modes to css custom properties', () => {
   )
   expect(tree.getByText('test')).toHaveStyleRule(
     'color',
-    'var(--theme-ui-colors-text, #000)'
+    'var(--theme-ui-colors-text)'
   )
 })
 
@@ -450,7 +450,7 @@ test('dot notation works with color modes and custom properties', () => {
   button.click()
   expect(button).toHaveStyleRule(
     'color',
-    'var(--theme-ui-colors-header-title, tomato)'
+    'var(--theme-ui-colors-header-title)'
   )
 })
 


### PR DESCRIPTION
removed the default values for css custom vars, since they are coming from the exact same theme keys. 
As discussed with @hasparus and @fcisio ry to check in while still in the 0.xxx stage.