### PR TITLE
Mdx table align styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.6.0 UNRELEASED
 
+- Add ability for MDX styling, and fix mdx table align styles. Issue #654
 - Remove recursive default values from CSS custom properties. PR #1327
 
 ## v0.6.0-alpha.1

--- a/packages/docs/src/gatsby-plugin-theme-ui/index.js
+++ b/packages/docs/src/gatsby-plugin-theme-ui/index.js
@@ -1,5 +1,14 @@
 import prism from '@theme-ui/prism/presets/theme-ui'
 
+const tableCellStyle = {
+  textAlign: 'left',
+  py: '4px',
+  pr: '4px',
+  pl: 0,
+  borderColor: 'muted',
+  borderBottomStyle: 'solid',
+}
+
 export default {
   colors: {
     text: '#000000',
@@ -315,22 +324,16 @@ export default {
       my: 4,
       borderCollapse: 'separate',
       borderSpacing: 0,
-      [['th', 'td']]: {
-        textAlign: 'left',
-        py: '4px',
-        pr: '4px',
-        pl: 0,
-        borderColor: 'muted',
-        borderBottomStyle: 'solid',
-      },
     },
     th: {
       verticalAlign: 'bottom',
       borderBottomWidth: '2px',
+      ...tableCellStyle,
     },
     td: {
       verticalAlign: 'top',
       borderBottomWidth: '1px',
+      ...tableCellStyle,
     },
     hr: {
       border: 0,

--- a/packages/docs/src/recipes/mdx-table-align.mdx
+++ b/packages/docs/src/recipes/mdx-table-align.mdx
@@ -1,0 +1,17 @@
+---
+name: 'MDX Table Columns Align'
+---
+
+# MDX Table Columns Align
+
+You can use standard MDX align styling to overwrite the column text align prop
+
+```mdx
+| Left | Centre | Right |
+| :--- | :----: | ----: |
+| 1    |   2    |     3 |
+```
+
+| Left | Centre | Right |
+| :--- | :----: | ----: |
+| 1    |   2    |     3 |

--- a/packages/docs/src/sidebar.mdx
+++ b/packages/docs/src/sidebar.mdx
@@ -108,5 +108,6 @@
   - [Footer A4](/recipes/footer-a4)
   - [PostList A1](/recipes/post-list-a1)
   - [PostList A2](/recipes/post-list-a2)
+  - [MDX Table Align](/recipes/mdx-table-align)
 - [Migrating](/migrating)
 - [GitHub](https://github.com/system-ui/theme-ui)

--- a/packages/mdx/src/index.ts
+++ b/packages/mdx/src/index.ts
@@ -13,10 +13,10 @@ import styled, { StyledComponent } from '@emotion/styled'
 import { MDXProvider as _MDXProvider, useMDXComponents } from '@mdx-js/react'
 
 type MDXProviderComponentsKnownKeys = {
-  [key in keyof IntrinsicSxElements]?: React.ComponentType<any> | string
+  [key in keyof IntrinsicSxElements]?: ComponentType<any> | string
 }
 export interface MDXProviderComponents extends MDXProviderComponentsKnownKeys {
-  [key: string]: React.ComponentType<any> | string | undefined
+  [key: string]: ComponentType<any> | string | undefined
 }
 export type MdxAliases = {
   [key in keyof IntrinsicSxElements]: keyof JSX.IntrinsicElements
@@ -86,8 +86,35 @@ export type ThemedComponentName =
 const alias = (n: ThemedComponentName): keyof JSX.IntrinsicElements =>
   isAlias(n) ? aliases[n] : n
 
-export const themed = (key: ThemedComponentName) => (props: ThemedProps) =>
-  css(get(props.theme, `styles.${key}`))(props.theme)
+const propOverrides: {
+  [key in Partial<ThemedComponentName>]?: Record<string, string>
+} = {
+  th: {
+    align: 'textAlign',
+  },
+  td: {
+    align: 'textAlign',
+  },
+}
+export const themed = (key: ThemedComponentName) => ({
+  theme,
+  ...rest
+}: ThemedProps) => {
+  const propsStyle = propOverrides[key]
+
+  const extraStyles = propsStyle
+    ? Object.keys(rest)
+        .filter((prop) => propsStyle[prop] !== undefined)
+        .reduce(
+          (acc, prop) => ({
+            ...acc,
+            [propsStyle[prop]]: (rest as Record<string, string>)[prop],
+          }),
+          {}
+        )
+    : undefined
+  return css({ ...get(theme, `styles.${key}`), ...extraStyles })(theme)
+}
 
 // opt out of typechecking whenever `as` prop is used
 interface AnyComponentProps extends JSX.IntrinsicAttributes {

--- a/packages/mdx/test/index.tsx
+++ b/packages/mdx/test/index.tsx
@@ -1,6 +1,6 @@
 /** @jsx mdx */
 import { mdx } from '@mdx-js/react'
-import renderer from 'react-test-renderer'
+import { render } from '@testing-library/react'
 import { matchers } from '@emotion/jest'
 import { ThemeProvider } from '@theme-ui/core'
 import { renderJSON } from '@theme-ui/test-utils'
@@ -153,4 +153,46 @@ test('opt out of typechecking props whenever `as` prop is used', () => {
       />
     </div>
   `)
+})
+
+test('table columns align', () => {
+  const tree = render(
+    <MDXProvider>
+      <Themed.table>
+        <thead>
+          <Themed.tr>
+            <Themed.th align="left">
+              Left
+            </Themed.th>
+            <Themed.th align="center">
+              Center
+            </Themed.th>
+            <Themed.th align="right">
+              Right
+            </Themed.th>
+          </Themed.tr>
+        </thead>  
+        <tbody>
+          <Themed.tr>
+            <Themed.td align="left">
+              TextLeft
+            </Themed.td>
+            <Themed.td align="center">
+              TextCenter
+            </Themed.td>
+            <Themed.td align="right">
+              TextRight
+            </Themed.td>
+          </Themed.tr>
+        </tbody>
+      </Themed.table>
+    </MDXProvider>
+  )
+  expect(tree.getByText('Left')).toHaveStyleRule('text-align', 'left')
+  expect(tree.getByText('Center')).toHaveStyleRule('text-align', 'center')
+  expect(tree.getByText('Right')).toHaveStyleRule('text-align', 'right')
+  expect(tree.getByText('TextLeft')).toHaveStyleRule('text-align', 'left')
+  expect(tree.getByText('TextCenter')).toHaveStyleRule('text-align', 'center')
+  expect(tree.getByText('TextRight')).toHaveStyleRule('text-align', 'right')
+
 })


### PR DESCRIPTION
issue: #654

Added ability to pass any props from MDX to the MDXProvider components and fix mdx table align styles. 
- propOverrides lookup - where each component can list style props aliases that should be passed to the styling
- added recipe to docs `MDX Table Columns Align` url `xxx/recipes/mdx-table-align`
- fixed the theme in docs as it was using precedence to override any styles on `th` and `td` elements of `table`