### PR TITLE
fix: extract objects with nested variant props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.6.0 UNRELEASED
 
+- Extract objects with nested variant props. Issue #1357
 - Add ability for MDX styling, and fix mdx table align styles. Issue #654
 - Remove recursive default values from CSS custom properties. PR #1327
 - Support a `"default"` key for object in scales. PR #951

--- a/packages/css/test/index.ts
+++ b/packages/css/test/index.ts
@@ -31,6 +31,15 @@ const theme: Theme = {
       bg: 'primary',
       borderRadius: 2,
     },
+    size: {
+      size: '100%',
+      bg: 'primary',
+    },
+    round: {
+      variant: 'buttons.size',
+      overflow: 'hidden',
+      borderRadius: '50%',
+    },
   },
   text: {
     caps: {
@@ -54,8 +63,8 @@ const theme: Theme = {
   },
   opacities: [0, '50%'],
   transitions: {
-    standard: '0.3s ease-in-out'
-  }
+    standard: '0.3s ease-in-out',
+  },
 }
 
 test('returns a function', () => {
@@ -118,7 +127,7 @@ test('returns nested responsive styles', () => {
     color: 'primary',
     h1: {
       py: [3, 4],
-      scrollPaddingY: [2, 4]
+      scrollPaddingY: [2, 4],
     },
   })({ theme })
   expect(result).toEqual({
@@ -133,7 +142,6 @@ test('returns nested responsive styles', () => {
         paddingBottom: 32,
         scrollPaddingBottom: 32,
         scrollPaddingTop: 32,
-  
       },
     },
   })
@@ -239,6 +247,19 @@ test('returns variants from theme', () => {
     color: 'white',
     backgroundColor: 'tomato',
     borderRadius: 2,
+  })
+})
+
+test('returns nested variants from theme', () => {
+  const result = css({
+    variant: 'buttons.round',
+  })(theme)
+  expect(result).toEqual({
+    width: '100%',
+    height: '100%',
+    overflow: 'hidden',
+    borderRadius: '50%',
+    backgroundColor: 'tomato',
   })
 })
 
@@ -516,7 +537,7 @@ test('returns correct media query order 2', () => {
     'paddingRight',
     'paddingTop',
     'paddingBottom',
-    'scrollPadding'
+    'scrollPadding',
   ])
 })
 

--- a/packages/docs/src/pages/api.mdx
+++ b/packages/docs/src/pages/api.mdx
@@ -146,7 +146,11 @@ css(styleObject)(theme)
 
 ### `get`
 
-An existential getter function used internally.
+An existential getter function used internally to extract a field (or object) from a theme object.
+
+### `getObjectWithVariants`
+
+Similar to the `get` function above, but will also resolve any `variant` field if found inside the object.
 
 ### `merge`
 


### PR DESCRIPTION
issue: #1357 

added `getObjectWithVariants` function to get the object properties while also expanding the variants recursively