### PR TITLE
docs: accepts both home and home/ as home page

### DIFF
--- a/packages/docs/src/components/layout.js
+++ b/packages/docs/src/components/layout.js
@@ -43,7 +43,9 @@ export default (props) => {
   const fullwidth =
     (props.pageContext.frontmatter &&
       props.pageContext.frontmatter.fullwidth) ||
-    props.location.pathname === '/home'
+    props.location.pathname === '/home' ||
+    props.location.pathname === '/home/'
+
   const showNav = !props.pageContext?.frontmatter?.hidenav
 
   const cycleMode = (e) => {


### PR DESCRIPTION
issue: #1360

added `/home/` as possible home page in addition to `/home` since gatsby adds a trailing slash on refresh
  
