### PR TITLE
Update example link to Base Preset

### DIFF
--- a/packages/docs/src/pages/theming.mdx
+++ b/packages/docs/src/pages/theming.mdx
@@ -276,5 +276,5 @@ export const theme = {
 
 For more information on the Theme UI `theme` object, see the [Theme Specification docs](/theme-spec).
 
-[example]: https://github.com/system-ui/theme-ui/tree/stable/packages/preset-base/src/index.ts
+[example]: https://github.com/system-ui/theme-ui/tree/develop/packages/preset-base/src/index.ts
 [emotion]: https://emotion.sh


### PR DESCRIPTION
The current Base Preset link points to the old path of the `@theme-ui/preset-base` index file. This file has been renamed from `index.js` to `index.ts`, so the URL pointing to this resource also needs to be updated.