### PR TITLE
Update system prop test

### DIFF
--- a/packages/css/test/index.ts
+++ b/packages/css/test/index.ts
@@ -70,6 +70,9 @@ const theme: Theme = {
       letterSpacing: ['-0.01em', '-0.02em'],
     },
   },
+  borders: {
+    body: "3px solid #000000",
+  },
   borderWidths: {
     thin: 1,
   },
@@ -82,6 +85,14 @@ const theme: Theme = {
   opacities: [0, '50%'],
   transitions: {
     standard: '0.3s ease-in-out',
+  },
+  shadows: {
+    card: "5px 5px 15px 5px #000000",
+  },
+  zIndices: {
+    below: -1,
+    body: 1,
+    nav: 2,
   },
 }
 
@@ -182,6 +193,9 @@ test('handles all core styled system props', () => {
     transition: 'standard',
     fontFamily: 'monospace',
     lineHeight: 'body',
+    border: 'body',
+    boxShadow: 'card',
+    zIndex: 'nav',
   })({ theme })
   expect(result).toEqual({
     margin: 0,
@@ -202,6 +216,9 @@ test('handles all core styled system props', () => {
     fontSize: 24,
     fontWeight: 600,
     lineHeight: 1.5,
+    border: '3px solid #000000',
+    boxShadow: '5px 5px 15px 5px #000000',
+    zIndex: 2,
   })
 })
 


### PR DESCRIPTION
There is an issue currently on the latest Alpha #1439
It seems to be fixed on the `develop` now; not sure what fixed it. Should be good on the next alpha release I presume?

`borders`, `shadows` & `zIndices` keys were missing from the system props tests. I added them so we make sure it's fixed on the next release 👍