### PR TITLE
fix: custom vars to be created even if no color modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## v0.6.0 UNRELEASED
 
+## v0.6.0-alpha.8 2021-02-19
+
 - Make the rename of `Styled` to `Themed` non-breaking. Add a deprecation warning on `Styled` until a future release. PR #1461
 - Paragraph component's hardcoded responsive style has been removed (issue #1476)
+- Fix issue where css custom vars are only added to body if modes is in the colors declaration of the theme.
 
 ## v0.6.0-alpha.7 2021-02-15
 

--- a/packages/color-modes/src/custom-properties.ts
+++ b/packages/color-modes/src/custom-properties.ts
@@ -73,7 +73,7 @@ export const objectToVars = (parent: string, obj: Record<string, any>) => {
 export const createColorStyles = (theme: Theme = {}) => {
   const use = __internalGetUseRootStyles(theme)
   if (!theme.colors || use.rootStyles === false) return {}
-  if (theme.useCustomProperties === false || !theme.colors.modes) {
+  if (theme.useCustomProperties === false) {
     return css({
       [use.scope]: {
         color: 'text',

--- a/packages/color-modes/test/custom-properties.tsx
+++ b/packages/color-modes/test/custom-properties.tsx
@@ -264,4 +264,21 @@ describe('createColorStyles', () => {
       },
     })
   })
+
+  test('creates styles from color palette', () => {
+    const styles = createColorStyles({
+      colors: {
+        text: 'tomato',
+        background: 'white',
+      },
+    })
+    expect(styles).toEqual({
+      body: {
+        color: 'var(--theme-ui-colors-text, tomato)',
+        backgroundColor: 'var(--theme-ui-colors-background, white)',
+        '--theme-ui-colors-text': 'tomato',
+        '--theme-ui-colors-background': 'white',
+      },
+    })
+  })
 })


### PR DESCRIPTION
@fcisio reported on discord:

`Just realized, that the custom properties are only printed on the body if modes is in the colors declaration.`

 