### PR TITLE
Skip Vercel deploy on dependabot branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,8 @@
 # Changelog
 
-## UNRELEASED
-
-- Option for `gatsby-plugin-theme-ui` to disable body script (`injectColorFlashScript`, defaulting to `true`). Issue #1369, PR #1370
-
 ## v0.6.0 UNRELEASED
 
+- Option for `gatsby-plugin-theme-ui` to disable body script (`injectColorFlashScript`, defaulting to `true`). Issue #1369, PR #1370
 - **BREAKING**: Default `useColorModeMediaQuery` to `true`. Issue #624, PR #1373
 - Bump versions `@mdx-js/mdx` and `@mdx-js/react` to `^1.6.22`, gatsby-plugin-mdx to `^1.6.0`. PR #1351
 - Fix: "as" prop on Themed.X components now properly opts out of typechecking

--- a/scripts/should-skip-deploy.sh
+++ b/scripts/should-skip-deploy.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Does the branch name start with "dependabot/"
+if [[ "dependabot/skip-deploy" = dependabot/* ]] ; then
+  echo "should-skip-deploy >> Skipping deploy!"
+  exit 0;
+else
+  echo "should-ski-deploy >> Proceeding with deploy."
+  exit 1;
+fi


### PR DESCRIPTION
Closes https://github.com/system-ui/theme-ui/issues/1349. We don't need Deploy Previews for dependabot, and it clogs the queue.