### PR TITLE
feat(css): skip false before passing style object to Emotion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.6.0 UNRELEASED
 
-- Skip`false` values before passing style objects to Emotion. Allow `false` as style property value in TS types.
+- Skip `false` values before passing style objects to Emotion. Allow `false` as style property value in TS types. Issue #1297, PR #1460.
 
 # v0.6.0-alpha.6 2021-01-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.6.0 UNRELEASED
 
+- Skip`false` values before passing style objects to Emotion. Allow `false` as style property value in TS types.
+
 # v0.6.0-alpha.6 2021-01-22
 
 - **BREAKING**: Default `useColorSchemeMediaQuery` to `true`. Issue #624, PR #1373

--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -299,7 +299,9 @@ const responsive = (
       value = value(theme || {})
     }
 
-    if (value == null) continue
+    if (value === false || value == null) {
+      continue
+    }
     if (!Array.isArray(value)) {
       next[key] = value
       continue

--- a/packages/css/src/types.ts
+++ b/packages/css/src/types.ts
@@ -442,10 +442,13 @@ export interface ThemeUIExtendedCSSProperties
     AliasesCSSProperties,
     OverwriteCSSProperties {}
 
+type Empty = undefined | null | false
+
 export type StylePropertyValue<T> =
   | ResponsiveStyleValue<Exclude<T, undefined>>
   | ((theme: Theme) => ResponsiveStyleValue<Exclude<T, undefined>> | undefined)
   | ThemeUIStyleObject
+  | Empty
 
 export type ThemeUICSSProperties = {
   [K in keyof ThemeUIExtendedCSSProperties]: StylePropertyValue<
@@ -490,7 +493,7 @@ export interface CSSOthersObject {
   // we want to match CSS selectors
   // but index signature needs to be a supertype
   // so as a side-effect we allow unknown CSS properties (Emotion does too)
-  [k: string]: StylePropertyValue<string | number> | undefined | null
+  [k: string]: StylePropertyValue<string | number>
 }
 
 export interface ThemeUICSSObject

--- a/packages/css/test/index.ts
+++ b/packages/css/test/index.ts
@@ -633,3 +633,14 @@ test('supports vendor properties', () => {
     WebkitOverflowScrolling: 'touch',
   })
 })
+
+test('omits empty values', () => {
+  expect(
+    css({
+      color: false && 'blue',
+      backgroundColor: undefined && 'whitesmoke',
+      textDecoration: null && 'underline',
+      border: '1px solid black',
+    })(theme)
+  ).toStrictEqual({ border: '1px solid black' })
+})


### PR DESCRIPTION
Closes https://github.com/system-ui/theme-ui/issues/1297

Allows TypeScript users to write
```
sx={{ color: isActive && 'blue' }}
```