### PR TITLE
Remove JSX pragma from gatsby-theme-style-guide

### DIFF
--- a/packages/gatsby-theme-style-guide/src/typography.js
+++ b/packages/gatsby-theme-style-guide/src/typography.js
@@ -1,5 +1,5 @@
-/** @jsx jsx */
-import { jsx, Themed, useThemeUI } from 'theme-ui'
+import React from 'react'
+import { Themed, useThemeUI } from 'theme-ui'
 import { TypeScale, TypeStyle } from '@theme-ui/style-guide'
 
 const Row = (props) => (

--- a/packages/gatsby-theme-style-guide/src/typography.js
+++ b/packages/gatsby-theme-style-guide/src/typography.js
@@ -1,12 +1,11 @@
 import React from 'react'
-import { Themed, useThemeUI } from 'theme-ui'
+import { Flex, Themed, useThemeUI } from 'theme-ui'
 import { TypeScale, TypeStyle } from '@theme-ui/style-guide'
 
 const Row = (props) => (
-  <div
+  <Flex
     {...props}
     sx={{
-      display: 'flex',
       alignItems: 'baseline',
       flexWrap: 'wrap',
       mx: -3,


### PR DESCRIPTION
Should fix `pragma and pragmaFrag cannot be set when runtime is automatic` when installing version `next` of Theme UI and this Gatsby plugin.