### PR TITLE
docs: Update homepage links

### DIFF
--- a/packages/docs/src/pages/index.mdx
+++ b/packages/docs/src/pages/index.mdx
@@ -39,7 +39,6 @@ Jonathan Hart, Maurice Granton, Julius Johnson, Jamee Johnson, Michael Dean...
 
 <br />
 <br />
-<br />
 
 The homepage is currently offline, as a small mark of respect, and expression of solidarity.
 The rest of the [docs pages are still available](/home).
@@ -47,10 +46,9 @@ The rest of the [docs pages are still available](/home).
 Organizations that could use your financial support include
 [Black Lives Matter](https://blacklivesmatter.com),
 [The NAACP Legal Defense and Educational Fund](https://www.naacpldf.org),
-[Reclaim the Block](https://www.reclaimtheblock.org),
 [The Equal Justice Initiative](https://eji.org),
 [We The Protesters](https://www.wetheprotesters.org),
 and the
-[George Floyd Memorial Fund](https://www.gofundme.com/f/georgefloyd).
+[Philadelphia Bail Fund](https://www.phillybailfund.org/).
 
 ---


### PR DESCRIPTION
Two of the organizations listed are no longer seeking donations, so I removed those & added a new one: https://www.phillybailfund.org/