### PR TITLE
docs(styled-components): Clarify & update instructions

### DIFF
--- a/packages/docs/src/pages/guides/styled-components.mdx
+++ b/packages/docs/src/pages/guides/styled-components.mdx
@@ -8,7 +8,7 @@ Theme UI itself doesn’t expose an API for styled components, but works seamles
 the `styled` API from the [@emotion/styled][] package. Components written with it
 should have access to the same theming context that Theme UI uses.
 
-Instead of using the `ThemeProvider` component from `emotion-theming`,
+Instead of using the `ThemeProvider` component from `@emotion/react`,
 import and use the Theme UI provider at your app’s root level.
 
 ```jsx

--- a/packages/docs/src/pages/guides/styled-components.mdx
+++ b/packages/docs/src/pages/guides/styled-components.mdx
@@ -4,8 +4,12 @@ title: 'Styled Components'
 
 # Styled Components
 
-If you're already using the `styled` API from the [@emotion/styled][] package, those components should have access to the same theming context that Theme UI uses.
-Instead of using the `ThemeProvider` component from `emotion-theming`, you can import and use the Theme UI provider.
+Theme UI itself doesn’t expose an API for styled components, but works seamlessly with
+the `styled` API from the [@emotion/styled][] package. Components written with it
+should have access to the same theming context that Theme UI uses.
+
+Instead of using the `ThemeProvider` component from `emotion-theming`,
+import and use the Theme UI provider at your app’s root level.
 
 ```jsx
 /** @jsxImportSource theme-ui */
@@ -20,7 +24,8 @@ export default (props) => (
 )
 ```
 
-If you're using the [Styled Components][] library, we're looking into integrations for existing components, but these can usually be converted to use Emotion with a single line change to the `import` statement.
+If you’re using the [Styled Components][] library, these can usually be converted to use Emotion
+with a single line change to the `import` statement.
 
 ```js
 // before
@@ -32,16 +37,20 @@ import styled from 'styled-components'
 import styled from '@emotion/styled'
 ```
 
+[@emotion/styled]: https://emotion.sh/docs/styled
+[styled components]: https://styled-components.com
+
 ## Using the `sx` prop
 
-To avoid the need for an additional dependency,
-you can use the `sx` prop to create custom styled components.
+Theme UI is actively working on removing its internal dependency on `@emotion/styled` to reduce bundle size.
+While Styled Components made with the package will continue to work into the future, we recommend using the
+[`sx` prop](/sx-prop) instead for simpler styling with [object styles](/guides/object-styles).
 
 ```jsx
 /** @jsxImportSource theme-ui */
 
-export default ({ width, color, bg, ...props }) => (
-  <div
+const Section = ({ width, color, bg, ...props }) => (
+  <section
     {...props}
     sx={{
       width,
@@ -52,6 +61,3 @@ export default ({ width, color, bg, ...props }) => (
   />
 )
 ```
-
-[@emotion/styled]: https://emotion.sh/docs/styled
-[styled components]: https://styled-components.com


### PR DESCRIPTION
This page has been a bit unclear, & we’re no longer worked on Styled Components migration paths, so clarifying those instructions.