### PR TITLE
fix(theme-ui): export jsx as createElement

### DIFF
--- a/packages/theme-ui/src/index.ts
+++ b/packages/theme-ui/src/index.ts
@@ -36,6 +36,7 @@ export const BaseStyles = (props: Record<string, unknown>) =>
   })
 
 export const jsx = coreJsx
+export const createElement = jsx
 export declare namespace jsx {
   export namespace JSX {
     export interface Element extends ThemeUIJSX.Element {}


### PR DESCRIPTION
Fix for #1603
The new JSX runtime transformation will sometimes use the `createElement` named export from the `jsxImportSource`, however `theme-ui` does not export its pragma under this name, causing crashes. This PR reexports the `jsx` pragma under the name `createElement` to fix this. For reference, `@emotion/react` currently [does the same thing](https://github.com/emotion-js/emotion/blob/%40emotion/react%4011.1.5/packages/react/src/index.js#L6)

A minimal reproduction case is rendering any JSX element with both spread props and a `key` prop:
```jsx
<div {...{}} key='1' />
```
([codesandbox](https://codesandbox.io/s/inspiring-shadow-bc96t?file=/src/App.js))

As far as I can tell, the tests use the classic runtime, so there is no way to write a test for this other than explicitly doing `import { createElement } from 'theme-ui'` and creating a node that way; is such a test worth having, since the use of `createElement` is essentially an implementation detail of the JSX transform?
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.6.1-canary.1604.15f511c.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @theme-ui/color-modes@0.6.1-canary.1604.15f511c.0
  npm install @theme-ui/color@0.6.1-canary.1604.15f511c.0
  npm install @theme-ui/components@0.6.1-canary.1604.15f511c.0
  npm install @theme-ui/core@0.6.1-canary.1604.15f511c.0
  npm install @theme-ui/css@0.6.1-canary.1604.15f511c.0
  npm install @theme-ui/custom-properties@0.6.1-canary.1604.15f511c.0
  npm install docs@0.6.1-canary.1604.15f511c.0
  npm install @theme-ui/editor@0.6.1-canary.1604.15f511c.0
  npm install gatsby-plugin-theme-ui@0.6.1-canary.1604.15f511c.0
  npm install gatsby-theme-code-recipes@0.6.1-canary.1604.15f511c.0
  npm install gatsby-theme-style-guide@0.6.1-canary.1604.15f511c.0
  npm install gatsby-theme-ui-layout@0.6.1-canary.1604.15f511c.0
  npm install @theme-ui/match-media@0.6.1-canary.1604.15f511c.0
  npm install @theme-ui/mdx@0.6.1-canary.1604.15f511c.0
  npm install @theme-ui/parse-props@0.6.1-canary.1604.15f511c.0
  npm install @theme-ui/preset-base@0.6.1-canary.1604.15f511c.0
  npm install @theme-ui/preset-bootstrap@0.6.1-canary.1604.15f511c.0
  npm install @theme-ui/preset-bulma@0.6.1-canary.1604.15f511c.0
  npm install @theme-ui/preset-dark@0.6.1-canary.1604.15f511c.0
  npm install @theme-ui/preset-deep@0.6.1-canary.1604.15f511c.0
  npm install @theme-ui/preset-funk@0.6.1-canary.1604.15f511c.0
  npm install @theme-ui/preset-future@0.6.1-canary.1604.15f511c.0
  npm install @theme-ui/preset-polaris@0.6.1-canary.1604.15f511c.0
  npm install @theme-ui/preset-roboto@0.6.1-canary.1604.15f511c.0
  npm install @theme-ui/preset-sketchy@0.6.1-canary.1604.15f511c.0
  npm install @theme-ui/preset-swiss@0.6.1-canary.1604.15f511c.0
  npm install @theme-ui/preset-system@0.6.1-canary.1604.15f511c.0
  npm install @theme-ui/preset-tailwind@0.6.1-canary.1604.15f511c.0
  npm install @theme-ui/preset-tosh@0.6.1-canary.1604.15f511c.0
  npm install @theme-ui/presets@0.6.1-canary.1604.15f511c.0
  npm install @theme-ui/prism@0.6.1-canary.1604.15f511c.0
  npm install @theme-ui/sidenav@0.6.1-canary.1604.15f511c.0
  npm install @theme-ui/style-guide@0.6.1-canary.1604.15f511c.0
  npm install @theme-ui/tachyons@0.6.1-canary.1604.15f511c.0
  npm install @theme-ui/tailwind@0.6.1-canary.1604.15f511c.0
  npm install @theme-ui/test-utils@0.6.1-canary.1604.15f511c.0
  npm install @theme-ui/theme-provider@0.6.1-canary.1604.15f511c.0
  npm install theme-ui@0.6.1-canary.1604.15f511c.0
  npm install @theme-ui/typography@0.6.1-canary.1604.15f511c.0
  # or 
  yarn add @theme-ui/color-modes@0.6.1-canary.1604.15f511c.0
  yarn add @theme-ui/color@0.6.1-canary.1604.15f511c.0
  yarn add @theme-ui/components@0.6.1-canary.1604.15f511c.0
  yarn add @theme-ui/core@0.6.1-canary.1604.15f511c.0
  yarn add @theme-ui/css@0.6.1-canary.1604.15f511c.0
  yarn add @theme-ui/custom-properties@0.6.1-canary.1604.15f511c.0
  yarn add docs@0.6.1-canary.1604.15f511c.0
  yarn add @theme-ui/editor@0.6.1-canary.1604.15f511c.0
  yarn add gatsby-plugin-theme-ui@0.6.1-canary.1604.15f511c.0
  yarn add gatsby-theme-code-recipes@0.6.1-canary.1604.15f511c.0
  yarn add gatsby-theme-style-guide@0.6.1-canary.1604.15f511c.0
  yarn add gatsby-theme-ui-layout@0.6.1-canary.1604.15f511c.0
  yarn add @theme-ui/match-media@0.6.1-canary.1604.15f511c.0
  yarn add @theme-ui/mdx@0.6.1-canary.1604.15f511c.0
  yarn add @theme-ui/parse-props@0.6.1-canary.1604.15f511c.0
  yarn add @theme-ui/preset-base@0.6.1-canary.1604.15f511c.0
  yarn add @theme-ui/preset-bootstrap@0.6.1-canary.1604.15f511c.0
  yarn add @theme-ui/preset-bulma@0.6.1-canary.1604.15f511c.0
  yarn add @theme-ui/preset-dark@0.6.1-canary.1604.15f511c.0
  yarn add @theme-ui/preset-deep@0.6.1-canary.1604.15f511c.0
  yarn add @theme-ui/preset-funk@0.6.1-canary.1604.15f511c.0
  yarn add @theme-ui/preset-future@0.6.1-canary.1604.15f511c.0
  yarn add @theme-ui/preset-polaris@0.6.1-canary.1604.15f511c.0
  yarn add @theme-ui/preset-roboto@0.6.1-canary.1604.15f511c.0
  yarn add @theme-ui/preset-sketchy@0.6.1-canary.1604.15f511c.0
  yarn add @theme-ui/preset-swiss@0.6.1-canary.1604.15f511c.0
  yarn add @theme-ui/preset-system@0.6.1-canary.1604.15f511c.0
  yarn add @theme-ui/preset-tailwind@0.6.1-canary.1604.15f511c.0
  yarn add @theme-ui/preset-tosh@0.6.1-canary.1604.15f511c.0
  yarn add @theme-ui/presets@0.6.1-canary.1604.15f511c.0
  yarn add @theme-ui/prism@0.6.1-canary.1604.15f511c.0
  yarn add @theme-ui/sidenav@0.6.1-canary.1604.15f511c.0
  yarn add @theme-ui/style-guide@0.6.1-canary.1604.15f511c.0
  yarn add @theme-ui/tachyons@0.6.1-canary.1604.15f511c.0
  yarn add @theme-ui/tailwind@0.6.1-canary.1604.15f511c.0
  yarn add @theme-ui/test-utils@0.6.1-canary.1604.15f511c.0
  yarn add @theme-ui/theme-provider@0.6.1-canary.1604.15f511c.0
  yarn add theme-ui@0.6.1-canary.1604.15f511c.0
  yarn add @theme-ui/typography@0.6.1-canary.1604.15f511c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
