### PR TITLE
chore: More explicit Gatsby peer dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## UNRELEASED
+
+- Set `gatsby` peerDependency more explicit to `^2.0.0 || ^3.0.0`. [#1640](https://github.com/system-ui/theme-ui/pull/1640) ([@LekoArts](https://github.com/LekoArts))
+
 ## v0.6.2 (Mon Apr 05 2021)
 
 ### 🐛 Bug Fix

--- a/deprecated/gatsby-theme-ui-blog/package.json
+++ b/deprecated/gatsby-theme-ui-blog/package.json
@@ -7,7 +7,7 @@
     "avatar": "npx capture-website-cli \"https://contrast.now.sh/fff/33e?text=UI&size=48&fontSize=1.5&radius=32&baseline=1\" content/assets/avatar.png --width=48 --height=48 --overwrite"
   },
   "peerDependencies": {
-    "gatsby": ">=2",
+    "gatsby": "^2.0.0 || ^3.0.0",
     "react": "^16.14.0 || ^17.0.0",
     "react-dom": "^16.8.0 || ^17.0.0"
   },

--- a/packages/gatsby-plugin-theme-ui/package.json
+++ b/packages/gatsby-plugin-theme-ui/package.json
@@ -5,7 +5,7 @@
   "author": "Brent Jackson",
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": ">=2",
+    "gatsby": "^2.0.0 || ^3.0.0",
     "theme-ui": ">=0.6.0"
   },
   "keywords": [

--- a/packages/gatsby-theme-code-recipes/package.json
+++ b/packages/gatsby-theme-code-recipes/package.json
@@ -4,7 +4,7 @@
   "main": "dist/gatsby-theme-code-recipes.cjs.js",
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": ">=2",
+    "gatsby": "^2.0.0 || ^3.0.0",
     "react": "^16.14.0 || ^17.0.0",
     "react-dom": "^16.14.0 || ^17.0.0"
   },

--- a/packages/gatsby-theme-style-guide/package.json
+++ b/packages/gatsby-theme-style-guide/package.json
@@ -4,7 +4,7 @@
   "main": "dist/gatsby-theme-style-guide.cjs.js",
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": ">=2",
+    "gatsby": "^2.0.0 || ^3.0.0",
     "react": "^16.14.0 || ^17.0.0",
     "react-dom": "^16.14.0 || ^17.0.0"
   },

--- a/packages/gatsby-theme-ui-layout/package.json
+++ b/packages/gatsby-theme-ui-layout/package.json
@@ -4,7 +4,7 @@
   "main": "dist/gatsby-theme-ui-layout.cjs.js",
   "repository": "system-ui/theme-ui",
   "peerDependencies": {
-    "gatsby": ">=2",
+    "gatsby": "^2.0.0 || ^3.0.0",
     "react": "^16.14.0 || ^17.0.0",
     "react-dom": "^16.14.0 || ^17.0.0"
   },


### PR DESCRIPTION
Hello <USER>, Gatsby maintainer here 👋 

While looking at the plugins I noticed that the `peerDependency` on `gatsby` is set incorrectly. In https://github.com/system-ui/theme-ui/commit/55dab22f6c17286dbbfd806ba281f4d310da4548 it was changed to `>=2`. We're in the process of providing more helpful information on the `/plugins` page of our website and for that we need plugins to set their `peerDependencies` correctly/more specific.

At the moment you say that _any_ version (v3, v4, v5, v6, etc.) will work with this even when in between we'd introduce breaking changes.

Making it more explicit is the safer choice (in the future you'll be able to mark breaking changes with explicit version ranges) and will allow us to display the plugin as compatible to versions X, Y, Z.

Thanks!

P.S.: Please let me know where I should change the `CHANGELOG`? I don't see a `UNRELEASED` bulletpoint anymore :)