### PR TITLE
feat: Have breakpoints accept custom media queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## UNRELEASED
 
 - Set `gatsby` peerDependency more explicit to `^2.0.0 || ^3.0.0`. [#1640](https://github.com/system-ui/theme-ui/pull/1640) ([@LekoArts](https://github.com/LekoArts))
-- Allow using custom media queries in `breakpoints`-key of theme. [@carolinmaisenbacher](https://github.com/carolinmaisenbacher)
+- Have `breakpoints` accept custom media queries [#1653](https://github.com/system-ui/theme-ui/pull/1653) [@carolinmaisenbacher](https://github.com/carolinmaisenbacher)
 
 ## v0.6.2 (Mon Apr 05 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## UNRELEASED
 
 - Set `gatsby` peerDependency more explicit to `^2.0.0 || ^3.0.0`. [#1640](https://github.com/system-ui/theme-ui/pull/1640) ([@LekoArts](https://github.com/LekoArts))
+- Allow using custom media queries in `breakpoints`-key of theme. [@carolinmaisenbacher](https://github.com/carolinmaisenbacher)
 
 ## v0.6.2 (Mon Apr 05 2021)
 

--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -290,7 +290,9 @@ const responsive = (
     (theme && (theme.breakpoints as string[])) || defaultBreakpoints
   const mediaQueries = [
     null,
-    ...breakpoints.map((n) => `@media screen and (min-width: ${n})`),
+    ...breakpoints.map((n) =>
+      n.includes('@media') ? n : `@media screen and (min-width: ${n})`
+    ),
   ]
 
   for (const k in styles) {

--- a/packages/css/test/index.ts
+++ b/packages/css/test/index.ts
@@ -660,6 +660,38 @@ test('returns correct media query order 2', () => {
   ])
 })
 
+test('returns custom media queries', () => {
+  const result = css({
+    fontSize: [2, 3, 4],
+    color: 'primary',
+  })({
+    theme: {
+      ...theme,
+      breakpoints: [
+        '32em',
+        '@media screen and (orientation: landscape) and (min-width: 40rem)',
+      ],
+    },
+  })
+  const keys = Object.keys(result)
+  expect(keys).toEqual([
+    'fontSize',
+    '@media screen and (min-width: 32em)',
+    '@media screen and (orientation: landscape) and (min-width: 40rem)',
+    'color',
+  ])
+  expect(result).toEqual({
+    fontSize: 16,
+    '@media screen and (min-width: 32em)': {
+      fontSize: 24,
+    },
+    '@media screen and (orientation: landscape) and (min-width: 40rem)': {
+      fontSize: 36,
+    },
+    color: 'tomato',
+  })
+})
+
 test('supports vendor properties', () => {
   expect(css({ WebkitOverflowScrolling: 'touch' })(theme)).toStrictEqual({
     WebkitOverflowScrolling: 'touch',
@@ -676,7 +708,6 @@ test('omits empty values', () => {
     })(theme)
   ).toStrictEqual({ border: '1px solid black' })
 })
-
 
 test('borderTopWidth accepts number', () => {
   expect(css({

--- a/packages/docs/src/pages/theme-spec.mdx
+++ b/packages/docs/src/pages/theme-spec.mdx
@@ -333,14 +333,15 @@ With Theme UI, _variants_ are the mechanism to use for such abstractions.
 ## Breakpoints
 
 To configure the default breakpoints used in responsive array values, add a `breakpoints` array to your theme.
-Each breakpoint should be a string with a CSS length unit included.
-These values will be used to generate mobile-first (i.e. `min-width`) media queries, which can then be used to apply [responsive styles](/getting-started/#responsive-styles).
+Each breakpoint should be a string with a CSS length unit included or a string including a CSS media query.
+String values with a CSS length unit will be used to generate a mobile-first (i.e. `min-width`) media query. 
+The breakpoints can then be used to apply [responsive styles](/sx-prop/#responsive-values).
 
 ```js
 // example custom breakpoints
 {
   breakpoints: [
-    '40em', '56em', '64em',
+    '40em', '@media (min-width: 56em) and (orientation: landscape)', '64em',
   ],
 }
 ```

--- a/packages/docs/src/pages/theming.mdx
+++ b/packages/docs/src/pages/theming.mdx
@@ -153,14 +153,15 @@ To add base, top-level styles to the `<body>` element, use `theme.styles.root`.
 ## Breakpoints
 
 To configure the default breakpoints used in responsive array values, add a `breakpoints` array to your theme.
-Each breakpoint should be a string with a CSS length unit included.
-These values will be used to generate mobile-first (i.e. `min-width`) media queries, which can then be used to apply [responsive styles](/sx-prop/#responsive-values).
+Each breakpoint should be a string with a CSS length unit included or a string including a CSS media query.
+String values with a CSS length unit will be used to generate a mobile-first (i.e. `min-width`) media query. 
+The breakpoints can then be used to apply [responsive styles](/sx-prop/#responsive-values).
 
 ```js
 // example custom breakpoints
 {
   breakpoints: [
-    '40em', '56em', '64em',
+    '40em', '@media (min-width: 56em) and (orientation: landscape)', '64em',
   ],
 }
 ```


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
Currently breakpoints generate mobile-first (i.e. min-width) media queries which does not work for every usecase. 
Our team e.g. uses on breakpoint that is only relevant if the screen's orientation is "landscape".

**Describe your solution**
In addition to accepting a the min-width as a string, breakpoints can now also consist of full media queries.

This is done, by checking, whether the breakpoint string contains "@media". In that case the custom media query is used to create the css.
If the breakpoint does not include "@media", the mobile-first media query is used, just like before.

A breakpoint array like this: 
```js
// example custom breakpoints
{
  breakpoints: [
    '40em', 
    '@media screen and (orientation: landscape) and (min-width: 40rem)',    
    '64em',
  ],
}
```

now results in the following generated media queries: 
```
'@media screen and (min-width: 40em)'
'@media screen and (orientation: landscape) and (min-width: 40rem)'
'@media screen and (min-width: 64em)'
```


This solution does not result in any breaking changes.

I updated the documentation and the CHANGELOG accordingly.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.6.3--canary.1653.a955910.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @theme-ui/color-modes@0.6.3--canary.1653.a955910.0
  npm install @theme-ui/color@0.6.3--canary.1653.a955910.0
  npm install @theme-ui/components@0.6.3--canary.1653.a955910.0
  npm install @theme-ui/core@0.6.3--canary.1653.a955910.0
  npm install @theme-ui/css@0.6.3--canary.1653.a955910.0
  npm install @theme-ui/custom-properties@0.6.3--canary.1653.a955910.0
  npm install @theme-ui/editor@0.6.3--canary.1653.a955910.0
  npm install gatsby-plugin-theme-ui@0.6.3--canary.1653.a955910.0
  npm install gatsby-theme-code-recipes@0.6.3--canary.1653.a955910.0
  npm install gatsby-theme-style-guide@0.6.3--canary.1653.a955910.0
  npm install gatsby-theme-ui-layout@0.6.3--canary.1653.a955910.0
  npm install @theme-ui/match-media@0.6.3--canary.1653.a955910.0
  npm install @theme-ui/mdx@0.6.3--canary.1653.a955910.0
  npm install @theme-ui/parse-props@0.6.3--canary.1653.a955910.0
  npm install @theme-ui/preset-base@0.6.3--canary.1653.a955910.0
  npm install @theme-ui/preset-bootstrap@0.6.3--canary.1653.a955910.0
  npm install @theme-ui/preset-bulma@0.6.3--canary.1653.a955910.0
  npm install @theme-ui/preset-dark@0.6.3--canary.1653.a955910.0
  npm install @theme-ui/preset-deep@0.6.3--canary.1653.a955910.0
  npm install @theme-ui/preset-funk@0.6.3--canary.1653.a955910.0
  npm install @theme-ui/preset-future@0.6.3--canary.1653.a955910.0
  npm install @theme-ui/preset-polaris@0.6.3--canary.1653.a955910.0
  npm install @theme-ui/preset-roboto@0.6.3--canary.1653.a955910.0
  npm install @theme-ui/preset-sketchy@0.6.3--canary.1653.a955910.0
  npm install @theme-ui/preset-swiss@0.6.3--canary.1653.a955910.0
  npm install @theme-ui/preset-system@0.6.3--canary.1653.a955910.0
  npm install @theme-ui/preset-tailwind@0.6.3--canary.1653.a955910.0
  npm install @theme-ui/preset-tosh@0.6.3--canary.1653.a955910.0
  npm install @theme-ui/presets@0.6.3--canary.1653.a955910.0
  npm install @theme-ui/prism@0.6.3--canary.1653.a955910.0
  npm install @theme-ui/sidenav@0.6.3--canary.1653.a955910.0
  npm install @theme-ui/style-guide@0.6.3--canary.1653.a955910.0
  npm install @theme-ui/tachyons@0.6.3--canary.1653.a955910.0
  npm install @theme-ui/tailwind@0.6.3--canary.1653.a955910.0
  npm install @theme-ui/theme-provider@0.6.3--canary.1653.a955910.0
  npm install theme-ui@0.6.3--canary.1653.a955910.0
  npm install @theme-ui/typography@0.6.3--canary.1653.a955910.0
  # or 
  yarn add @theme-ui/color-modes@0.6.3--canary.1653.a955910.0
  yarn add @theme-ui/color@0.6.3--canary.1653.a955910.0
  yarn add @theme-ui/components@0.6.3--canary.1653.a955910.0
  yarn add @theme-ui/core@0.6.3--canary.1653.a955910.0
  yarn add @theme-ui/css@0.6.3--canary.1653.a955910.0
  yarn add @theme-ui/custom-properties@0.6.3--canary.1653.a955910.0
  yarn add @theme-ui/editor@0.6.3--canary.1653.a955910.0
  yarn add gatsby-plugin-theme-ui@0.6.3--canary.1653.a955910.0
  yarn add gatsby-theme-code-recipes@0.6.3--canary.1653.a955910.0
  yarn add gatsby-theme-style-guide@0.6.3--canary.1653.a955910.0
  yarn add gatsby-theme-ui-layout@0.6.3--canary.1653.a955910.0
  yarn add @theme-ui/match-media@0.6.3--canary.1653.a955910.0
  yarn add @theme-ui/mdx@0.6.3--canary.1653.a955910.0
  yarn add @theme-ui/parse-props@0.6.3--canary.1653.a955910.0
  yarn add @theme-ui/preset-base@0.6.3--canary.1653.a955910.0
  yarn add @theme-ui/preset-bootstrap@0.6.3--canary.1653.a955910.0
  yarn add @theme-ui/preset-bulma@0.6.3--canary.1653.a955910.0
  yarn add @theme-ui/preset-dark@0.6.3--canary.1653.a955910.0
  yarn add @theme-ui/preset-deep@0.6.3--canary.1653.a955910.0
  yarn add @theme-ui/preset-funk@0.6.3--canary.1653.a955910.0
  yarn add @theme-ui/preset-future@0.6.3--canary.1653.a955910.0
  yarn add @theme-ui/preset-polaris@0.6.3--canary.1653.a955910.0
  yarn add @theme-ui/preset-roboto@0.6.3--canary.1653.a955910.0
  yarn add @theme-ui/preset-sketchy@0.6.3--canary.1653.a955910.0
  yarn add @theme-ui/preset-swiss@0.6.3--canary.1653.a955910.0
  yarn add @theme-ui/preset-system@0.6.3--canary.1653.a955910.0
  yarn add @theme-ui/preset-tailwind@0.6.3--canary.1653.a955910.0
  yarn add @theme-ui/preset-tosh@0.6.3--canary.1653.a955910.0
  yarn add @theme-ui/presets@0.6.3--canary.1653.a955910.0
  yarn add @theme-ui/prism@0.6.3--canary.1653.a955910.0
  yarn add @theme-ui/sidenav@0.6.3--canary.1653.a955910.0
  yarn add @theme-ui/style-guide@0.6.3--canary.1653.a955910.0
  yarn add @theme-ui/tachyons@0.6.3--canary.1653.a955910.0
  yarn add @theme-ui/tailwind@0.6.3--canary.1653.a955910.0
  yarn add @theme-ui/theme-provider@0.6.3--canary.1653.a955910.0
  yarn add theme-ui@0.6.3--canary.1653.a955910.0
  yarn add @theme-ui/typography@0.6.3--canary.1653.a955910.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
