### PR TITLE
fix(components): Allow styled-system space props on Paragraph

### DIFF
--- a/packages/components/src/Paragraph.js
+++ b/packages/components/src/Paragraph.js
@@ -2,7 +2,7 @@ import React from 'react'
 import Box from './Box'
 
 export const Paragraph = React.forwardRef(function Paragraph(
-  { sx, ...props },
+  props,
   ref
 ) {
   return (
@@ -10,18 +10,15 @@ export const Paragraph = React.forwardRef(function Paragraph(
       ref={ref}
       as="p"
       variant="paragraph"
-      {...props}
-      sx={{
-        // reset margin by default: avoid relying on user-agent margins (not aware of theme-ui space scale)
-        margin: 0,
-        ...sx
-      }}
+      // reset margin by default: avoid relying on user-agent margins (not aware of theme-ui space scale)
+      m={0}
       __themeKey="text"
       __css={{
         fontFamily: 'body',
         fontWeight: 'body',
         lineHeight: 'body',
       }}
+      {...props}
     />
   )
 })

--- a/packages/components/test/index.js
+++ b/packages/components/test/index.js
@@ -335,6 +335,16 @@ describe('Paragraph', () => {
     )
     expect(json).toHaveStyleRule('margin', margin)
   })
+
+  test('renders with space prop overrides', () => {
+    const margin = '8px'
+    const json = renderJSON(
+      <Paragraph
+        m={margin}
+      />
+    )
+    expect(json).toHaveStyleRule('margin', margin)
+  })
 })
 
 describe('Text', () => {


### PR DESCRIPTION
References [this discussion](https://github.com/system-ui/theme-ui/pull/1560#issuecomment-820033785):

Updated Paragraph component to allow overriding the margin using styled-system space props.