### PR TITLE
fix(gatsby-plugin-theme-ui): Fast Refresh Compatibility

### DIFF
--- a/examples/custom-pragma/gatsby-browser.js
+++ b/examples/custom-pragma/gatsby-browser.js
@@ -1,1 +1,6 @@
-export { wrapRootElement } from './src'
+import * as React from 'react'
+import { WrapRootElement } from './src'
+
+export const wrapRootElement = ({ element }) => (
+  <WrapRootElement element={element} />
+)

--- a/examples/custom-pragma/gatsby-ssr.js
+++ b/examples/custom-pragma/gatsby-ssr.js
@@ -1,1 +1,6 @@
-export { wrapRootElement } from './src'
+import * as React from 'react'
+import { WrapRootElement } from './src'
+
+export const wrapRootElement = ({ element }) => (
+  <WrapRootElement element={element} />
+)

--- a/examples/custom-pragma/src/index.js
+++ b/examples/custom-pragma/src/index.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { ThemeProvider, Themed } from 'theme-ui'
 import theme from './theme'
 
-export const wrapRootElement = ({ element }) => (
+export const WrapRootElement = ({ element }) => (
   <ThemeProvider theme={theme}>
     <Themed.root>{element}</Themed.root>
   </ThemeProvider>

--- a/examples/dark-mode/gatsby-browser.js
+++ b/examples/dark-mode/gatsby-browser.js
@@ -1,1 +1,6 @@
-export { wrapRootElement } from './src'
+import * as React from 'react'
+import { WrapRootElement } from './src'
+
+export const wrapRootElement = ({ element }) => (
+  <WrapRootElement element={element} />
+)

--- a/examples/dark-mode/gatsby-ssr.js
+++ b/examples/dark-mode/gatsby-ssr.js
@@ -1,1 +1,6 @@
-export { wrapRootElement } from './src'
+import * as React from 'react'
+import { WrapRootElement } from './src'
+
+export const wrapRootElement = ({ element }) => (
+  <WrapRootElement element={element} />
+)

--- a/examples/dark-mode/src/index.js
+++ b/examples/dark-mode/src/index.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { ThemeProvider, Themed } from 'theme-ui'
 import theme from './theme'
 
-export const wrapRootElement = ({ element }) => (
+export const WrapRootElement = ({ element }) => (
   <ThemeProvider theme={theme}>
     <Themed.root>{element}</Themed.root>
   </ThemeProvider>

--- a/examples/dark-mode/src/layout.js
+++ b/examples/dark-mode/src/layout.js
@@ -2,7 +2,7 @@
 import { jsx, useColorMode, Layout, Header, Main, Container } from 'theme-ui'
 import { Global } from '@emotion/react'
 
-export default (props) => {
+const Layout = (props) => {
   const [mode, setMode] = useColorMode()
   const toggleMode = (e) => {
     setMode(mode === 'dark' ? 'light' : 'dark')
@@ -31,3 +31,5 @@ export default (props) => {
     </Layout>
   )
 }
+
+export default Layout

--- a/examples/dark-mode/src/theme.js
+++ b/examples/dark-mode/src/theme.js
@@ -1,4 +1,4 @@
-export default {
+const theme = {
   colors: {
     text: '#000',
     background: '#fff',
@@ -39,3 +39,5 @@ export default {
     },
   },
 }
+
+export default theme

--- a/examples/gatsby-plugin/src/gatsby-plugin-theme-ui/index.js
+++ b/examples/gatsby-plugin/src/gatsby-plugin-theme-ui/index.js
@@ -1,4 +1,4 @@
-export default {
+const theme = {
   useCustomProperties: true,
   initialColorMode: 'light',
   colors: {
@@ -37,3 +37,5 @@ export default {
     },
   },
 }
+
+export default theme

--- a/examples/gatsby-plugin/src/layout.js
+++ b/examples/gatsby-plugin/src/layout.js
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { jsx, Themed } from 'theme-ui'
 
-export default (props) => (
+const Layout = (props) => (
   <Themed.root>
     <header>
       <h2>Theme UI Gatsby Example</h2>
@@ -11,3 +11,5 @@ export default (props) => (
     </main>
   </Themed.root>
 )
+
+export default Layout

--- a/examples/gatsby/gatsby-browser.js
+++ b/examples/gatsby/gatsby-browser.js
@@ -1,1 +1,6 @@
-export { wrapRootElement } from './src'
+import * as React from 'react'
+import { WrapRootElement } from './src'
+
+export const wrapRootElement = ({ element }) => (
+  <WrapRootElement element={element} />
+)

--- a/examples/gatsby/gatsby-ssr.js
+++ b/examples/gatsby/gatsby-ssr.js
@@ -1,1 +1,6 @@
-export { wrapRootElement } from './src'
+import * as React from 'react'
+import { WrapRootElement } from './src'
+
+export const wrapRootElement = ({ element }) => (
+  <WrapRootElement element={element} />
+)

--- a/examples/gatsby/src/index.tsx
+++ b/examples/gatsby/src/index.tsx
@@ -2,7 +2,7 @@ import React, { FC, ReactNode } from 'react'
 import { ThemeProvider, Themed } from 'theme-ui'
 import theme from './theme'
 
-export const wrapRootElement: FC<{ element: ReactNode }> = ({ element }) => (
+export const WrapRootElement: FC<{ element: ReactNode }> = ({ element }) => (
   <ThemeProvider theme={theme}>
     <Themed.root>{element}</Themed.root>
   </ThemeProvider>

--- a/examples/prism/gatsby-browser.js
+++ b/examples/prism/gatsby-browser.js
@@ -1,1 +1,6 @@
-export { wrapRootElement } from './src'
+import * as React from 'react'
+import { WrapRootElement } from './src'
+
+export const wrapRootElement = ({ element }) => (
+  <WrapRootElement element={element} />
+)

--- a/examples/prism/gatsby-ssr.js
+++ b/examples/prism/gatsby-ssr.js
@@ -1,1 +1,6 @@
-export { wrapRootElement } from './src'
+import * as React from 'react'
+import { WrapRootElement } from './src'
+
+export const wrapRootElement = ({ element }) => (
+  <WrapRootElement element={element} />
+)

--- a/examples/prism/src/index.js
+++ b/examples/prism/src/index.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { ThemeProvider, Themed } from 'theme-ui'
 import theme from './theme'
 
-export const wrapRootElement = ({ element }) => (
+export const WrapRootElement = ({ element }) => (
   <ThemeProvider theme={theme}>
     <Themed.root>{element}</Themed.root>
   </ThemeProvider>

--- a/examples/prism/src/layout.js
+++ b/examples/prism/src/layout.js
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { jsx, Layout, Header, Main, Container } from 'theme-ui'
 
-export default (props) => (
+const Layout = (props) => (
   <Layout>
     <Header>
       <h2>Theme UI Gatsby Example</h2>
@@ -11,3 +11,5 @@ export default (props) => (
     </Main>
   </Layout>
 )
+
+export default Layout

--- a/examples/prism/src/theme.js
+++ b/examples/prism/src/theme.js
@@ -1,4 +1,4 @@
-export default {
+const theme = {
   colors: {
     text: '#000',
     background: '#fff',
@@ -89,3 +89,5 @@ export default {
     },
   },
 }
+
+export default theme

--- a/examples/typography/gatsby-browser.js
+++ b/examples/typography/gatsby-browser.js
@@ -1,1 +1,6 @@
-export { wrapRootElement } from './src'
+import * as React from 'react'
+import { WrapRootElement } from './src'
+
+export const wrapRootElement = ({ element }) => (
+  <WrapRootElement element={element} />
+)

--- a/examples/typography/gatsby-ssr.js
+++ b/examples/typography/gatsby-ssr.js
@@ -1,1 +1,6 @@
-export { wrapRootElement } from './src'
+import * as React from 'react'
+import { WrapRootElement } from './src'
+
+export const wrapRootElement = ({ element }) => (
+  <WrapRootElement element={element} />
+)

--- a/examples/typography/src/index.js
+++ b/examples/typography/src/index.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { ThemeProvider, Themed } from 'theme-ui'
 import theme from './theme'
 
-export const wrapRootElement = ({ element }) => (
+export const WrapRootElement = ({ element }) => (
   <ThemeProvider theme={theme}>
     <Themed.root>{element}</Themed.root>
   </ThemeProvider>

--- a/examples/typography/src/layout.js
+++ b/examples/typography/src/layout.js
@@ -1,10 +1,12 @@
 /** @jsx jsx */
 import { jsx, Layout, Main, Container } from 'theme-ui'
 
-export default (props) => (
+const Layout = (props) => (
   <Layout>
     <Main>
       <Container>{props.children}</Container>
     </Main>
   </Layout>
 )
+
+export default Layout

--- a/examples/typography/src/theme.js
+++ b/examples/typography/src/theme.js
@@ -4,7 +4,7 @@ import fairyGates from 'typography-theme-fairy-gates'
 
 const typography = toTheme(fairyGates)
 
-export default merge(typography, {
+const theme = merge(typography, {
   colors: {
     text: '#000',
     background: '#fff',
@@ -26,3 +26,5 @@ export default merge(typography, {
     },
   },
 })
+
+export default theme

--- a/packages/docs/gatsby-browser.js
+++ b/packages/docs/gatsby-browser.js
@@ -1,6 +1,5 @@
 import * as React from 'react'
+
 import { WrapPageElement } from './src'
 
-export const wrapPageElement = ({ element }) => (
-  <WrapPageElement element={element} />
-)
+export const wrapPageElement = (props) => <WrapPageElement {...props} />

--- a/packages/docs/gatsby-browser.js
+++ b/packages/docs/gatsby-browser.js
@@ -1,1 +1,6 @@
-export { wrapPageElement } from './src'
+import * as React from 'react'
+import { WrapPageElement } from './src'
+
+export const wrapPageElement = ({ element }) => (
+  <WrapPageElement element={element} />
+)

--- a/packages/docs/gatsby-ssr.js
+++ b/packages/docs/gatsby-ssr.js
@@ -1,6 +1,5 @@
 import * as React from 'react'
+
 import { WrapPageElement } from './src'
 
-export const wrapPageElement = ({ element }) => (
-  <WrapPageElement element={element} />
-)
+export const wrapPageElement = (props) => <WrapPageElement {...props} />

--- a/packages/docs/gatsby-ssr.js
+++ b/packages/docs/gatsby-ssr.js
@@ -1,1 +1,6 @@
-export { wrapPageElement } from './src'
+import * as React from 'react'
+import { WrapPageElement } from './src'
+
+export const wrapPageElement = ({ element }) => (
+  <WrapPageElement element={element} />
+)

--- a/packages/docs/src/components/layout.js
+++ b/packages/docs/src/components/layout.js
@@ -39,10 +39,11 @@ const getModeName = (mode) => {
   }
 }
 
-export default (props) => {
+export default function DocsLayout(props) {
   const [menuOpen, setMenuOpen] = useState(false)
   const nav = useRef(null)
   const [mode, setMode] = useColorMode()
+
   const fullwidth =
     (props.pageContext.frontmatter &&
       props.pageContext.frontmatter.fullwidth) ||

--- a/packages/docs/src/gatsby-plugin-theme-ui/components.js
+++ b/packages/docs/src/gatsby-plugin-theme-ui/components.js
@@ -22,7 +22,7 @@ const heading = (Tag) => (props) =>
     <Tag {...props} />
   )
 
-export default {
+const components = {
   code,
   pre: (props) => props.children,
   h2: heading('h2'),
@@ -33,3 +33,5 @@ export default {
   // "shortcodes"
   Note,
 }
+
+export default components

--- a/packages/docs/src/gatsby-plugin-theme-ui/index.js
+++ b/packages/docs/src/gatsby-plugin-theme-ui/index.js
@@ -9,7 +9,7 @@ const tableCellStyle = {
   borderBottomStyle: 'solid',
 }
 
-export default {
+const theme = {
   colors: {
     text: '#000000',
     background: '#ffffff',
@@ -357,3 +357,5 @@ export default {
   },
   prism,
 }
+
+export default theme

--- a/packages/docs/src/index.js
+++ b/packages/docs/src/index.js
@@ -2,7 +2,7 @@
 import { jsx } from 'theme-ui'
 import Layout from './components/layout'
 
-export const wrapPageElement = ({ element, props }) => (
+export const WrapPageElement = ({ element, props }) => (
   <Layout {...props} children={element} />
 )
 

--- a/packages/docs/src/pages/getting-started/gatsby.mdx
+++ b/packages/docs/src/pages/getting-started/gatsby.mdx
@@ -22,12 +22,14 @@ Create a theme file located at `src/gatsby-plugin-theme-ui/index.js`.
 
 ```js
 // example theme file
-export default {
+const theme = {
   colors: {
     text: '#000',
     background: '#fff',
   },
 }
+
+export default theme
 ```
 
 With `gatsby-plugin-theme-ui`, there is no need to manually use the `ThemeProvider` component.

--- a/packages/docs/src/pages/guides/syntax-highlighting.mdx
+++ b/packages/docs/src/pages/guides/syntax-highlighting.mdx
@@ -32,11 +32,13 @@ Import and add a syntax theme from the Prism component to your theme object.
 // src/gatsby-plugin-theme-ui/index.js
 import nightOwl from '@theme-ui/prism/presets/night-owl'
 
-export default {
+const theme = {
   styles: {
     pre: {
       ...nightOwl,
     },
   },
 }
+
+export default theme
 ```

--- a/packages/docs/src/pages/packages/gatsby-theme-ui-blog.mdx
+++ b/packages/docs/src/pages/packages/gatsby-theme-ui-blog.mdx
@@ -53,7 +53,7 @@ module.exports = {
 // shadow src/gatsby-plugin-theme-ui/index.js
 import base from 'gatsby-theme-ui-blog/src/gatsby-plugin-theme-ui'
 
-export default {
+const theme = {
   ...base,
   colors: {
     text: 'white',
@@ -62,6 +62,8 @@ export default {
     secondary: 'magenta',
   },
 }
+
+export default theme
 ```
 
 ## Options

--- a/packages/gatsby-plugin-theme-ui/README.md
+++ b/packages/gatsby-plugin-theme-ui/README.md
@@ -51,12 +51,14 @@ To customize the theme used in your Gatsby site,
 shadow the `src/gatsby-plugin-theme-ui/index.js` module.
 
 ```js filename=src/gatsby-plugin-theme-ui/index.js
-export default {
+const theme = {
   colors: {
     text: '#111',
     background: '#fff',
   },
 }
+
+export default theme
 ```
 
 ### Load theme from custom path
@@ -95,7 +97,7 @@ To extend a Gatsby theme that uses Theme UI, import the base theme and export a 
 ```js filename=src/gatsby-plugin-theme-ui/index.js
 import baseTheme from 'gatsby-theme-blog/src/gatsby-plugin-theme-ui'
 
-export default {
+const theme = {
   ...baseTheme,
   colors: {
     ...baseTheme.colors,
@@ -103,6 +105,8 @@ export default {
     background: '#fff',
   },
 }
+
+export default theme
 ```
 
 You can also import and use presets from [@theme-ui/presets](https://theme-ui.com/packages/presets) to use as a starting point.
@@ -112,7 +116,7 @@ You can also import and use presets from [@theme-ui/presets](https://theme-ui.co
 To enable support for multiple color modes, add a nested `modes` object to `theme.colors`.
 
 ```js filename=src/gatsby-plugin-theme-ui/index.js
-export default {
+const theme = {
   colors: {
     text: '#000',
     background: '#fff',
@@ -124,6 +128,8 @@ export default {
     },
   },
 }
+
+export default theme
 ```
 
 ## Components
@@ -131,13 +137,15 @@ export default {
 Custom MDX components that will receive styles from the theme can be included by adding a `src/gatsby-plugin-theme-ui/components.js` module.
 
 ```js filename=src/gatsby-plugin-theme-ui/components.js
-export default {
+const components = {
   h1: (props) => (
     <h1 {...props}>
       <a href={`#${props.id}`}>{props.children}</a>
     </h1>
   ),
 }
+
+export default components
 ```
 
 MIT License

--- a/packages/gatsby-plugin-theme-ui/gatsby-browser.js
+++ b/packages/gatsby-plugin-theme-ui/gatsby-browser.js
@@ -1,1 +1,6 @@
-export { wrapRootElement } from './src/provider'
+import * as React from "react"
+import { WrapRootElement } from './src/provider'
+
+export const wrapRootElement = ({ element }) => (
+  <WrapRootElement element={element} />
+)

--- a/packages/gatsby-plugin-theme-ui/gatsby-ssr.js
+++ b/packages/gatsby-plugin-theme-ui/gatsby-ssr.js
@@ -1,6 +1,6 @@
+import * as React from "react"
 import { jsx, InitializeColorMode } from 'theme-ui'
-
-export { wrapRootElement } from './src/provider'
+import { WrapRootElement } from './src/provider'
 
 export const onRenderBody = (
   { setPreBodyComponents },
@@ -12,3 +12,7 @@ export const onRenderBody = (
     ])
   }
 }
+
+export const wrapRootElement = ({ element }) => (
+  <WrapRootElement element={element} />
+)

--- a/packages/gatsby-plugin-theme-ui/src/components.js
+++ b/packages/gatsby-plugin-theme-ui/src/components.js
@@ -1,2 +1,4 @@
 // add custom MDX components here
-export default {}
+const components = {}
+
+export default components

--- a/packages/gatsby-plugin-theme-ui/src/index.js
+++ b/packages/gatsby-plugin-theme-ui/src/index.js
@@ -1,2 +1,4 @@
 // add colors, fonts, fontSizes, space, etc
-export default {}
+const theme = {}
+
+export default theme

--- a/packages/gatsby-plugin-theme-ui/src/provider.js
+++ b/packages/gatsby-plugin-theme-ui/src/provider.js
@@ -26,6 +26,6 @@ const Root = ({ children }) => {
   )
 }
 
-export const wrapRootElement = ({ element }) => {
+export const WrapRootElement = ({ element }) => {
   return <Root>{element}</Root>
 }

--- a/packages/gatsby-plugin-theme-ui/test/provider.js
+++ b/packages/gatsby-plugin-theme-ui/test/provider.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render, cleanup } from '@testing-library/react'
 import { useThemeUI } from 'theme-ui'
-import { wrapRootElement } from '../src/provider'
+import { WrapRootElement } from '../src/provider'
 import theme from '../src/index'
 import renderer from 'react-test-renderer'
 
@@ -20,7 +20,7 @@ const Consumer = (props) => {
 }
 
 test('renders with theme context', () => {
-  const root = render(wrapRootElement({ element: <Consumer /> }, {}))
+  const root = render(WrapRootElement({ element: <Consumer /> }, {}))
   expect(context.theme).toEqual({
     colors: {},
     styles: {
@@ -39,7 +39,7 @@ test.skip('renders with ColorMode component', () => {
     },
   }
   const root = renderer.create(
-    wrapRootElement(
+    WrapRootElement(
       {
         element: <Consumer />,
       },


### PR DESCRIPTION
## Description

Hi!

We were looking into the issues listed below and found that we'd need to fix a little thing in Gatsby and also something in Theme UI. Fast Refresh has some limitations (https://www.gatsbyjs.com/docs/reference/local-development/fast-refresh/#limitations) and in the past our docs didn't account for those + the Theme UI plugin is pretty "old" so it used the suggested solutions at the time.

Anyhow, the issue is that the `wrapRootElement`/`wrapPageElement` APIs in Gatsby are not React components but functions that we call and so in this plugin they pass the lowercased component through. Fast Refresh doesn't like lowercased components so the fix is to 1) use PascalCase for the real react component and 2) use that React component explicitly in `gatsby-ssr.js`/`gatsby-browser.js`.

While our fix on Gatsby's side of things will make Theme UI work, too, adding these changes here will minimize the React tree that Fast Refresh has to go through. Here's a video:

https://user-images.githubusercontent.com/16143594/115028225-e8b6ba00-9ec4-11eb-971d-d95d66c7485f.mp4

As you can see only two files were traversed for the change. And it works, of course 😆 

## This PR

I've put each change in separate commits for easier reviewing. I essentially applied the changes made to the Gatsby plugin to all other Gatsby instances where that pattern was used.

I also updated the docs and any occurrence of a theme/components to not use anonymous default exports (as Fast Refresh doesn't like that) and it's also better for debugging / profiling.

## Related

Fixes https://github.com/system-ui/theme-ui/issues/1440
Fixes https://github.com/gatsbyjs/gatsby/issues/30387
Fixes https://github.com/system-ui/theme-ui/issues/1595
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v0.7.1-develop.0`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from a new contributor! :tada:
  
  Thank you, Jonathan Van Buren ([@vanbujm](https://github.com/vanbujm)), for all your work!
  
  #### 🐛 Bug Fix
  
  - `gatsby-plugin-theme-ui`
    - fix(gatsby-plugin-theme-ui): Fast Refresh Compatibility [#1659](https://github.com/system-ui/theme-ui/pull/1659) ([@LekoArts](https://github.com/LekoArts) [@hasparus](https://github.com/hasparus))
  - `@theme-ui/components`
    - fix(components): Allow styled-system space props on Paragraph [#1658](https://github.com/system-ui/theme-ui/pull/1658) ([@vanbujm](https://github.com/vanbujm))
  
  #### ⚠️ Pushed to `develop`
  
  - ci(auto): temporarily disable auto/magic-zero ([@hasparus](https://github.com/hasparus))
  - chore: gitignore yarn-error.log ([@hasparus](https://github.com/hasparus))
  - chore: add auto magic-zero plugin ([@hasparus](https://github.com/hasparus))
  - `@theme-ui/editor`, `gatsby-plugin-theme-ui`, `@theme-ui/parse-props`, `@theme-ui/prism`, `@theme-ui/style-guide`
    - chore: update internal peerDependencies ([@hasparus](https://github.com/hasparus))
  - `@theme-ui/style-guide`
    - chore(style-guide): widen theme-ui peerDependency ([@hasparus](https://github.com/hasparus))
  
  #### 🔩 Dependency Updates
  
  - chore(deps): bump ssri from 6.0.1 to 6.0.2 in /examples/next [#1661](https://github.com/system-ui/theme-ui/pull/1661) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): [security] bump ssri from 6.0.1 to 6.0.2 [#1660](https://github.com/system-ui/theme-ui/pull/1660) ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
  
  #### Authors: 5
  
  - [@dependabot-preview[bot]](https://github.com/dependabot-preview[bot])
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Jonathan Van Buren ([@vanbujm](https://github.com/vanbujm))
  - Lennart ([@LekoArts](https://github.com/LekoArts))
  - Piotr Monwid-Olechnowicz ([@hasparus](https://github.com/hasparus))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
