### PR TITLE
Return negative number from lookup if theme value is a number

### DIFF
--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -246,6 +246,9 @@ const positiveOrNegative = (scale: object, value: string | number) => {
     if (typeof value === 'string' && value.startsWith('-')) {
       const valueWithoutMinus = value.substring(1)
       const n = get(scale, valueWithoutMinus, valueWithoutMinus)
+      if (typeof n === 'number') {
+        return n * -1
+      }
       return `-${n}`
     }
     return get(scale, value, value)

--- a/packages/css/test/index.ts
+++ b/packages/css/test/index.ts
@@ -405,7 +405,7 @@ test('handles negative top, left, bottom, and right from scale', () => {
   })
 })
 
-test('handles negative margins from scale that is an object', () => {
+test.only('handles negative margins from scale that is an object and value is string', () => {
   const result = css({
     mt: '-s',
     mx: '-m',
@@ -414,6 +414,18 @@ test('handles negative margins from scale that is an object', () => {
     marginTop: '-16px',
     marginLeft: '-32px',
     marginRight: '-32px',
+  })
+})
+
+test.only('handles negative margins from scale that is an object and value is number', () => {
+  const result = css({
+    mt: '-s',
+    mx: '-m',
+  })({ ...theme, space: { s: 16, m: 32 } })
+  expect(result).toEqual({
+    marginTop: -16,
+    marginLeft: -32,
+    marginRight: -32,
   })
 })
 

--- a/packages/css/test/index.ts
+++ b/packages/css/test/index.ts
@@ -405,7 +405,7 @@ test('handles negative top, left, bottom, and right from scale', () => {
   })
 })
 
-test.only('handles negative margins from scale that is an object and value is string', () => {
+test('handles negative margins from scale that is an object and value is string', () => {
   const result = css({
     mt: '-s',
     mx: '-m',
@@ -417,7 +417,7 @@ test.only('handles negative margins from scale that is an object and value is st
   })
 })
 
-test.only('handles negative margins from scale that is an object and value is number', () => {
+test('handles negative margins from scale that is an object and value is number', () => {
   const result = css({
     mt: '-s',
     mx: '-m',


### PR DESCRIPTION
On a previous pull request https://github.com/system-ui/theme-ui/pull/865 I added the feature to allow negative lookups of theme objects to be resolved.

eg:
given `{ space: { s: '8px' }` and `sx={{ margin: '-s' }}` would be resolved to `margin: '-8px'`

however when the theme value is a `number` it resolves to `'-8'` (string) instead of `-8` (number) and then in the browser you see `margin: -80` instead of `margin: -80px`

This pr will fix this by checking if the theme value type is a number, and if it is will return a number. 