### PR TITLE
fix: prevent unwanted rerender

### DIFF
--- a/packages/color-modes/src/index.tsx
+++ b/packages/color-modes/src/index.tsx
@@ -69,6 +69,7 @@ const getModeFromClass = (): string | undefined => {
 }
 
 const useColorModeState = (theme: Theme = {}) => {
+  let stored: ReturnType<typeof storage.get>
   let [mode, setMode] = useState(() => {
     const modeFromClass = getModeFromClass()
     if (modeFromClass) {
@@ -78,22 +79,17 @@ const useColorModeState = (theme: Theme = {}) => {
     const preferredMode =
       theme.useColorSchemeMediaQuery !== false && getPreferredColorScheme()
 
-    return preferredMode || theme.initialColorModeName
+    stored = theme.useLocalStorage !== false ? storage.get() : undefined;
+
+    return stored || preferredMode || theme.initialColorModeName
   })
 
   // on first render, we read the color mode from localStorage and
   // clear the class on document element body
   useEffect(() => {
-    const stored = theme.useLocalStorage !== false && storage.get()
-
     if (typeof document !== 'undefined') {
       document.documentElement.classList.remove('theme-ui-' + stored)
       document.body.classList.remove('theme-ui-' + stored)
-    }
-
-    if (stored && stored !== mode) {
-      mode = stored
-      setMode(stored)
     }
   }, [])
 

--- a/packages/color-modes/src/index.tsx
+++ b/packages/color-modes/src/index.tsx
@@ -81,6 +81,7 @@ const useColorModeState = (theme: Theme = {}) => {
     return preferredMode || theme.initialColorModeName
   })
 
+  // remove initial color mode classes from the document and body
   useEffect(() => {
     const classMode = getModeFromClass()
     if (classMode) {

--- a/packages/color-modes/src/index.tsx
+++ b/packages/color-modes/src/index.tsx
@@ -72,9 +72,12 @@ const useColorModeState = (theme: Theme = {}) => {
   let [mode, setMode] = useState(() => {
     const stored = theme.useLocalStorage !== false ? storage.get() : undefined
     if (stored) {
+      // on first render, we clear the class on document element body
+      document.documentElement.classList.remove('theme-ui-' + mode)
+      document.body.classList.remove('theme-ui-' + mode)
       return stored
     }
-    
+
     const modeFromClass = getModeFromClass()
     if (modeFromClass) {
       return modeFromClass
@@ -85,14 +88,6 @@ const useColorModeState = (theme: Theme = {}) => {
 
     return preferredMode || theme.initialColorModeName
   })
-
-  // on first render, we clear the class on document element body
-  useEffect(() => {
-    if (typeof document !== 'undefined') {
-      document.documentElement.classList.remove('theme-ui-' + mode)
-      document.body.classList.remove('theme-ui-' + mode)
-    }
-  }, [])
 
   // when mode changes, we save it to localStorage
   React.useEffect(() => {

--- a/packages/color-modes/src/index.tsx
+++ b/packages/color-modes/src/index.tsx
@@ -69,7 +69,6 @@ const getModeFromClass = (): string | undefined => {
 }
 
 const useColorModeState = (theme: Theme = {}) => {
-  let stored: ReturnType<typeof storage.get>
   let [mode, setMode] = useState(() => {
     const modeFromClass = getModeFromClass()
     if (modeFromClass) {
@@ -79,17 +78,16 @@ const useColorModeState = (theme: Theme = {}) => {
     const preferredMode =
       theme.useColorSchemeMediaQuery !== false && getPreferredColorScheme()
 
-    stored = theme.useLocalStorage !== false ? storage.get() : undefined;
+    const stored = theme.useLocalStorage !== false ? storage.get() : undefined;
 
-    return stored || preferredMode || theme.initialColorModeName
+    return  stored || preferredMode || theme.initialColorModeName
   })
 
-  // on first render, we read the color mode from localStorage and
-  // clear the class on document element body
+  // on first render, we clear the class on document element body
   useEffect(() => {
     if (typeof document !== 'undefined') {
-      document.documentElement.classList.remove('theme-ui-' + stored)
-      document.body.classList.remove('theme-ui-' + stored)
+      document.documentElement.classList.remove('theme-ui-' + mode)
+      document.body.classList.remove('theme-ui-' + mode)
     }
   }, [])
 

--- a/packages/color-modes/src/index.tsx
+++ b/packages/color-modes/src/index.tsx
@@ -81,7 +81,7 @@ const useColorModeState = (theme: Theme = {}) => {
     return preferredMode || theme.initialColorModeName
   })
 
-  React.useEffect(() => {
+  useEffect(() => {
     const classMode = getModeFromClass()
     if (classMode) {
       document.documentElement.classList.remove('theme-ui-' + classMode)
@@ -90,7 +90,7 @@ const useColorModeState = (theme: Theme = {}) => {
   }, [])
 
   // when mode changes, we save it to localStorage
-  React.useEffect(() => {
+  useEffect(() => {
     if (mode && theme.useLocalStorage !== false) {
       storage.set(mode)
     }

--- a/packages/color-modes/src/index.tsx
+++ b/packages/color-modes/src/index.tsx
@@ -70,6 +70,11 @@ const getModeFromClass = (): string | undefined => {
 
 const useColorModeState = (theme: Theme = {}) => {
   let [mode, setMode] = useState(() => {
+    const stored = theme.useLocalStorage !== false ? storage.get() : undefined
+    if (stored) {
+      return stored
+    }
+    
     const modeFromClass = getModeFromClass()
     if (modeFromClass) {
       return modeFromClass
@@ -78,9 +83,7 @@ const useColorModeState = (theme: Theme = {}) => {
     const preferredMode =
       theme.useColorSchemeMediaQuery !== false && getPreferredColorScheme()
 
-    const stored = theme.useLocalStorage !== false ? storage.get() : undefined;
-
-    return  stored || preferredMode || theme.initialColorModeName
+    return preferredMode || theme.initialColorModeName
   })
 
   // on first render, we clear the class on document element body

--- a/packages/color-modes/src/index.tsx
+++ b/packages/color-modes/src/index.tsx
@@ -70,14 +70,6 @@ const getModeFromClass = (): string | undefined => {
 
 const useColorModeState = (theme: Theme = {}) => {
   let [mode, setMode] = useState(() => {
-    const stored = theme.useLocalStorage !== false ? storage.get() : undefined
-    if (stored) {
-      // on first render, we clear the class on document element body
-      document.documentElement.classList.remove('theme-ui-' + mode)
-      document.body.classList.remove('theme-ui-' + mode)
-      return stored
-    }
-
     const modeFromClass = getModeFromClass()
     if (modeFromClass) {
       return modeFromClass
@@ -88,6 +80,14 @@ const useColorModeState = (theme: Theme = {}) => {
 
     return preferredMode || theme.initialColorModeName
   })
+
+  React.useEffect(() => {
+    const classMode = getModeFromClass()
+    if (classMode) {
+      document.documentElement.classList.remove('theme-ui-' + classMode)
+      document.body.classList.remove('theme-ui-' + classMode)
+    }
+  }, [])
 
   // when mode changes, we save it to localStorage
   React.useEffect(() => {


### PR DESCRIPTION
I noticed that after initial render of the `ThemeColorProvider`, it was re-rendering.This MR prevents this re-render from taking place by populating initial color state with the localStorage cache state on first render.

Edit: It now just uses the classNames to populate initial state.