### PR TITLE
Docs: improve Switch component documentation

### DIFF
--- a/packages/docs/src/pages/components/switch.mdx
+++ b/packages/docs/src/pages/components/switch.mdx
@@ -17,25 +17,24 @@ import { Switch } from 'theme-ui'
 ## Input state style `&:checked`
 
 The Switch component renders several elements, among other things an
-`<input type="checkbox" />` which state can be used to update the style.
+`<input type="checkbox" />`, the state of which can be used to update the style.
 
 However, since this input is hidden by CSS (the "visual switch" is a Box),
 applying for instance the `&:checked` CSS selector will not show any difference.
 
 To show different style based on the input state, you can use
-[Emotion's "&" selector](https://emotion.sh/docs/styled#nesting-components)
-instead
+[Emotion’s `&` selector](https://emotion.sh/docs/styled#nesting-components)
 
 ```jsx live=true
 <Switch
   label="Enable email alerts?"
   sx={{
     bakgroundColor: 'gray',
-    // This will not be shown since the input is hidden
+    // This will not be visible since the input is hidden
     // '&:checked': {
     //   backgroundColor: 'primary'
     // },
-    // This will be shown
+    // This will be visible
     'input:checked ~ &': {
       backgroundColor: 'primary',
     },

--- a/packages/docs/src/pages/components/switch.mdx
+++ b/packages/docs/src/pages/components/switch.mdx
@@ -10,10 +10,65 @@ Form switch input component
 import { Switch } from 'theme-ui'
 ```
 
-```js live=true
+```jsx live=true
 <Switch label="Enable email alerts?" />
+```
+
+## Input state style `&:checked`
+
+The Switch component renders several elements, among other things an
+`<input type="checkbox" />` which state can be used to update the style.
+
+However, since this input is hidden by CSS (the "visual switch" is a Box),
+applying for instance the `&:checked` CSS selector will not show any difference.
+
+To show different style based on the input state, you can use
+[Emotion's `&` nest selector](https://emotion.sh/docs/styled#nesting-components)
+instead
+
+```jsx live=true
+<Switch
+  label="Enable email alerts?"
+  sx={{
+    bakgroundColor: 'gray',
+    // This will not be shown since the input is hidden
+    // '&:checked': {
+    //   backgroundColor: 'primary'
+    // },
+    // This will be shown
+    'input:checked ~ &': {
+      backgroundColor: 'primary',
+    },
+  }}
+/>
+```
+
+## External label
+
+Even though the Switch component already renders a label, but you can also
+opt-in for an external label instead.
+
+```js
+import { Box, Flex, Label, Switch } from 'theme-ui'
+```
+
+```jsx live=true
+<Flex
+  sx={{
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    py: 4,
+  }}>
+  <Label htmlFor="enable-email-alerts" sx={{ flex: 1 }}>
+    Enable email alerts?
+  </Label>
+  <Box>
+    <Switch id="enable-email-alerts" />
+  </Box>
+</Flex>
 ```
 
 ## Variants
 
-Radio variants can be defined in `theme.forms` and the component uses the `theme.forms.switch` variant by default.
+Switch variants can be defined in `theme.forms` and the component uses the
+`theme.forms.switch` variant by default.

--- a/packages/docs/src/pages/components/switch.mdx
+++ b/packages/docs/src/pages/components/switch.mdx
@@ -23,7 +23,7 @@ However, since this input is hidden by CSS (the "visual switch" is a Box),
 applying for instance the `&:checked` CSS selector will not show any difference.
 
 To show different style based on the input state, you can use
-[Emotion's `&` nest selector](https://emotion.sh/docs/styled#nesting-components)
+[Emotion's "&" selector](https://emotion.sh/docs/styled#nesting-components)
 instead
 
 ```jsx live=true


### PR DESCRIPTION
- docs(components): update Switch documentation page
  - illustrate how to use input state with Emotion's nest selector
  - add example with external label

Relates to #1671 