### PR TITLE
modernize Babel config

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,14 @@
 module.exports = {
   presets: [
-    [require.resolve('@babel/preset-env'), { loose: true }],
+    [
+      '@babel/preset-env',
+      {
+        bugfixes: true,
+        loose: true,
+        modules: false,
+        targets: '> 0.25%, not dead, not ie 11',
+      },
+    ],
     '@babel/react',
     '@babel/preset-typescript',
   ],

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,9 @@
 module.exports = {
-  presets: ['@babel/env', '@babel/react', '@babel/preset-typescript'],
+  presets: [
+    [require.resolve('@babel/preset-env'), { loose: true }],
+    '@babel/react',
+    '@babel/preset-typescript',
+  ],
   env: {
     test: {
       plugins: ['@babel/plugin-transform-runtime'],

--- a/packages/preset-base/babel.config.js
+++ b/packages/preset-base/babel.config.js
@@ -1,1 +1,0 @@
-module.exports = require('../../babel.config')

--- a/packages/preset-bootstrap/babel.config.js
+++ b/packages/preset-bootstrap/babel.config.js
@@ -1,1 +1,0 @@
-module.exports = require('../../babel.config')

--- a/packages/sidenav/babel.config.js
+++ b/packages/sidenav/babel.config.js
@@ -1,1 +1,0 @@
-module.exports = require('../../babel.config')

--- a/packages/typography/babel.config.js
+++ b/packages/typography/babel.config.js
@@ -1,1 +1,0 @@
-module.exports = require('../../babel.config')


### PR DESCRIPTION
First commit of this PR hase the same configuration for `@babel/preset-env` Emotion uses (if I'm not wrong — [emotion/babel-preset-emotion-dev/src/index.js](https://github.com/emotion-js/emotion/blob/main/scripts/babel-preset-emotion-dev/src/index.js)).

Enabling `loose` resulted with 20% reduction in build size compared to current `develop`.

## Release notes

All Theme UI package became on average 34% lighter! 🪶 It's 9.5kB if you sum all of them!

The trade-off is, Babel config has changed and it no longer supports Internet Explorer 11. 
If you need to support legacy browsers, you can transpile node_modules (e.g. with [next-transpile-modules](https://github.com/martpie/next-transpile-modules)).

- [See build raport with size comparison for each package.](https://github.com/system-ui/theme-ui/runs/2618450614)
- [See updated Babel config.](https://github.com/system-ui/theme-ui/blob/develop/babel.config.js)

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->

---

### Published prerelease version: `v0.9.0-develop.1`

<details>
  <summary>Changelog</summary>

  ### Release Notes
  
  #### modernize Babel config ([#1721](https://github.com/system-ui/theme-ui/pull/1721))
  
  All Theme UI package became on average 34% lighter! 🪶 It's 9.5kB if you sum all of them!
  
  The trade-off is, Babel config has changed and it no longer supports Internet Explorer 11. 
  If you need to support legacy browsers, you can transpile node_modules (e.g. with [next-transpile-modules](https://github.com/martpie/next-transpile-modules)).
  
  - [See build raport with size comparison for each package.](https://github.com/system-ui/theme-ui/runs/2618450614)
  - [See updated Babel config.](https://github.com/system-ui/theme-ui/blob/develop/babel.config.js)
  
  ---
  
  #### 🚀 Enhancement
  
  - `@theme-ui/preset-base`, `@theme-ui/preset-bootstrap`, `@theme-ui/sidenav`, `@theme-ui/typography`
    - modernize Babel config [#1721](https://github.com/system-ui/theme-ui/pull/1721) ([@hasparus](https://github.com/hasparus))
  
  #### 🐛 Bug Fix
  
  - Stop dependabot from trying to run codechecks [#1753](https://github.com/system-ui/theme-ui/pull/1753) ([@hasparus](https://github.com/hasparus))
  - fix(ci): add branches to codechecks ([@hasparus](https://github.com/hasparus))
  - ci: add codechecks with build-size-watcher [#1740](https://github.com/system-ui/theme-ui/pull/1740) ([@hasparus](https://github.com/hasparus))
  - `@theme-ui/components`
    - fix(components): set Select's bgColor to "background" - fixes dark mode ([@hasparus](https://github.com/hasparus))
  
  #### ⚠️ Pushed to `develop`
  
  - chore(auto): add omit-commits plugin ([@hasparus](https://github.com/hasparus))
  - ci(codechecks): remove debug env var ([@hasparus](https://github.com/hasparus))
  - ci(codechecks): remove patch ([@hasparus](https://github.com/hasparus))
  - ci(codechecks): use yml ([@hasparus](https://github.com/hasparus))
  - ci(codechecks): turn speculativeBranchSelection on ([@hasparus](https://github.com/hasparus))
  - ci(codechecks): another patch ([@hasparus](https://github.com/hasparus))
  - ci(codechecks): patch - yeah, it can only be done on develop ([@hasparus](https://github.com/hasparus))
  - ci(codechecks): patch ([@hasparus](https://github.com/hasparus))
  - ci(codechecks): debug ([@hasparus](https://github.com/hasparus))
  - ci(codechecks): make output verbose ([@hasparus](https://github.com/hasparus))
  - ci(codechecks): turn off speculative branch selection ([@hasparus](https://github.com/hasparus))
  - `@theme-ui/components`
    - test(components): update Select tests ([@hasparus](https://github.com/hasparus))
  
  #### 📝 Documentation
  
  - style DocSearch [#1714](https://github.com/system-ui/theme-ui/pull/1714) ([@atanasster](https://github.com/atanasster) [@hasparus](https://github.com/hasparus))
  
  #### Authors: 2
  
  - Atanas Stoyanov ([@atanasster](https://github.com/atanasster))
  - Piotr Monwid-Olechnowicz ([@hasparus](https://github.com/hasparus))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
