### PR TITLE
fix: Allow overriding Paragraph margins via theme

### DIFF
--- a/packages/components/src/Paragraph.js
+++ b/packages/components/src/Paragraph.js
@@ -1,17 +1,12 @@
 import React from 'react'
 import Box from './Box'
 
-export const Paragraph = React.forwardRef(function Paragraph(
-  props,
-  ref
-) {
+export const Paragraph = React.forwardRef(function Paragraph(props, ref) {
   return (
     <Box
       ref={ref}
       as="p"
       variant="paragraph"
-      // reset margin by default: avoid relying on user-agent margins (not aware of theme-ui space scale)
-      m={0}
       __themeKey="text"
       __css={{
         fontFamily: 'body',

--- a/packages/components/test/__snapshots__/index.js.snap
+++ b/packages/components/test/__snapshots__/index.js.snap
@@ -1097,7 +1097,6 @@ exports[`Paragraph renders 1`] = `
   font-family: body;
   font-weight: body;
   line-height: body;
-  margin: 0;
 }
 
 <p

--- a/packages/components/test/index.js
+++ b/packages/components/test/index.js
@@ -341,6 +341,26 @@ describe('Paragraph', () => {
     const json = renderJSON(<Paragraph m={margin} />)
     expect(json).toHaveStyleRule('margin', margin)
   })
+
+  test('renders with theme override', () => {
+    const margin = '8px'
+    const json = renderJSON(
+      <ThemeProvider theme={{ text: { paragraph: { margin } } }}>
+        <Paragraph />
+      </ThemeProvider>
+    )
+    expect(json).toHaveStyleRule('margin', margin)
+  })
+
+  test('renders with theme variant', () => {
+    const margin = '8px'
+    const json = renderJSON(
+      <ThemeProvider theme={{ text: { override: { margin } } }}>
+        <Paragraph variant="override" />
+      </ThemeProvider>
+    )
+    expect(json).toHaveStyleRule('margin', margin)
+  })
 })
 
 describe('Text', () => {


### PR DESCRIPTION
This fixes #1774 - I found that margin: 0 is set by default (coming from Box maybe? Not 100% sure).

So if we don't set the margin for Paragraph manually, the specificity issues disappear.

I also added two tests using a theme override - the other two cases are already covered by the existing tests.
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v0.9.1-develop.0`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - `@theme-ui/components`
    - fix: Allow overriding Paragraph margins via theme [#1775](https://github.com/system-ui/theme-ui/pull/1775) ([@bernharduw](https://github.com/bernharduw))
  
  #### Authors: 1
  
  - Bernhard Gschwantner ([@bernharduw](https://github.com/bernharduw))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
