### PR TITLE
Add missing repository metadata to published packages

### DIFF
--- a/packages/color/package.json
+++ b/packages/color/package.json
@@ -14,5 +14,6 @@
     "access": "public"
   },
   "license": "MIT",
+  "repository": "system-ui/theme-ui",
   "gitHead": "621199460fa3bdb0100748441e62517b7529b8c8"
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -23,6 +23,7 @@
   },
   "author": "Brent Jackson <jxnblk@gmail.com>",
   "license": "MIT",
+  "repository": "system-ui/theme-ui",
   "devDependencies": {
     "react": "^17.0.1"
   }

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -8,6 +8,7 @@
   "scripts": {},
   "author": "Brent Jackson",
   "license": "MIT",
+  "repository": "system-ui/theme-ui",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/custom-properties/package.json
+++ b/packages/custom-properties/package.json
@@ -7,6 +7,7 @@
   "module": "dist/theme-ui-custom-properties.esm.js",
   "author": "Alex Page <alex@alexpage.com.au>",
   "license": "MIT",
+  "repository": "system-ui/theme-ui",
   "scripts": {},
   "publishConfig": {
     "access": "public"

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -5,6 +5,7 @@
   "main": "dist/docs.cjs.js",
   "author": "Brent Jackson <jxnblk@gmail.com>",
   "license": "MIT",
+  "repository": "system-ui/theme-ui",
   "scripts": {
     "start": "DEBUG=gatsby:query-watcher gatsby develop",
     "build": "gatsby build",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -6,6 +6,7 @@
   "types": "dist/theme-ui-editor.cjs.d.ts",
   "author": "Brent Jackson",
   "license": "MIT",
+  "repository": "system-ui/theme-ui",
   "scripts": {},
   "dependencies": {
     "@theme-ui/components": "0.9.0",

--- a/packages/gatsby-theme-style-guide/package.json
+++ b/packages/gatsby-theme-style-guide/package.json
@@ -3,6 +3,7 @@
   "version": "0.9.0",
   "main": "dist/gatsby-theme-style-guide.cjs.js",
   "license": "MIT",
+  "repository": "system-ui/theme-ui",
   "peerDependencies": {
     "gatsby": "^2.0.0 || ^3.0.0",
     "react": "^16.14.0 || ^17.0.0",

--- a/packages/preset-bootstrap/package.json
+++ b/packages/preset-bootstrap/package.json
@@ -7,6 +7,7 @@
   "source": "src/index.ts",
   "author": "Brent Jackson",
   "license": "MIT",
+  "repository": "system-ui/theme-ui",
   "scripts": {},
   "publishConfig": {
     "access": "public"

--- a/packages/preset-bulma/package.json
+++ b/packages/preset-bulma/package.json
@@ -6,6 +6,7 @@
   "source": "src/index.ts",
   "author": "Brent Jackson",
   "license": "MIT",
+  "repository": "system-ui/theme-ui",
   "scripts": {},
   "dependencies": {
     "@theme-ui/preset-base": "0.9.0"

--- a/packages/preset-dark/package.json
+++ b/packages/preset-dark/package.json
@@ -7,6 +7,7 @@
   "source": "src/index.ts",
   "author": "Brent Jackson",
   "license": "MIT",
+  "repository": "system-ui/theme-ui",
   "scripts": {},
   "publishConfig": {
     "access": "public"

--- a/packages/preset-deep/package.json
+++ b/packages/preset-deep/package.json
@@ -6,6 +6,7 @@
   "source": "src/index.ts",
   "author": "Brent Jackson",
   "license": "MIT",
+  "repository": "system-ui/theme-ui",
   "scripts": {},
   "publishConfig": {
     "access": "public"

--- a/packages/preset-funk/package.json
+++ b/packages/preset-funk/package.json
@@ -6,6 +6,7 @@
   "source": "src/index.ts",
   "author": "Brent Jackson",
   "license": "MIT",
+  "repository": "system-ui/theme-ui",
   "scripts": {},
   "dependencies": {
     "@theme-ui/preset-base": "0.9.0"

--- a/packages/preset-future/package.json
+++ b/packages/preset-future/package.json
@@ -6,6 +6,7 @@
   "source": "src/index.ts",
   "author": "Brent Jackson",
   "license": "MIT",
+  "repository": "system-ui/theme-ui",
   "scripts": {},
   "dependencies": {
     "@theme-ui/preset-base": "0.9.0"

--- a/packages/preset-polaris/package.json
+++ b/packages/preset-polaris/package.json
@@ -6,6 +6,7 @@
   "source": "src/index.ts",
   "author": "Yuraima Estevez",
   "license": "MIT",
+  "repository": "system-ui/theme-ui",
   "scripts": {},
   "dependencies": {
     "@theme-ui/preset-base": "0.9.0"

--- a/packages/preset-roboto/package.json
+++ b/packages/preset-roboto/package.json
@@ -7,6 +7,7 @@
   "source": "src/index.ts",
   "author": "Brent Jackson",
   "license": "MIT",
+  "repository": "system-ui/theme-ui",
   "scripts": {},
   "dependencies": {
     "@theme-ui/preset-base": "0.9.0"

--- a/packages/preset-sketchy/package.json
+++ b/packages/preset-sketchy/package.json
@@ -7,6 +7,7 @@
   "source": "src/index.ts",
   "author": "Aleksandra Sikora",
   "license": "MIT",
+  "repository": "system-ui/theme-ui",
   "scripts": {},
   "publishConfig": {
     "access": "public"

--- a/packages/preset-swiss/package.json
+++ b/packages/preset-swiss/package.json
@@ -7,6 +7,7 @@
   "source": "src/index.ts",
   "author": "Brent Jackson",
   "license": "MIT",
+  "repository": "system-ui/theme-ui",
   "scripts": {},
   "publishConfig": {
     "access": "public"

--- a/packages/preset-system/package.json
+++ b/packages/preset-system/package.json
@@ -7,6 +7,7 @@
   "source": "src/index.ts",
   "author": "Brent Jackson",
   "license": "MIT",
+  "repository": "system-ui/theme-ui",
   "scripts": {},
   "publishConfig": {
     "access": "public"

--- a/packages/preset-tailwind/package.json
+++ b/packages/preset-tailwind/package.json
@@ -7,6 +7,7 @@
   "source": "src/index.ts",
   "author": "Brent Jackson",
   "license": "MIT",
+  "repository": "system-ui/theme-ui",
   "scripts": {},
   "publishConfig": {
     "access": "public"

--- a/packages/style-guide/package.json
+++ b/packages/style-guide/package.json
@@ -7,6 +7,7 @@
   "source": "src/index.ts",
   "author": "Brent Jackson",
   "license": "MIT",
+  "repository": "system-ui/theme-ui",
   "scripts": {},
   "dependencies": {
     "@theme-ui/presets": "0.9.0",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -3,6 +3,7 @@
   "version": "0.9.0",
   "private": true,
   "license": "MIT",
+  "repository": "system-ui/theme-ui",
   "source": "src/index.ts",
   "main": "dist/theme-ui-test-utils.cjs.js",
   "module": "dist/theme-ui-test-utils.esm.js",


### PR DESCRIPTION
Resolves #1776 by ensuring repository metadata is set in `package.json` in all published packages.
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v0.9.2-develop.0`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - `@theme-ui/color`, `@theme-ui/components`, `@theme-ui/css`, `@theme-ui/custom-properties`, `@theme-ui/editor`, `gatsby-theme-style-guide`, `@theme-ui/preset-bootstrap`, `@theme-ui/preset-bulma`, `@theme-ui/preset-dark`, `@theme-ui/preset-deep`, `@theme-ui/preset-funk`, `@theme-ui/preset-future`, `@theme-ui/preset-polaris`, `@theme-ui/preset-roboto`, `@theme-ui/preset-sketchy`, `@theme-ui/preset-swiss`, `@theme-ui/preset-system`, `@theme-ui/preset-tailwind`, `@theme-ui/style-guide`
    - Add missing repository metadata to published packages [#1779](https://github.com/system-ui/theme-ui/pull/1779) ([@aaronadamsCA](https://github.com/aaronadamsCA))
  
  #### Authors: 1
  
  - Aaron Adams ([@aaronadamsCA](https://github.com/aaronadamsCA))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
