### PR TITLE
Fix JSDoc comment for Paragraph default variant

### DIFF
--- a/packages/components/index.d.ts
+++ b/packages/components/index.d.ts
@@ -92,7 +92,7 @@ export interface ParagraphProps
  * Primitive typographic component.
  *
  * Text style variants can be defined in the theme.text object.
- * The Paragraph component uses theme.text.default as its default variant style.
+ * The Paragraph component uses theme.text.paragraph as its default variant style.
  * @see https://theme-ui.com/components/paragraph
  */
 export const Paragraph: ForwardRef<HTMLParagraphElement, ParagraphProps>


### PR DESCRIPTION
The JSDoc comment in the Paragraph component incorrectly mentions text.default as the default variant – this is shown in the Intellisense help text and is misleading.