### PR TITLE
fix(color-modes): combine color modes in nested theme providers

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,5 +11,12 @@ module.exports = {
   rules: {
     'no-use-before-define': 'off',
     'react/react-in-jsx-scope': 'off',
+    '@typescript-eslint/no-unused-vars': [
+      'warn',
+      {
+        varsIgnorePattern: '^_',
+        argsIgnorePattern: '^_',
+      },
+    ],
   },
 }

--- a/packages/color-modes/README.md
+++ b/packages/color-modes/README.md
@@ -4,7 +4,8 @@ Adds support for user-controlled color modes
 
 https://theme-ui.com
 
-**Note:** _This package is included in the main `theme-ui` package, and generally should not be used on its own._
+**Note:** _This package is included in the main `theme-ui` package, and
+generally should not be used on its own._
 
 ```sh
 npm i @theme-ui/color-modes

--- a/packages/color-modes/src/custom-properties.ts
+++ b/packages/color-modes/src/custom-properties.ts
@@ -80,10 +80,8 @@ export const createColorStyles = (theme: Theme = {}) => {
   if (!colors || useRootStyles === false) return {}
   if (useCustomProperties === false) {
     return css({
-      html: {
-        color: 'text',
-        bg: 'background',
-      },
+      color: 'text',
+      bg: 'background',
     })(theme)
   }
 
@@ -105,10 +103,8 @@ export const createColorStyles = (theme: Theme = {}) => {
   const colorToVarValue = (color: string) => toVarValue(`colors-${color}`)
 
   return css({
-    html: {
-      ...styles,
-      color: colorToVarValue('text'),
-      bg: colorToVarValue('background'),
-    },
+    ...styles,
+    color: colorToVarValue('text'),
+    bg: colorToVarValue('background'),
   })(theme)
 }

--- a/packages/color-modes/src/index.tsx
+++ b/packages/color-modes/src/index.tsx
@@ -146,7 +146,7 @@ export function useColorMode<T extends string = string>(): [
   }
 
   // We're allowing the user to specify a narrower type for its color mode name.
-  return ([colorMode, setColorMode] as unknown) as [
+  return [colorMode, setColorMode] as unknown as [
     T,
     Dispatch<SetStateAction<T>>
   ]
@@ -262,7 +262,7 @@ export const ColorModeProvider: React.FC = ({ children }) => {
         })
       : jsx('div', {
           className: 'theme-ui__nested-color-mode-provider',
-          style: createColorStyles(theme)['html'],
+          css: createColorStyles(theme)['html'],
         }),
     children
   )

--- a/packages/color-modes/test/custom-properties.tsx
+++ b/packages/color-modes/test/custom-properties.tsx
@@ -72,21 +72,19 @@ describe('createColorStyles', () => {
       },
     })
     expect(styles).toEqual({
-      html: {
-        color: 'var(--theme-ui-colors-text)',
-        backgroundColor: 'var(--theme-ui-colors-background)',
-        '--theme-ui-colors-text': 'tomato',
-        '--theme-ui-colors-background': 'white',
-        '--theme-ui-colors-primary': '#3333ee',
-        '--theme-ui-colors-primary-light': '#7373f7',
-        '--theme-ui-colors-primary-dark': '#00008f',
-        '&.theme-ui-dark': {
-          '--theme-ui-colors-text': 'white',
-          '--theme-ui-colors-background': 'black',
-          '--theme-ui-colors-primary': '#ee4933',
-          '--theme-ui-colors-primary-light': '#fd6d5a',
-          '--theme-ui-colors-primary-dark': '#962415',
-        },
+      color: 'var(--theme-ui-colors-text)',
+      backgroundColor: 'var(--theme-ui-colors-background)',
+      '--theme-ui-colors-text': 'tomato',
+      '--theme-ui-colors-background': 'white',
+      '--theme-ui-colors-primary': '#3333ee',
+      '--theme-ui-colors-primary-light': '#7373f7',
+      '--theme-ui-colors-primary-dark': '#00008f',
+      '&.theme-ui-dark': {
+        '--theme-ui-colors-text': 'white',
+        '--theme-ui-colors-background': 'black',
+        '--theme-ui-colors-primary': '#ee4933',
+        '--theme-ui-colors-primary-light': '#fd6d5a',
+        '--theme-ui-colors-primary-dark': '#962415',
       },
     })
   })
@@ -105,15 +103,13 @@ describe('createColorStyles', () => {
       },
     })
     expect(styles).toEqual({
-      html: {
-        color: 'var(--theme-ui-colors-text)',
-        backgroundColor: 'var(--theme-ui-colors-background)',
-        '--theme-ui-colors-text': 'tomato',
-        '--theme-ui-colors-background': 'white',
-        '&.theme-ui-dark': {
-          '--theme-ui-colors-text': 'white',
-          '--theme-ui-colors-background': 'black',
-        },
+      color: 'var(--theme-ui-colors-text)',
+      backgroundColor: 'var(--theme-ui-colors-background)',
+      '--theme-ui-colors-text': 'tomato',
+      '--theme-ui-colors-background': 'white',
+      '&.theme-ui-dark': {
+        '--theme-ui-colors-text': 'white',
+        '--theme-ui-colors-background': 'black',
       },
     })
   })
@@ -133,15 +129,13 @@ describe('createColorStyles', () => {
       },
     })
     expect(styles).toEqual({
-      html: {
-        color: 'var(--theme-ui-colors-text)',
-        backgroundColor: 'var(--theme-ui-colors-background)',
-        '--theme-ui-colors-text': 'white',
-        '--theme-ui-colors-background': 'tomato',
-        '&.theme-ui-light': {
-          '--theme-ui-colors-text': 'tomato',
-          '--theme-ui-colors-background': 'white',
-        },
+      color: 'var(--theme-ui-colors-text)',
+      backgroundColor: 'var(--theme-ui-colors-background)',
+      '--theme-ui-colors-text': 'white',
+      '--theme-ui-colors-background': 'tomato',
+      '&.theme-ui-light': {
+        '--theme-ui-colors-text': 'tomato',
+        '--theme-ui-colors-background': 'white',
       },
     })
   })
@@ -161,15 +155,13 @@ describe('createColorStyles', () => {
       },
     })
     expect(styles).toEqual({
-      html: {
-        color: 'var(--theme-ui-colors-text)',
-        backgroundColor: 'var(--theme-ui-colors-background)',
-        '--theme-ui-colors-text': 'white',
-        '--theme-ui-colors-background': 'tomato',
-        '&.theme-ui-light': {
-          '--theme-ui-colors-text': 'tomato',
-          '--theme-ui-colors-background': 'white',
-        },
+      color: 'var(--theme-ui-colors-text)',
+      backgroundColor: 'var(--theme-ui-colors-background)',
+      '--theme-ui-colors-text': 'white',
+      '--theme-ui-colors-background': 'tomato',
+      '&.theme-ui-light': {
+        '--theme-ui-colors-text': 'tomato',
+        '--theme-ui-colors-background': 'white',
       },
     })
   })
@@ -191,19 +183,17 @@ describe('createColorStyles', () => {
       },
     })
     expect(styles).toEqual({
-      html: {
-        color: 'var(--theme-ui-colors-text)',
-        backgroundColor: 'var(--theme-ui-colors-background)',
-        '--theme-ui-colors-text': 'white',
-        '--theme-ui-colors-background': 'tomato',
-        '&.theme-ui-light': {
-          '--theme-ui-colors-text': 'tomato',
-          '--theme-ui-colors-background': 'white',
-        },
-        '@media print': {
-          '--theme-ui-colors-text': 'tomato',
-          '--theme-ui-colors-background': 'white',
-        },
+      color: 'var(--theme-ui-colors-text)',
+      backgroundColor: 'var(--theme-ui-colors-background)',
+      '--theme-ui-colors-text': 'white',
+      '--theme-ui-colors-background': 'tomato',
+      '&.theme-ui-light': {
+        '--theme-ui-colors-text': 'tomato',
+        '--theme-ui-colors-background': 'white',
+      },
+      '@media print': {
+        '--theme-ui-colors-text': 'tomato',
+        '--theme-ui-colors-background': 'white',
       },
     })
   })
@@ -226,19 +216,17 @@ describe('createColorStyles', () => {
       },
     })
     expect(styles).toEqual({
-      html: {
-        color: 'var(--theme-ui-colors-text)',
-        backgroundColor: 'var(--theme-ui-colors-background)',
+      color: 'var(--theme-ui-colors-text)',
+      backgroundColor: 'var(--theme-ui-colors-background)',
+      '--theme-ui-colors-text': 'tomato',
+      '--theme-ui-colors-background': 'white',
+      '&.theme-ui-dark': {
+        '--theme-ui-colors-text': 'white',
+        '--theme-ui-colors-background': 'black',
+      },
+      '@media print': {
         '--theme-ui-colors-text': 'tomato',
         '--theme-ui-colors-background': 'white',
-        '&.theme-ui-dark': {
-          '--theme-ui-colors-text': 'white',
-          '--theme-ui-colors-background': 'black',
-        },
-        '@media print': {
-          '--theme-ui-colors-text': 'tomato',
-          '--theme-ui-colors-background': 'white',
-        },
       },
     })
   })
@@ -251,12 +239,10 @@ describe('createColorStyles', () => {
       },
     })
     expect(styles).toEqual({
-      html: {
-        color: 'var(--theme-ui-colors-text)',
-        backgroundColor: 'var(--theme-ui-colors-background)',
-        '--theme-ui-colors-text': 'tomato',
-        '--theme-ui-colors-background': 'white',
-      },
+      color: 'var(--theme-ui-colors-text)',
+      backgroundColor: 'var(--theme-ui-colors-background)',
+      '--theme-ui-colors-text': 'tomato',
+      '--theme-ui-colors-background': 'white',
     })
   })
 })

--- a/packages/color-modes/test/index.tsx
+++ b/packages/color-modes/test/index.tsx
@@ -898,7 +898,57 @@ test('warns when localStorage is disabled', () => {
   restoreConsole()
 })
 
-test('rawColors are properly inherited in nested providers', () => {
+test('rawColors are properly inherited in nested providers #1', () => {
+  let finalTheme: Theme = {}
+  const Grabber = () => {
+    const context = useThemeUI()
+    finalTheme = context.theme
+    return null
+  }
+
+  const outerTheme: Theme = {
+    colors: {
+      text: 'black',
+      modes: { dark: { text: 'white' } },
+    },
+  }
+
+  const nestedTheme: Theme = {
+    colors: {
+      background: 'white',
+      modes: { dark: { background: 'black' } },
+    },
+  }
+
+  render(
+    <ThemeProvider theme={outerTheme}>
+      <ColorModeProvider>
+        <ThemeProvider theme={nestedTheme}>
+          <ColorModeProvider>
+            <Grabber />
+          </ColorModeProvider>
+        </ThemeProvider>
+      </ColorModeProvider>
+    </ThemeProvider>
+  )
+
+  expect(finalTheme.rawColors).toStrictEqual({
+    text: 'black',
+    background: 'white',
+    modes: {
+      __default: {
+        text: 'black',
+        background: 'white',
+      },
+      dark: {
+        text: 'white',
+        background: 'black',
+      },
+    },
+  })
+})
+
+test('rawColors are properly inherited in nested providers #2', () => {
   let finalTheme: Theme = {}
   const Grabber = () => {
     const context = useThemeUI()
@@ -958,8 +1008,7 @@ test('rawColors are properly inherited in nested providers', () => {
       dark: {
         text: 'white',
         primary: 'red',
-        // todo: needs fix – we're losing this when nesting ColorModeProviders
-        // background: 'black',
+        background: 'black',
       },
     },
   })

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -57,10 +57,8 @@ export declare namespace jsx {
       extends ThemeUIJSX.ElementAttributesProperty {}
     export interface ElementChildrenAttribute
       extends ThemeUIJSX.ElementChildrenAttribute {}
-    export type LibraryManagedAttributes<
-      C,
-      P
-    > = ThemeUIJSX.LibraryManagedAttributes<C, P>
+    export type LibraryManagedAttributes<C, P> =
+      ThemeUIJSX.LibraryManagedAttributes<C, P>
     export interface IntrinsicAttributes
       extends ThemeUIJSX.IntrinsicAttributes {}
     export interface IntrinsicClassAttributes<T>
@@ -77,10 +75,17 @@ export interface ThemeUIContextValue {
 /**
  * @internal
  */
-export const __ThemeUIContext = React.createContext<ThemeUIContextValue>({
+export const __themeUiDefaultContextValue: ThemeUIContextValue = {
   __EMOTION_VERSION__,
   theme: {},
-})
+}
+
+/**
+ * @internal
+ */
+export const __ThemeUIContext = React.createContext(
+  __themeUiDefaultContextValue
+)
 
 export const useThemeUI = () => React.useContext(__ThemeUIContext)
 
@@ -118,14 +123,15 @@ merge.all = mergeAll
 
 export interface __ThemeUIInternalBaseThemeProviderProps {
   context: ThemeUIContextValue
+  children: React.ReactNode
 }
 /**
  * @internal
  */
-export const __ThemeUIInternalBaseThemeProvider: React.FC<__ThemeUIInternalBaseThemeProviderProps> = ({
+export const __ThemeUIInternalBaseThemeProvider = ({
   context,
   children,
-}) =>
+}: __ThemeUIInternalBaseThemeProviderProps) =>
   jsx(
     EmotionContext.Provider,
     { value: context.theme },
@@ -158,5 +164,5 @@ export function ThemeProvider({ theme, children }: ThemeProviderProps) {
       ? { ...outer, theme: theme(outer.theme) }
       : merge.all({}, outer, { theme })
 
-  return jsx(__ThemeUIInternalBaseThemeProvider, { context }, children)
+  return jsx(__ThemeUIInternalBaseThemeProvider, { context, children })
 }

--- a/packages/core/test/__snapshots__/react-jsx.tsx.snap
+++ b/packages/core/test/__snapshots__/react-jsx.tsx.snap
@@ -10,7 +10,7 @@ exports[`JSX accepts sx prop 1`] = `
 }
 
 .emotion-1 {
-  bg-color: primary;
+  background-color: primary;
 }
 
 <div

--- a/packages/core/test/react-jsx.tsx
+++ b/packages/core/test/react-jsx.tsx
@@ -1,5 +1,7 @@
+/* eslint-disable no-lone-blocks */
+
 /** @jsx jsx */
-import { renderJSON, NotHas, Assert, IsExact } from '@theme-ui/test-utils'
+import { renderJSON, NotHas, Assert } from '@theme-ui/test-utils'
 
 import { jsx, SxProp, ThemeUIJSX } from '../src'
 
@@ -17,7 +19,7 @@ describe('JSX', () => {
           <input
             onChange={(e) => console.log(e.target.value)}
             sx={{
-              bgColor: 'primary',
+              bg: 'primary',
             }}
           />
         </div>

--- a/packages/editor/src/EditorProvider.ts
+++ b/packages/editor/src/EditorProvider.ts
@@ -25,5 +25,5 @@ export const EditorProvider = ({
     setTheme,
   }
 
-  return jsx(__ThemeUIInternalBaseThemeProvider, { context }, children)
+  return jsx(__ThemeUIInternalBaseThemeProvider, { context, children })
 }

--- a/packages/theme-provider/src/index.tsx
+++ b/packages/theme-provider/src/index.tsx
@@ -1,8 +1,10 @@
+import React from 'react'
 import {
   jsx,
   useThemeUI,
   ThemeProvider as CoreProvider,
   ThemeProviderProps as CoreThemeProviderProps,
+  __themeUiDefaultContextValue,
 } from '@theme-ui/core'
 import { css, Theme } from '@theme-ui/css'
 import { ColorModeProvider } from '@theme-ui/color-modes'
@@ -31,7 +33,7 @@ const RootStyles = () =>
         },
         body: {
           margin: 0,
-        }
+        },
       })(theme)
     },
   })
@@ -48,28 +50,14 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({
 }) => {
   const outer = useThemeUI()
 
-  if (typeof outer.setColorMode === 'function') {
-    return jsx(
-      CoreProvider,
-      { theme },
-      jsx(MDXProvider, {
-        components,
-        children,
-      })
-    )
-  }
+  const isTopLevel = outer === __themeUiDefaultContextValue
 
-  return jsx(
-    CoreProvider,
-    { theme },
-    jsx(
-      ColorModeProvider,
-      null,
-      jsx(RootStyles),
-      jsx(MDXProvider, {
-        components,
-        children,
-      })
-    )
+  return (
+    <CoreProvider theme={theme}>
+      <ColorModeProvider>
+        {isTopLevel && <RootStyles />}
+        <MDXProvider components={components}>{children}</MDXProvider>
+      </ColorModeProvider>
+    </CoreProvider>
   )
 }

--- a/packages/theme-provider/test/index.tsx
+++ b/packages/theme-provider/test/index.tsx
@@ -1,7 +1,13 @@
 /** @jsx jsx */
-import { jsx } from '@theme-ui/core'
+import { jsx, useThemeUI, __ThemeUIContext } from '@theme-ui/core'
 import { mdx } from '@mdx-js/react'
-import { render, cleanup } from '@testing-library/react'
+import {
+  render,
+  cleanup,
+  fireEvent,
+  waitFor,
+  waitForElementToBeRemoved,
+} from '@testing-library/react'
 import { matchers } from '@emotion/jest'
 import { renderJSON } from '@theme-ui/test-utils'
 
@@ -226,4 +232,43 @@ test('does not add box-sizing: border-box', () => {
   )
   const style = window.getComputedStyle(root.baseElement)
   expect(style.boxSizing).toBe('')
+})
+
+test('updates CSS Custom Properties on root element', async () => {
+  const DarkModeButton = () => {
+    const { colorMode, setColorMode } = useThemeUI()
+
+    if (colorMode === 'dark') return null
+
+    return <button onClick={() => setColorMode!('dark')}>Dark Mode</button>
+  }
+
+  const root = render(
+    <ThemeProvider
+      theme={{
+        config: {
+          // useCustomProperties defaults to `true`
+        },
+        colors: {
+          text: '#000',
+          modes: {
+            dark: { text: '#fff' },
+          },
+        },
+      }}>
+      <DarkModeButton />
+    </ThemeProvider>
+  )
+
+  const html = root.baseElement.parentElement!
+
+  expect(
+    window.getComputedStyle(html).getPropertyValue('--theme-ui-colors-text')
+  ).toBe('#000')
+
+  fireEvent.click(root.getByText('Dark Mode'))
+
+  expect(
+    window.getComputedStyle(html).getPropertyValue('--theme-ui-colors-text')
+  ).toBe('#fff')
 })

--- a/packages/theme-provider/test/index.tsx
+++ b/packages/theme-provider/test/index.tsx
@@ -59,8 +59,8 @@ test('renders with styles', () => {
   expect(json).toHaveStyleRule('color', 'tomato')
 })
 
-test('renders with nested provider', () => {
-  const json = renderJSON(
+test('renders with nested provider', async () => {
+  const tree = render(
     <ThemeProvider
       theme={{
         config: {
@@ -84,7 +84,10 @@ test('renders with nested provider', () => {
       </ThemeProvider>
     </ThemeProvider>
   )
-  expect(json).toHaveStyleRule('color', 'cyan')
+
+  const style = global.getComputedStyle(await tree.findByText('Hello'))
+
+  expect(style.color).toBe('cyan')
 })
 
 test('renders with custom components', () => {

--- a/packages/theme-ui/test/color-modes.tsx
+++ b/packages/theme-ui/test/color-modes.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import React from 'react'
 import renderer from 'react-test-renderer'
-import { render, fireEvent, cleanup, act } from '@testing-library/react'
+import { render, fireEvent, cleanup } from '@testing-library/react'
 import { matchers } from '@emotion/jest'
 import mockConsole, { RestoreConsole } from 'jest-mock-console'
 import packageInfo from '@emotion/react/package.json'
@@ -193,11 +193,11 @@ test('converts color modes to css custom properties', () => {
 test('uses default mode', () => {
   let mode
   const Button = () => {
-    const [colorMode, setMode] = useColorMode()
+    const [colorMode] = useColorMode()
     mode = colorMode
     return <button children="test" />
   }
-  const tree = render(
+  render(
     <ThemeProvider theme={{}}>
       <Button />
     </ThemeProvider>
@@ -209,11 +209,11 @@ test('initializes mode based on localStorage', () => {
   window.localStorage.setItem(STORAGE_KEY, 'dark')
   let mode
   const Button = () => {
-    const [colorMode, setMode] = useColorMode()
+    const [colorMode] = useColorMode()
     mode = colorMode
     return <button children="test" />
   }
-  const tree = render(
+  render(
     <ThemeProvider theme={{}}>
       <Button />
     </ThemeProvider>
@@ -351,7 +351,7 @@ test('does not initialize mode from prefers-color-scheme media query when useCol
 test('useColorMode throws when there is no theme context', () => {
   expect(() => {
     const Consumer = () => {
-      const _ = useColorMode()
+      useColorMode()
       return null
     }
     render(<Consumer />)
@@ -367,7 +367,7 @@ test('useThemeUI returns current color mode colors', () => {
     colors = theme.colors
     return null
   }
-  const root = render(
+  render(
     <ThemeProvider
       theme={{
         config: {
@@ -392,7 +392,7 @@ test('useThemeUI returns current color mode colors', () => {
 })
 
 test('warns when initialColorModeName matches a key in theme.colors.modes', () => {
-  const root = render(
+  render(
     <ThemeProvider
       theme={{
         config: {
@@ -416,7 +416,7 @@ test('warns when initialColorModeName matches a key in theme.colors.modes', () =
 
 test('dot notation works with color modes', () => {
   const Button = () => {
-    const [colorMode, setMode] = useColorMode()
+    const [, setMode] = useColorMode()
     return (
       <button
         sx={{
@@ -458,7 +458,7 @@ test('dot notation works with color modes', () => {
 
 test('dot notation works with color modes and custom properties', () => {
   const Button = () => {
-    const [colorMode, setMode] = useColorMode()
+    const [, setMode] = useColorMode()
     return (
       <button
         sx={{
@@ -509,7 +509,7 @@ test('raw color values are passed to theme-ui context when custom properties are
     color = context.theme.rawColors!.primary
     return null
   }
-  const root = render(
+  render(
     <ThemeProvider
       theme={{
         colors: {

--- a/packages/theme-ui/test/index.tsx
+++ b/packages/theme-ui/test/index.tsx
@@ -1,6 +1,5 @@
 /** @jsx mdx */
 import { mdx } from '@mdx-js/react'
-import renderer from 'react-test-renderer'
 import { matchers } from '@emotion/jest'
 import mockConsole from 'jest-mock-console'
 import { renderJSON } from '@theme-ui/test-utils'
@@ -8,7 +7,6 @@ import { renderJSON } from '@theme-ui/test-utils'
 import {
   ThemeProvider,
   jsx,
-  useColorMode,
   BaseStyles,
   Theme,
   __ThemeUIContext,
@@ -103,7 +101,7 @@ test('custom pragma adds styles', () => {
 
 test('warns when multiple versions of emotion are installed', () => {
   const restore = mockConsole()
-  const json = renderJSON(
+  renderJSON(
     <__ThemeUIContext.Provider
       value={{
         __EMOTION_VERSION__: '9.0.0',

--- a/packages/theme-ui/test/index.tsx
+++ b/packages/theme-ui/test/index.tsx
@@ -125,7 +125,10 @@ test('functional themes receive outer theme', () => {
       primary: 'black',
     },
   }
-  const theme = jest.fn<Theme, [Theme]>(() => ({}))
+  const theme = jest.fn<Theme, [Theme]>((t) => ({
+    ...t,
+    colors: { text: t.colors?.primary },
+  }))
   const json = renderJSON(
     jsx(
       ThemeProvider,
@@ -142,7 +145,7 @@ test('functional themes receive outer theme', () => {
     )
   )
   expect(theme).toHaveBeenCalledWith(outer)
-  expect(json).toHaveStyleRule('color', 'text')
+  expect(json).toHaveStyleRule('color', 'black')
 })
 
 test('functional themes can be used at the top level', () => {


### PR DESCRIPTION
Should close https://github.com/system-ui/theme-ui/issues/1456.

Updated repro: https://codesandbox.io/s/theme-ui-nested-color-modes-bug-qm0lt?file=/src/index.js.

@rezaabedian could you take a look at the [CodeSandbox](https://codesandbox.io/s/theme-ui-nested-color-modes-bug-qm0lt?file=/src/index.js) and see if this is what you expected in #1456?
