### PR TITLE
(color-modes) Add support for forEach on classList for IE11

### DIFF
--- a/packages/color-modes/src/index.tsx
+++ b/packages/color-modes/src/index.tsx
@@ -70,7 +70,7 @@ const getPreferredColorScheme = (): 'dark' | 'light' | null => {
 const getModeFromClass = (): string | undefined => {
   let mode: string | undefined
   if (typeof document !== 'undefined') {
-    document.documentElement.classList.forEach((className) => {
+    Array.from(document.documentElement.classList).forEach((className: string) => {
       if (className.startsWith('theme-ui-')) {
         mode = className.replace('theme-ui-', '')
       }


### PR DESCRIPTION
I've been working in a project using next.js and theme-ui and we have to support IE11. 
During debugging I could see that the classList.forEach was throwing an error due to IE11 not havving support for forEach on the NodeList data type, although modern browsers and the specs do.

This is the simplest form of adjusting this without adding polyfills.