### PR TITLE
Update global-styles.mdx

### DIFF
--- a/packages/docs/src/pages/guides/global-styles.mdx
+++ b/packages/docs/src/pages/guides/global-styles.mdx
@@ -29,7 +29,8 @@ export default (props) => (
 ```
 
 <Note>
-  If you are upgrading from an older version of theme-ui, be aware the import 
-  statement has changed from `import { Global } from '@emotion/**core**'` 
-  to `import { Global } from '@emotion/**react**'`
+
+  If you are upgrading from an older version of theme-ui, be aware the import
+  package has changed from `@emotion/core` to `@emotion/react`.
+
 </Note>

--- a/packages/docs/src/pages/guides/global-styles.mdx
+++ b/packages/docs/src/pages/guides/global-styles.mdx
@@ -27,3 +27,9 @@ export default (props) => (
   />
 )
 ```
+
+<Note>
+  If you are upgrading from an older version of theme-ui, be aware the import 
+  statement has changed from `import { Global } from '@emotion/**core**'` 
+  to `import { Global } from '@emotion/**react**'`
+</Note>

--- a/packages/docs/src/pages/guides/global-styles.mdx
+++ b/packages/docs/src/pages/guides/global-styles.mdx
@@ -30,7 +30,8 @@ export default (props) => (
 
 <Note>
 
-  If you are upgrading from an older version of theme-ui, be aware the import
-  package has changed from `@emotion/core` to `@emotion/react`.
+  If you are upgrading from a version of theme-ui older that v0.6.0, be aware the import
+  package has changed from `@emotion/core` to `@emotion/react`. For more information see
+  the [Migration Notes for 0.6](https://theme-ui.com/migrating/#breaking-changes).
 
 </Note>


### PR DESCRIPTION
Add a note for people updating. I ran into an issue with the `theme` arg not being defined after I updated from theme-ui 0.3.1 and took me a while to realise the imports had changed.

No worries if you don't wish to add this, but it might stop someone else pulling their hair out.