### PR TITLE
add types for css prop back

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,5 +22,6 @@ module.exports = {
 
     // TypeScript checks this
     'no-undef': 'off',
+    'no-lone-blocks': 'off',
   },
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,20 +1,22 @@
-import { ThemeUIStyleObject } from '@theme-ui/css'
+import { Interpolation } from '@emotion/react'
+import { ThemeUIStyleObject, Theme as ThemeUITheme } from '@theme-ui/css'
 
 import { ThemeUIJSX } from './jsx-namespace'
 
 export interface SxProp {
   /**
    * The sx prop lets you style elements inline, using values from your
-   * theme. To use the sx prop, add the custom pragma as a comment to the
-   * top of your module and import the jsx function.
+   * theme.
    *
-   * ```ts
-   * // @jsx jsx
-   *
-   * import { jsx } from 'theme-ui'
-   * ```
+   * @see https://theme-ui.com/sx-prop/
    */
   sx?: ThemeUIStyleObject
+  /**
+   * Theme UI uses Emotion's JSX function. You can pass styles to it directly
+   * using `css` prop.
+   * @see https://theme-ui.com/sx-prop/#raw-css
+   */
+  css?: Interpolation<ThemeUITheme>
 }
 
 export interface IntrinsicSxElements {

--- a/packages/core/test/react-jsx.tsx
+++ b/packages/core/test/react-jsx.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-lone-blocks */
 
 /** @jsx jsx */
-import { renderJSON, NotHas, Assert } from '@theme-ui/test-utils'
+import { renderJSON, NotHas, Assert, expecter } from '@theme-ui/test-utils'
 
 import { jsx, SxProp, ThemeUIJSX } from '../src'
 
@@ -25,6 +25,40 @@ describe('JSX', () => {
         </div>
       )
     ).toMatchSnapshot()
+  })
+
+  test('accepts css prop', () => {
+    const expectSnippet = expecter(
+      `/** @jsxImportSource @theme-ui/core */
+
+      export {}`,
+      { jsx: false }
+    )
+
+    expectSnippet(`const _1 = <div css={{ color: 'red' }} />`).toSucceed()
+
+    // Theme UI theme can be injected to @emotion/react module in userspace
+    expectSnippet(
+      `
+      import { Theme as ThemeUITheme } from '@theme-ui/css'
+
+      declare module '@emotion/react' {
+        export interface Theme extends ThemeUITheme {}
+      }
+
+      <div
+         css={(t) => {
+           const _t = t;
+           return {}
+         }}
+       />`
+    ).toInfer('_t', 'Theme')
+
+    expectSnippet(
+      `import { css } from '@emotion/react'
+
+       const TestComponent = () => <div css={css\`display: block;\`} />`
+    ).toSucceed()
   })
 })
 

--- a/packages/css/emotion-theme.d.ts
+++ b/packages/css/emotion-theme.d.ts
@@ -1,9 +1,0 @@
-import '@emotion/react'
-
-import { Theme } from '@theme-ui/css'
-
-interface ThemeUITheme extends Theme {}
-
-declare module '@emotion/react' {
-  export interface Theme extends ThemeUITheme {}
-}

--- a/packages/docs/src/pages/sx-prop.mdx
+++ b/packages/docs/src/pages/sx-prop.mdx
@@ -6,12 +6,15 @@ import { Note } from '..'
 
 # The `sx` Prop
 
-The `sx` prop lets you style elements inline, using values from your theme.
-To use the `sx` prop, add the custom `/** @jsxImportSource theme-ui */` pragma comment to the top of your module.
+The `sx` prop lets you style elements inline, using values from your theme. To
+use the `sx` prop, add the custom `/** @jsxImportSource theme-ui */` pragma
+comment to the top of your module or configure
+[automatic JSX runtime](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html)
+in your transpiler.
 
-The `sx` prop lets you add any valid CSS to an element,
-while using values from your theme to keep styles consistent.
-You can think of the style object that the `sx` prop accepts as a _superset_ of CSS.
+The `sx` prop lets you add any valid CSS to an element, while using values from
+your theme to keep styles consistent. You can think of the style object that the
+`sx` prop accepts as a _superset_ of CSS.
 
 ```jsx
 /** @jsxImportSource theme-ui */
@@ -33,16 +36,20 @@ export default (props) => (
 
 <Note>
 
-Under the hood, Theme UI uses a [custom pragma comment](/guides/jsx-pragma) that converts a theme-aware `sx` prop into a style object and passes it to Emotion's `jsx` functions.
-The `sx` prop only works in modules that have defined a custom pragma at the top of the file, which replaces the default React `jsx` functions.
-This means you can control which modules in your application opt into this feature without the need for a Babel plugin or additional configuration.
-This is intended as a complete replacement for the Emotion custom JSX pragma.
+Under the hood, Theme UI uses a [custom pragma comment](/guides/jsx-pragma) that
+converts a theme-aware `sx` prop into a style object and passes it to Emotion's
+`jsx` functions. The `sx` prop only works in modules that have defined a custom
+pragma at the top of the file, which replaces the default React `jsx` functions.
+This means you can control which modules in your application opt into this
+feature without the need for a Babel plugin or additional configuration. This is
+intended as a complete replacement for the Emotion custom JSX pragma.
 
 </Note>
 
 ## Theme-Aware Properties
 
-The following CSS properties will use values defined in the theme, when available.
+The following CSS properties will use values defined in the theme, when
+available.
 
 | Property                  | Theme Key        |
 | ------------------------- | ---------------- |
@@ -138,7 +145,8 @@ The following CSS properties will use values defined in the theme, when availabl
 | `fill`                    | `colors`         |
 | `stroke`                  | `colors`         |
 
-Theme UI also supports [CSS Logical Properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties),
+Theme UI also supports
+[CSS Logical Properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties),
 which follow this structure:
 
 - `margin-{block,inline}-{start,end}`
@@ -209,8 +217,10 @@ which follow this structure:
 
 ## Responsive Values
 
-Theme UI, like Styled System, includes a shorthand syntax for writing mobile-first responsive styles using arrays as values.
-This is useful when you want to change a single property across multiple breakpoints without needing to write verbose media query syntax.
+Theme UI, like Styled System, includes a shorthand syntax for writing
+mobile-first responsive styles using arrays as values. This is useful when you
+want to change a single property across multiple breakpoints without needing to
+write verbose media query syntax.
 
 ```jsx
 /** @jsxImportSource theme-ui */
@@ -227,7 +237,8 @@ export default (props) => (
 
 ### Skipping Breakpoints
 
-If you want to skip a breakpoint, you can use the value `null`. This is useful if you want to set a value for only the largest breakpoint, for example.
+If you want to skip a breakpoint, you can use the value `null`. This is useful
+if you want to set a value for only the largest breakpoint, for example.
 
 ```jsx
 /** @jsxImportSource theme-ui */
@@ -244,7 +255,8 @@ export default (props) => (
 
 ### Media Queries
 
-If you prefer standard CSS media query syntax, you can use nested objects for responsive styles as well.
+If you prefer standard CSS media query syntax, you can use nested objects for
+responsive styles as well.
 
 ```jsx
 <div
@@ -259,10 +271,12 @@ If you prefer standard CSS media query syntax, you can use nested objects for re
 
 ## Margin and Padding
 
-Margin and padding are treated as first-class citizens in Theme UI,
-using values defined in the `theme.space` scale, and include an optional shorthand syntax for using negative space in your application.
+Margin and padding are treated as first-class citizens in Theme UI, using values
+defined in the `theme.space` scale, and include an optional shorthand syntax for
+using negative space in your application.
 
-In addition to shorthands for applying margin and padding on the x- and y-axes, a terse naming convention can be used to quickly edit styles.
+In addition to shorthands for applying margin and padding on the x- and y-axes,
+a terse naming convention can be used to quickly edit styles.
 
 ```jsx
 // example of using margin and padding shorthand syntax
@@ -278,8 +292,9 @@ In addition to shorthands for applying margin and padding on the x- and y-axes, 
 
 ## Functional Values
 
-For shorthand CSS properties or ones that are not automatically mapped to values in the theme,
-use an inline function to reference values from the `theme` object.
+For shorthand CSS properties or ones that are not automatically mapped to values
+in the theme, use an inline function to reference values from the `theme`
+object.
 
 ```jsx
 /** @jsxImportSource theme-ui */
@@ -320,14 +335,16 @@ export default (props) => (
 
 <Note>
 
-If you’re looking to style text content like Markdown or from a CMS using your theme,
-check out the [`BaseStyles`](/api#basestyles) component.
+If you’re looking to style text content like Markdown or from a CMS using your
+theme, check out the [`BaseStyles`](/api#basestyles) component.
 
 </Note>
 
-If you want to reference the current class selector of the component, such as for
+If you want to reference the current class selector of the component, such as
+for
 [psuedo-classes & psuedo-elements](https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Selectors/Pseudo-classes_and_pseudo-elements),
-you can use the [`&`](https://emotion.sh/docs/object-styles#child-selectors) symbol.
+you can use the [`&`](https://emotion.sh/docs/object-styles#child-selectors)
+symbol.
 
 ```jsx
 /** @jsx jsx */
@@ -350,7 +367,8 @@ export default (props) => (
 
 ## Raw CSS
 
-To opt-out of using theme-based CSS, use the `css` prop to render raw CSS values.
+To opt-out of using theme-based CSS, use the `css` prop to render raw CSS
+values.
 
 ```jsx
 /** @jsxImportSource theme-ui */
@@ -369,9 +387,10 @@ export default (props) => (
 
 ## Using the `sx` Prop in MDX
 
-Because MDX uses its own custom pragma and `createElement` function, the Theme UI pragma will not work in MDX files.
-You can use any of the [Theme UI components](/components),
-which support the `sx` prop, in an MDX file as a workaround.
+Because MDX uses its own custom pragma and `createElement` function, the Theme
+UI pragma will not work in MDX files. You can use any of the
+[Theme UI components](/components), which support the `sx` prop, in an MDX file
+as a workaround.
 
 ```mdx
 import { Box } from 'theme-ui'
@@ -390,4 +409,5 @@ import { Box } from 'theme-ui'
 
 ## Object Styles
 
-If you're new to using JavaScript object notation for authoring styles, see the [guide to using objects for styling](/guides/object-styles).
+If you're new to using JavaScript object notation for authoring styles, see the
+[guide to using objects for styling](/guides/object-styles).


### PR DESCRIPTION
Closes #1833.

- I added `css` prop to `sx` prop types, as Theme UI's `jsx` function calls Emotion's `jsx` function, and we have this documented in our docs.
- Prettier trolled me a bit. I mean, I'm not sure why `css/index.ts` wasn't formatted this way in the first place. I don't really like this diff, but I don't want to fight it.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @theme-ui/color-modes@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  npm install @theme-ui/color@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  npm install @theme-ui/components@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  npm install @theme-ui/core@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  npm install @theme-ui/css@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  npm install @theme-ui/custom-properties@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  npm install @theme-ui/editor@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  npm install gatsby-plugin-theme-ui@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  npm install gatsby-theme-style-guide@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  npm install gatsby-theme-ui-layout@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  npm install @theme-ui/match-media@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  npm install @theme-ui/mdx@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  npm install @theme-ui/parse-props@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  npm install @theme-ui/preset-base@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  npm install @theme-ui/preset-bootstrap@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  npm install @theme-ui/preset-bulma@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  npm install @theme-ui/preset-dark@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  npm install @theme-ui/preset-deep@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  npm install @theme-ui/preset-funk@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  npm install @theme-ui/preset-future@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  npm install @theme-ui/preset-polaris@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  npm install @theme-ui/preset-roboto@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  npm install @theme-ui/preset-sketchy@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  npm install @theme-ui/preset-swiss@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  npm install @theme-ui/preset-system@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  npm install @theme-ui/preset-tailwind@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  npm install @theme-ui/preset-tosh@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  npm install @theme-ui/presets@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  npm install @theme-ui/prism@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  npm install @theme-ui/sidenav@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  npm install @theme-ui/style-guide@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  npm install @theme-ui/tachyons@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  npm install @theme-ui/tailwind@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  npm install @theme-ui/theme-provider@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  npm install theme-ui@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  npm install @theme-ui/typography@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  # or 
  yarn add @theme-ui/color-modes@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  yarn add @theme-ui/color@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  yarn add @theme-ui/components@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  yarn add @theme-ui/core@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  yarn add @theme-ui/css@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  yarn add @theme-ui/custom-properties@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  yarn add @theme-ui/editor@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  yarn add gatsby-plugin-theme-ui@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  yarn add gatsby-theme-style-guide@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  yarn add gatsby-theme-ui-layout@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  yarn add @theme-ui/match-media@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  yarn add @theme-ui/mdx@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  yarn add @theme-ui/parse-props@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  yarn add @theme-ui/preset-base@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  yarn add @theme-ui/preset-bootstrap@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  yarn add @theme-ui/preset-bulma@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  yarn add @theme-ui/preset-dark@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  yarn add @theme-ui/preset-deep@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  yarn add @theme-ui/preset-funk@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  yarn add @theme-ui/preset-future@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  yarn add @theme-ui/preset-polaris@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  yarn add @theme-ui/preset-roboto@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  yarn add @theme-ui/preset-sketchy@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  yarn add @theme-ui/preset-swiss@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  yarn add @theme-ui/preset-system@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  yarn add @theme-ui/preset-tailwind@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  yarn add @theme-ui/preset-tosh@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  yarn add @theme-ui/presets@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  yarn add @theme-ui/prism@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  yarn add @theme-ui/sidenav@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  yarn add @theme-ui/style-guide@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  yarn add @theme-ui/tachyons@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  yarn add @theme-ui/tailwind@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  yarn add @theme-ui/theme-provider@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  yarn add theme-ui@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  yarn add @theme-ui/typography@0.11.0-canary.1866.095ab5bd1ea54f6d6ce32a3d3fd85aa24f96ab27.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v0.11.0-develop.1`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from a new contributor! :tada:
  
  Thank you, Jordie Bodlay ([@jordie23](https://github.com/jordie23)), for all your work!
  
  #### 🚀 Enhancement
  
  - `@theme-ui/color-modes`, `@theme-ui/core`, `@theme-ui/editor`, `@theme-ui/theme-provider`, `theme-ui`
    - fix(color-modes): combine colors in nested providers [#1838](https://github.com/system-ui/theme-ui/pull/1838) ([@hasparus](https://github.com/hasparus))
  
  #### 🐛 Bug Fix
  
  - Update global-styles.mdx [#1858](https://github.com/system-ui/theme-ui/pull/1858) ([@jordie23](https://github.com/jordie23))
  - `@theme-ui/core`, `@theme-ui/css`
    - add types for css prop back [#1866](https://github.com/system-ui/theme-ui/pull/1866) ([@hasparus](https://github.com/hasparus))
  - `@theme-ui/color-modes`, `@theme-ui/components`, `@theme-ui/core`, `@theme-ui/editor`, `gatsby-theme-style-guide`, `gatsby-theme-ui-layout`, `@theme-ui/match-media`, `@theme-ui/mdx`, `@theme-ui/parse-props`, `@theme-ui/sidenav`, `@theme-ui/style-guide`, `@theme-ui/theme-provider`, `theme-ui`
    - 0.10 chores [#1842](https://github.com/system-ui/theme-ui/pull/1842) ([@hasparus](https://github.com/hasparus))
  
  #### 🏠 Internal
  
  - `theme-ui`
    - Setup Cypress [#1845](https://github.com/system-ui/theme-ui/pull/1845) ([@hasparus](https://github.com/hasparus))
  
  #### Authors: 2
  
  - Jordie Bodlay ([@jordie23](https://github.com/jordie23))
  - Piotr Monwid-Olechnowicz ([@hasparus](https://github.com/hasparus))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
