### PR TITLE
docs: correct location of `initialColorModeName: 'light'`

### DIFF
--- a/packages/docs/src/pages/color-modes.mdx
+++ b/packages/docs/src/pages/color-modes.mdx
@@ -15,8 +15,10 @@ for optional color modes.
 ```js
 // example theme colors
 {
-  colors: {
+  config: {
     initialColorModeName: 'light',
+  }
+  colors: {
     text: '#000',
     background: '#fff',
     primary: '#07c',
@@ -52,7 +54,9 @@ be accessible as
 
 ```js
 {
-  initialColorModeName: 'light',
+  config: {
+    initialColorModeName: 'light',
+  }
   rawColors: {
     primary: '#07c',
     modes: {

--- a/packages/docs/src/pages/color-modes.mdx
+++ b/packages/docs/src/pages/color-modes.mdx
@@ -15,8 +15,8 @@ for optional color modes.
 ```js
 // example theme colors
 {
-  initialColorModeName: 'light',
   colors: {
+    initialColorModeName: 'light',
     text: '#000',
     background: '#fff',
     primary: '#07c',


### PR DESCRIPTION
It seems as though `initialColorModeName: 'light'` should no longer be stored in the root theme object but in the colors object instead. Here I moved it in the documentation to reflect that change.