### PR TITLE
Patch GridProps

### DIFF
--- a/packages/components/index.d.ts
+++ b/packages/components/index.d.ts
@@ -46,13 +46,17 @@ export interface GridProps extends BoxProps {
    */
   width?: ResponsiveStyleValue<string | number>
   /**
-   * 	Number of columns to use for the layout (cannot be used in conjunction with the width prop)
+   * Number of columns to use for the layout (cannot be used in conjunction with the width prop)
    */
   columns?: ResponsiveStyleValue<string | number>
   /**
    * Space between child elements
    */
   gap?: ResponsiveStyleValue<string | number>
+  /**
+   * Auto-repeat track behaviour (default is fit)
+   */
+  repeat?: 'fit' | 'fill'
 }
 /**
  * CSS grid layout component to arrange direct child elements in a tiled grid layout.


### PR DESCRIPTION
Add missing definition for `repeat` prop.

Valid values are "fit" and "fill" as seen in the CSS spec:

https://developer.mozilla.org/en-US/docs/Web/CSS/repeat()