### PR TITLE
chore: Update Gatsby peerDeps

### DIFF
--- a/packages/gatsby-plugin-theme-ui/package.json
+++ b/packages/gatsby-plugin-theme-ui/package.json
@@ -5,7 +5,7 @@
   "author": "Brent Jackson",
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": "^2.0.0 || ^3.0.0",
+    "gatsby": "^2.0.0 || ^3.0.0 || ^4.0.0",
     "theme-ui": ">=0.7.0"
   },
   "keywords": [

--- a/packages/gatsby-theme-ui-layout/package.json
+++ b/packages/gatsby-theme-ui-layout/package.json
@@ -4,7 +4,7 @@
   "main": "dist/gatsby-theme-ui-layout.cjs.js",
   "repository": "system-ui/theme-ui",
   "peerDependencies": {
-    "gatsby": "^2.0.0 || ^3.0.0",
+    "gatsby": "^2.0.0 || ^3.0.0 || ^4.0.0",
     "react": "^16 || ^17",
     "react-dom": "^16 || ^17"
   },


### PR DESCRIPTION
Hi!

v4 is out and so we can update the peerDeps of the plugins :)
I've tried out the latest version of them, they all work fine on Gatsby 4 👍 
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v0.11.4-develop.16`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - fix(examples/next): Use config object in theme ([@lachlanjc](https://github.com/lachlanjc))
  - fix(examples/next): Fix import typo ([@lachlanjc](https://github.com/lachlanjc))
  
  #### Authors: 1
  
  - Lachlan Campbell ([@lachlanjc](https://github.com/lachlanjc))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
