### PR TITLE
docs(pragma): add SWC instructions for Next.js

### DIFF
--- a/packages/docs/src/pages/guides/jsx-pragma.mdx
+++ b/packages/docs/src/pages/guides/jsx-pragma.mdx
@@ -147,6 +147,8 @@ NOTE: this requires
 
 ### Using next.js
 
+#### With Babel
+
 ```js
 // babel.config.js
 module.exports = {
@@ -168,3 +170,15 @@ module.exports = {
 
 You can read more about
 [customizing Babel config in Next.js docs](https://nextjs.org/docs/advanced-features/customizing-babel-config).
+
+#### With SWC
+
+In `jsconfig.json` or `tsconfig.json` (since Next.js 12.0.4):
+
+```json
+{
+  "compilerOptions": {
+    "jsxImportSource": "theme-ui"
+  }
+}
+```


### PR DESCRIPTION
Since 12.0.4 Next.js has added support for configuring the pragma via jsconfig.json or tsconfig.json so it can be used with SWC.

Some notes on this here:
https://github.com/vercel/next.js/discussions/30174
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v0.12.2-develop.0`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from a new contributor! :tada:
  
  Thank you, Greg Poole ([@gpoole](https://github.com/gpoole)), for all your work!
  
  #### 🏠 Internal
  
  - docs(pragma): add SWC instructions for Next.js [#2020](https://github.com/system-ui/theme-ui/pull/2020) ([@gpoole](https://github.com/gpoole))
  
  #### Authors: 1
  
  - Greg Poole ([@gpoole](https://github.com/gpoole))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
