### PR TITLE
Add custom svg option to checkbox component

### DIFF
--- a/packages/components/src/Checkbox.js
+++ b/packages/components/src/Checkbox.js
@@ -2,13 +2,15 @@ import React from 'react'
 import Box from './Box'
 import SVG from './SVG'
 
-const CheckboxChecked = (props) => (
+const CheckboxChecked = ({icons, ...props}) => (
+  icons?.checked ? <SVG {...icons.checked.props} {...props}></SVG> :
   <SVG {...props}>
     <path d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z" />
   </SVG>
 )
 
-const CheckboxUnchecked = (props) => (
+const CheckboxUnchecked = ({icons, ...props}) => (
+  icons?.unchecked ? <SVG {...icons.unchecked.props} {...props}></SVG> :
   <SVG {...props}>
     <path d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z" />
   </SVG>
@@ -38,9 +40,38 @@ const CheckboxIcon = (props) => (
 )
 
 export const Checkbox = React.forwardRef(function Checkbox(
-  { className, sx, variant = 'checkbox', children, ...props },
+  { className, sx, variant = 'checkbox', children, icons, ...props },
   ref
 ) {
+
+  let CustomCheckboxIcon;
+  if (icons) {
+    CustomCheckboxIcon = (props) => (
+      <React.Fragment>
+        <CheckboxChecked
+          icons={icons}
+          {...props}
+          __css={{
+            display: 'none',
+            'input:checked ~ &': {
+              display: 'block',
+            },
+          }}
+        />
+        <CheckboxUnchecked
+          icons={icons}
+          {...props}
+          __css={{
+            display: 'block',
+            'input:checked ~ &': {
+              display: 'none',
+            },
+          }}
+        />
+      </React.Fragment>
+    )
+  }
+
   return (
     <Box sx={{ minWidth: 'min-content' }}>
       <Box
@@ -58,7 +89,7 @@ export const Checkbox = React.forwardRef(function Checkbox(
         }}
       />
       <Box
-        as={CheckboxIcon}
+        as={icons ? CustomCheckboxIcon : CheckboxIcon}
         aria-hidden="true"
         __themeKey="forms"
         variant={variant}

--- a/packages/components/test/__snapshots__/index.js.snap
+++ b/packages/components/test/__snapshots__/index.js.snap
@@ -375,6 +375,122 @@ input:focus~.emotion-3 {
 </div>
 `;
 
+exports[`Checkbox renders with custom icon 1`] = `
+.emotion-0 {
+  box-sizing: border-box;
+  margin: 0;
+  min-width: 0;
+  min-width: -webkit-min-content;
+  min-width: -moz-min-content;
+  min-width: min-content;
+}
+
+.emotion-1 {
+  box-sizing: border-box;
+  margin: 0;
+  min-width: 0;
+  position: absolute;
+  opacity: 0;
+  z-index: -1;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+.emotion-2 {
+  box-sizing: border-box;
+  margin: 0;
+  min-width: 0;
+  display: none;
+  box-sizing: border-box;
+  margin: 0;
+  min-width: 0;
+  margin-right: 8px;
+  border-radius: 4px;
+  color: gray;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+input:checked~.emotion-2 {
+  display: block;
+}
+
+input:checked~.emotion-2 {
+  color: primary;
+}
+
+input:focus~.emotion-2 {
+  color: primary;
+  background-color: highlight;
+}
+
+.emotion-3 {
+  box-sizing: border-box;
+  margin: 0;
+  min-width: 0;
+  display: block;
+  box-sizing: border-box;
+  margin: 0;
+  min-width: 0;
+  margin-right: 8px;
+  border-radius: 4px;
+  color: gray;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+input:checked~.emotion-3 {
+  display: none;
+}
+
+input:checked~.emotion-3 {
+  color: primary;
+}
+
+input:focus~.emotion-3 {
+  color: primary;
+  background-color: highlight;
+}
+
+<div
+  className="emotion-0"
+>
+  <input
+    className="emotion-1"
+    type="checkbox"
+  />
+  <svg
+    aria-hidden="true"
+    className="emotion-2"
+    fill="currentcolor"
+    height="24"
+    viewBox="0 0 24 24"
+    width="24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M22 2v20h-20v-20h20zm2-2h-24v24h24v-24zm-6 16.538l-4.592-4.548 4.546-4.587-1.416-1.403-4.545 4.589-4.588-4.543-1.405 1.405 4.593 4.552-4.547 4.592 1.405 1.405 4.555-4.596 4.591 4.55 1.403-1.416z"
+    />
+  </svg>
+  <svg
+    aria-hidden="true"
+    className="emotion-3"
+    fill="currentcolor"
+    height="24"
+    viewBox="0 0 24 24"
+    width="24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+    />
+  </svg>
+</div>
+`;
+
 exports[`Close renders 1`] = `
 .emotion-0 {
   box-sizing: border-box;

--- a/packages/components/test/index.js
+++ b/packages/components/test/index.js
@@ -471,6 +471,18 @@ describe('Radio', () => {
 })
 
 describe('Checkbox', () => {
+  test('renders with custom icon', () => {
+    const customCheck = <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M22 2v20h-20v-20h20zm2-2h-24v24h24v-24zm-6 16.538l-4.592-4.548 4.546-4.587-1.416-1.403-4.545 4.589-4.588-4.543-1.405 1.405 4.593 4.552-4.547 4.592 1.405 1.405 4.555-4.596 4.591 4.55 1.403-1.416z"/></svg>
+    const icons = {checked: customCheck, unchecked: null}
+    const json = renderJSON(
+      <ThemeProvider theme={theme}>
+        <Checkbox 
+          icons={icons}
+        />
+      </ThemeProvider>
+    )
+    expect(json).toMatchSnapshot()
+  })
   test('renders', () => {
     const json = renderJSON(
       <ThemeProvider theme={theme}>
@@ -479,6 +491,7 @@ describe('Checkbox', () => {
     )
     expect(json).toMatchSnapshot()
   })
+
 })
 
 describe('Slider', () => {


### PR DESCRIPTION
Signed-off-by: Jay Clark <jay@jayeclark.dev>

Addresses #2013 

There is currently no option to display a one-off custom checkbox or radio button. This PR adds that feature. This functionality creates a custom checkbox/radio button icon if alternate icons are passed to a Checkbox component, while preserving the default appearance for all other buttons. It is different from updating theme.forms, which allows users to change the overall default appearance of all checkboxes and radio buttons.

I'm keeping the PR in draft mode for the moment while I work on refactoring/investigating a possible alternate implementation. Once I've finished that, I'll add additional commits for the radio button.