### PR TITLE
fix(docs): Set text color on Demo page JSON code

### DIFF
--- a/packages/docs/src/components/presets-demo.js
+++ b/packages/docs/src/components/presets-demo.js
@@ -90,6 +90,7 @@ export default function PresetsDemo() {
                 bg: 'muted',
                 border: 0,
                 borderRadius: 4,
+                color: 'text'
               }}
             />
           </Themed.root>


### PR DESCRIPTION
Currently in dark-mode; the color is not visible as it assumes the default color which is black.
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v0.12.2-develop.2`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from new contributors! :tada:
  
  Thanks for all your work!
  
  :heart: Akash ([@appsparkler](https://github.com/appsparkler))
  
  :heart: Greg Poole ([@gpoole](https://github.com/gpoole))
  
  #### 🐛 Bug Fix
  
  - fix(docs): Set text color on Demo page JSON code [#2024](https://github.com/system-ui/theme-ui/pull/2024) ([@appsparkler](https://github.com/appsparkler))
  
  #### 🏠 Internal
  
  - docs(pragma): add SWC instructions for Next.js [#2020](https://github.com/system-ui/theme-ui/pull/2020) ([@gpoole](https://github.com/gpoole))
  
  #### Authors: 2
  
  - Akash ([@appsparkler](https://github.com/appsparkler))
  - Greg Poole ([@gpoole](https://github.com/gpoole))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
