### PR TITLE
docs: Add indivorg/theme to resources

### DIFF
--- a/packages/docs/src/pages/resources.mdx
+++ b/packages/docs/src/pages/resources.mdx
@@ -18,7 +18,9 @@ Tools, themes, extensions and examples built by the Theme UI community.
   Used on [United Nations World Data Forum](https://undataforum.org/).
 - [**theme-ui-preset-geist**](https://github.com/lachlanjc/theme-ui-preset-geist):
   Inspired by/adapted from [Geist UI](https://geist-ui.dev).
-- [**theme-ui-preset-nice-boys**](https://github.com/nice-boys/theme-ui-preset-nice-boys)  
+- [**theme-ui-preset-nice-boys**](https://github.com/nice-boys/theme-ui-preset-nice-boys)
+- [**indivorg/theme**](https://github.com/indivorg/theme):
+  Used in Indiv's mobile and web applications.  
 
 ## Component kits
 


### PR DESCRIPTION
Thanks for Theme UI 🎉

This adds indivorg/theme to the list. The interesting thing about this theme is that it contains two themes, a) base theme and b) web theme. Base theme is used with Dripsy on a React Native application.