### PR TITLE
docs: Add next-theme-ui

### DIFF
--- a/packages/docs/src/pages/resources.mdx
+++ b/packages/docs/src/pages/resources.mdx
@@ -76,4 +76,6 @@ Tools, themes, extensions and examples built by the Theme UI community.
   Library for making animated modals with Theme UI & Framer Motion.
 - [**React Layouts**](https://react-layouts.com/):
   Grab-and-go layouts for React, including Theme UI.
+- [**Next Theme UI**](https://github.com/cobraz/next-theme-ui):
+  Components for using Theme UI with Next.js.
 


### PR DESCRIPTION
`next-theme-ui` is a small library to ease using Theme UI with Next.js.

Replaces these imports:

```typescript
import { Link } from '@theme-ui/components';
import { NavLink } from '@theme-ui/components';
```

with

```typescript
import { Link } from 'next-theme-ui';
import { NavLink } from 'next-theme-ui';
```

`<Link />` and `<NavLink />` uses `Link` from the `next/link` package.