### PR TITLE
fix: presets-demo and select-field styles

### DIFF
--- a/packages/docs/src/components/presets-demo.js
+++ b/packages/docs/src/components/presets-demo.js
@@ -1,6 +1,5 @@
 /** @jsx jsx */
-import { jsx, Themed, components, Select } from 'theme-ui'
-import { ThemeContext } from '@emotion/react'
+import { jsx, Themed, components, Select, ThemeProvider } from 'theme-ui'
 import { MDXProvider } from '@mdx-js/react'
 import { useState } from 'react'
 import { Helmet } from 'react-helmet'
@@ -16,7 +15,8 @@ import Lorem from './lorem.mdx'
 
 export default function PresetsDemo() {
   const [theme, setTheme] = useState('base')
-  const preset = presets[theme]
+  const preset = presets[theme]   
+
 
   return (
     <div>
@@ -57,7 +57,7 @@ export default function PresetsDemo() {
             ))}
           </Select>
         </label>
-        <ThemeContext.Provider value={preset}>
+        <ThemeProvider theme={() => ({...preset})}>
           <Themed.root sx={{ bg: 'background', color: 'text', p: 3 }}>
             <Themed.h2>Colors</Themed.h2>
             <ColorPalette omit={['modes', 'header']} />
@@ -94,7 +94,7 @@ export default function PresetsDemo() {
               }}
             />
           </Themed.root>
-        </ThemeContext.Provider>
+        </ThemeProvider>
       </div>
     </div>
   )

--- a/packages/docs/src/components/presets-demo.js
+++ b/packages/docs/src/components/presets-demo.js
@@ -46,7 +46,7 @@ export default function PresetsDemo() {
           <span>Preset:</span>
           <Select
             id="theme"
-            sx={{ display: 'inline-flex', paddingRight: 24 }}
+            sx={{ display: 'inline-flex', paddingRight: 32 }}
             value={theme}
             onChange={(e) => {
               setTheme(e.target.value)

--- a/packages/docs/src/components/presets-demo.js
+++ b/packages/docs/src/components/presets-demo.js
@@ -46,7 +46,7 @@ export default function PresetsDemo() {
           <span>Preset:</span>
           <Select
             id="theme"
-            sx={{ display: 'inline-flex' }}
+            sx={{ display: 'inline-flex', paddingRight: 24 }}
             value={theme}
             onChange={(e) => {
               setTheme(e.target.value)
@@ -57,7 +57,7 @@ export default function PresetsDemo() {
             ))}
           </Select>
         </label>
-        <ThemeProvider theme={() => ({...preset})}>
+        <ThemeProvider theme={preset}>
           <Themed.root sx={{ bg: 'background', color: 'text', p: 3 }}>
             <Themed.h2>Colors</Themed.h2>
             <ColorPalette omit={['modes', 'header']} />


### PR DESCRIPTION
Fixes:
- presets demo wasn't working
- minor style issue when you select the `bootstrap` in the field for selecting presets.