### PR TITLE
feat(docs): update theme-ui install command

### DIFF
--- a/packages/docs/src/pages/getting-started/index.mdx
+++ b/packages/docs/src/pages/getting-started/index.mdx
@@ -9,7 +9,7 @@ import IntroCodeSamples from '../../components/intro-code-samples'
 Install Theme UI.
 
 ```sh
-npm install theme-ui
+npm install theme-ui @emotion/react @emotion/styled @mdx-js/react
 ```
 
 Create a theme object to include custom color, typography, and layout values.


### PR DESCRIPTION
Update the `theme-ui` install command in the "Getting started" part of the docs to match the install command shown in the [README](https://github.com/system-ui/theme-ui/blob/develop/packages/theme-ui/README.md).

I don't know if there are other changes we would want to make here, but the install command should at least be updated so people won't get dependency errors when trying to run their project. 

**TODO**
- [ ] Write changelog entry