### PR TITLE
feat(custom-properties): Warn in development on invalid theme keys

### DIFF
--- a/packages/custom-properties/src/index.ts
+++ b/packages/custom-properties/src/index.ts
@@ -1,6 +1,10 @@
 import pluralize from 'pluralize'
 import { Theme } from '@theme-ui/css'
 
+// Simplified validator based on spec https://www.w3.org/TR/CSS22/syndata.html#value-def-identifier
+// Does not check for "cannot start with a digit, two hyphens, or a hyphen followed by a digit"
+const keyValidator = /^[A-z0-9][\w-]*$/
+
 interface CustomProperties {
   [key: string]: string | number
 }
@@ -11,6 +15,16 @@ export default function makeCustomProperties(theme: Theme, prefix?: string) {
   const generateProperties = (object: object, previousKey?: string) => {
     Object.entries(object).forEach(([key, value]) => {
       let formattedKey = pluralize(key, 1)
+
+      if (
+        process.env.NODE_ENV !== 'production' &&
+        !keyValidator.test(formattedKey)
+      ) {
+        console.warn(
+          `[theme-ui] Theme key "${value}" found will produce an invalid CSS custom property. ` +
+            'Keys must only contain the following: A-Z, a-z, 0-9, hyphen, underscore.'
+        )
+      }
 
       if (prefix && !previousKey) {
         formattedKey = `${prefix}-${formattedKey}`

--- a/packages/custom-properties/test/test.js
+++ b/packages/custom-properties/test/test.js
@@ -1,4 +1,5 @@
 import toCustomProperties from '../src'
+import mockConsole from 'jest-mock-console'
 
 const theme = {
   colors: {
@@ -18,8 +19,7 @@ const theme = {
     },
   },
   fonts: {
-    body:
-      'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif',
+    body: 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif',
     heading:
       'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif',
     monospace: 'Menlo, monospace',
@@ -35,13 +35,25 @@ const theme = {
 }
 
 it('transforms a theme config to CSS custom properties', () => {
+  mockConsole()
   const result = toCustomProperties(theme)
 
   expect(result).toMatchSnapshot()
+  expect(console.warn).toHaveBeenCalledTimes(0)
 })
 
 it('transforms a theme config to CSS custom properties with prefix', () => {
   const result = toCustomProperties(theme, '🍭')
 
   expect(result).toMatchSnapshot()
+})
+
+it('warns on invalid CSS custom property key', () => {
+  mockConsole()
+  toCustomProperties({ sizes: { '1/4': 1 / 4, '1/2': 1 / 2 } })
+
+  expect(console.warn).toHaveBeenCalledTimes(2)
+  expect(console.warn).toHaveBeenLastCalledWith(
+    '[theme-ui] Theme key "0.5" found will produce an invalid CSS custom property. Keys must only contain the following: A-Z, a-z, 0-9, hyphen, underscore.'
+  )
 })


### PR DESCRIPTION
Closes #1728 by warning (in non-production environments) when invalid CSS custom properties are being generated, including a test.

I wrote a simplified validator based on [the spec](https://www.w3.org/TR/CSS22/syndata.html#value-def-identifier) that checks for the right characters but does not check for "cannot start with a digit, two hyphens, or a hyphen followed by a digit", but figured this should cover the bulk of cases.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @theme-ui/color-modes@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  npm install @theme-ui/color@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  npm install @theme-ui/components@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  npm install @theme-ui/core@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  npm install @theme-ui/css@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  npm install @theme-ui/custom-properties@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  npm install @theme-ui/editor@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  npm install gatsby-plugin-theme-ui@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  npm install gatsby-theme-style-guide@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  npm install gatsby-theme-ui-layout@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  npm install @theme-ui/match-media@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  npm install @theme-ui/mdx@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  npm install @theme-ui/parse-props@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  npm install @theme-ui/preset-base@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  npm install @theme-ui/preset-bootstrap@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  npm install @theme-ui/preset-bulma@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  npm install @theme-ui/preset-dark@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  npm install @theme-ui/preset-deep@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  npm install @theme-ui/preset-funk@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  npm install @theme-ui/preset-future@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  npm install @theme-ui/preset-polaris@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  npm install @theme-ui/preset-roboto@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  npm install @theme-ui/preset-sketchy@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  npm install @theme-ui/preset-swiss@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  npm install @theme-ui/preset-system@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  npm install @theme-ui/preset-tailwind@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  npm install @theme-ui/preset-tosh@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  npm install @theme-ui/presets@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  npm install @theme-ui/prism@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  npm install @theme-ui/sidenav@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  npm install @theme-ui/style-guide@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  npm install @theme-ui/tailwind@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  npm install @theme-ui/theme-provider@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  npm install theme-ui@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  npm install @theme-ui/typography@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  # or 
  yarn add @theme-ui/color-modes@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  yarn add @theme-ui/color@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  yarn add @theme-ui/components@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  yarn add @theme-ui/core@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  yarn add @theme-ui/css@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  yarn add @theme-ui/custom-properties@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  yarn add @theme-ui/editor@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  yarn add gatsby-plugin-theme-ui@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  yarn add gatsby-theme-style-guide@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  yarn add gatsby-theme-ui-layout@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  yarn add @theme-ui/match-media@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  yarn add @theme-ui/mdx@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  yarn add @theme-ui/parse-props@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  yarn add @theme-ui/preset-base@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  yarn add @theme-ui/preset-bootstrap@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  yarn add @theme-ui/preset-bulma@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  yarn add @theme-ui/preset-dark@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  yarn add @theme-ui/preset-deep@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  yarn add @theme-ui/preset-funk@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  yarn add @theme-ui/preset-future@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  yarn add @theme-ui/preset-polaris@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  yarn add @theme-ui/preset-roboto@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  yarn add @theme-ui/preset-sketchy@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  yarn add @theme-ui/preset-swiss@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  yarn add @theme-ui/preset-system@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  yarn add @theme-ui/preset-tailwind@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  yarn add @theme-ui/preset-tosh@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  yarn add @theme-ui/presets@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  yarn add @theme-ui/prism@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  yarn add @theme-ui/sidenav@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  yarn add @theme-ui/style-guide@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  yarn add @theme-ui/tailwind@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  yarn add @theme-ui/theme-provider@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  yarn add theme-ui@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  yarn add @theme-ui/typography@0.14.0--canary.2080.bedf631c6c5280d5dc457bd4e2c38896a99bde38.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v0.14.0-develop.7`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from a new contributor! :tada:
  
  Thank you, Brage ([@braaar](https://github.com/braaar)), for all your work!
  
  #### 🚀 Enhancement
  
  - feat(examples/next): Add new deps, fully use TSX, rebuild [#2068](https://github.com/system-ui/theme-ui/pull/2068) ([@lachlanjc](https://github.com/lachlanjc))
  - `@theme-ui/custom-properties`
    - feat(custom-properties): Warn in development on invalid theme keys [#2080](https://github.com/system-ui/theme-ui/pull/2080) ([@lachlanjc](https://github.com/lachlanjc))
  - `@theme-ui/color-modes`
    - feat(color-modes): Warn when theme color keys have leading/trailing whitespace [#2099](https://github.com/system-ui/theme-ui/pull/2099) ([@lachlanjc](https://github.com/lachlanjc))
  - `theme-ui`
    - feat(theme-ui): Add sx prop to BaseStyles component [#2081](https://github.com/system-ui/theme-ui/pull/2081) ([@lachlanjc](https://github.com/lachlanjc))
  
  #### 🐛 Bug Fix
  
  - Finish editing note [#2079](https://github.com/system-ui/theme-ui/pull/2079) ([@lachlanjc](https://github.com/lachlanjc))
  - fix(docs): Update recommendations in Keyframes doc [#2079](https://github.com/system-ui/theme-ui/pull/2079) ([@lachlanjc](https://github.com/lachlanjc))
  - `@theme-ui/sidenav`
    - fix(sidenav): Build with latest theme-ui version [#2084](https://github.com/system-ui/theme-ui/pull/2084) ([@lachlanjc](https://github.com/lachlanjc))
  - `@theme-ui/components`
    - components: Fix visual collapsing bug with Switch component [#2067](https://github.com/system-ui/theme-ui/pull/2067) ([@lachlanjc](https://github.com/lachlanjc))
  
  #### 👨‍💻 Minor changes
  
  - docs(examples/next): fix case insensitive import ([@hasparus](https://github.com/hasparus))
  
  #### 🏠 Internal
  
  - docs(jsx): add some more detail to #with-swc section in jsx-pragma docs [#2094](https://github.com/system-ui/theme-ui/pull/2094) ([@hasparus](https://github.com/hasparus) [@lachlanjc](https://github.com/lachlanjc))
  - e2e: Upgrade dependencies [#2098](https://github.com/system-ui/theme-ui/pull/2098) ([@lachlanjc](https://github.com/lachlanjc))
  - Set up CodeSandbox CI [#2085](https://github.com/system-ui/theme-ui/pull/2085) ([@lachlanjc](https://github.com/lachlanjc))
  - examples: Remove CodeSandbox starter example [#2086](https://github.com/system-ui/theme-ui/pull/2086) ([@lachlanjc](https://github.com/lachlanjc))
  - docs: Document default theme values [#2087](https://github.com/system-ui/theme-ui/pull/2087) ([@lachlanjc](https://github.com/lachlanjc))
  - docs: add dependencies to "getting started" [#2071](https://github.com/system-ui/theme-ui/pull/2071) ([@braaar](https://github.com/braaar))
  - `@theme-ui/sidenav`
    - sidenav: Fix props leaking to DOM on Pagination component [#2057](https://github.com/system-ui/theme-ui/pull/2057) ([@lachlanjc](https://github.com/lachlanjc))
  
  #### Authors: 3
  
  - Brage ([@braaar](https://github.com/braaar))
  - Lachlan Campbell ([@lachlanjc](https://github.com/lachlanjc))
  - Piotr Monwid-Olechnowicz ([@hasparus](https://github.com/hasparus))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
