### PR TITLE
fix(color-modes): properly use print mode even if its name is `initialColorModeName`

### DIFF
--- a/packages/color-modes/src/custom-properties.ts
+++ b/packages/color-modes/src/custom-properties.ts
@@ -88,13 +88,20 @@ export const __createColorStyles = (theme: Theme = {}) => {
   const styles = __createColorProperties(colors, modes)
 
   if (printColorModeName) {
-    const mode =
-      printColorModeName === 'initial' ||
-      printColorModeName === initialColorModeName
-        ? colors
-        : modes[printColorModeName]
-    styles['@media print'] = __objectToVars('colors', mode)
+    let printMode = modes[printColorModeName]
+    if (!printMode && printColorModeName === initialColorModeName)
+      printMode = colors
+
+    if (printMode) {
+      styles['@media print'] = __objectToVars('colors', printMode)
+    } else {
+      console.error(
+        `Theme UI \`printColorModeName\` was not found in colors scale`,
+        { colors, printColorModeName }
+      )
+    }
   }
+
   const colorToVarValue = (color: string) => toVarValue(`colors-${color}`)
 
   return css({

--- a/packages/color-modes/test/custom-properties.tsx
+++ b/packages/color-modes/test/custom-properties.tsx
@@ -185,6 +185,7 @@ describe('__createColorStyles', () => {
         },
       },
     })
+
     expect(styles).toEqual({
       color: 'var(--theme-ui-colors-text)',
       backgroundColor: 'var(--theme-ui-colors-background)',
@@ -198,6 +199,31 @@ describe('__createColorStyles', () => {
         '--theme-ui-colors-text': 'tomato',
         '--theme-ui-colors-background': 'white',
       },
+    })
+  })
+
+  test('creates styles for print color mode if its name is the same as initialColorModeName', () => {
+    const styles = __createColorStyles({
+      config: {
+        initialColorModeName: 'light',
+        useColorSchemeMediaQuery: true,
+        printColorModeName: 'light',
+      },
+      colors: {
+        text: '#fff',
+        background: '#000',
+        modes: {
+          light: {
+            text: '#000',
+            background: '#fff',
+          },
+        },
+      },
+    })
+
+    expect(styles['@media print']).toEqual({
+      '--theme-ui-colors-text': '#000',
+      '--theme-ui-colors-background': '#fff',
     })
   })
 


### PR DESCRIPTION
Fixes https://github.com/system-ui/theme-ui/issues/1964.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @theme-ui/color-modes@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  npm install @theme-ui/color@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  npm install @theme-ui/components@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  npm install @theme-ui/core@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  npm install @theme-ui/css@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  npm install @theme-ui/custom-properties@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  npm install @theme-ui/editor@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  npm install gatsby-plugin-theme-ui@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  npm install gatsby-theme-style-guide@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  npm install gatsby-theme-ui-layout@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  npm install @theme-ui/match-media@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  npm install @theme-ui/mdx@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  npm install @theme-ui/parse-props@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  npm install @theme-ui/preset-base@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  npm install @theme-ui/preset-bootstrap@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  npm install @theme-ui/preset-bulma@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  npm install @theme-ui/preset-dark@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  npm install @theme-ui/preset-deep@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  npm install @theme-ui/preset-funk@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  npm install @theme-ui/preset-future@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  npm install @theme-ui/preset-polaris@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  npm install @theme-ui/preset-roboto@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  npm install @theme-ui/preset-sketchy@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  npm install @theme-ui/preset-swiss@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  npm install @theme-ui/preset-system@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  npm install @theme-ui/preset-tailwind@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  npm install @theme-ui/preset-tosh@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  npm install @theme-ui/presets@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  npm install @theme-ui/prism@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  npm install @theme-ui/sidenav@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  npm install @theme-ui/style-guide@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  npm install @theme-ui/tailwind@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  npm install @theme-ui/theme-provider@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  npm install theme-ui@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  npm install @theme-ui/typography@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  # or 
  yarn add @theme-ui/color-modes@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  yarn add @theme-ui/color@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  yarn add @theme-ui/components@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  yarn add @theme-ui/core@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  yarn add @theme-ui/css@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  yarn add @theme-ui/custom-properties@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  yarn add @theme-ui/editor@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  yarn add gatsby-plugin-theme-ui@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  yarn add gatsby-theme-style-guide@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  yarn add gatsby-theme-ui-layout@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  yarn add @theme-ui/match-media@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  yarn add @theme-ui/mdx@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  yarn add @theme-ui/parse-props@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  yarn add @theme-ui/preset-base@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  yarn add @theme-ui/preset-bootstrap@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  yarn add @theme-ui/preset-bulma@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  yarn add @theme-ui/preset-dark@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  yarn add @theme-ui/preset-deep@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  yarn add @theme-ui/preset-funk@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  yarn add @theme-ui/preset-future@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  yarn add @theme-ui/preset-polaris@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  yarn add @theme-ui/preset-roboto@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  yarn add @theme-ui/preset-sketchy@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  yarn add @theme-ui/preset-swiss@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  yarn add @theme-ui/preset-system@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  yarn add @theme-ui/preset-tailwind@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  yarn add @theme-ui/preset-tosh@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  yarn add @theme-ui/presets@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  yarn add @theme-ui/prism@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  yarn add @theme-ui/sidenav@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  yarn add @theme-ui/style-guide@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  yarn add @theme-ui/tailwind@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  yarn add @theme-ui/theme-provider@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  yarn add theme-ui@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  yarn add @theme-ui/typography@0.14.0--canary.2090.55a1fbfa47decd8d745779790d9eb48a1efb60e6.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v0.14.0-develop.23`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from new contributors! :tada:
  
  Thanks for all your work!
  
  :heart: Brage ([@braaar](https://github.com/braaar))
  
  :heart: peterlits zo ([@PeterlitsZo](https://github.com/PeterlitsZo))
  
  :heart: Ryan Turner ([@rtturner](https://github.com/rtturner))
  
  :heart: Cannon Lock ([@CannonLock](https://github.com/CannonLock))
  
  #### 🚀 Enhancement
  
  - feat(examples/next): Add new deps, fully use TSX, rebuild [#2068](https://github.com/system-ui/theme-ui/pull/2068) ([@lachlanjc](https://github.com/lachlanjc))
  - `@theme-ui/tailwind`
    - feat(tailwind): Upgrade Tailwind theme conversion for v3.0 [#2082](https://github.com/system-ui/theme-ui/pull/2082) ([@lachlanjc](https://github.com/lachlanjc))
  - `@theme-ui/custom-properties`
    - feat(custom-properties): Warn in development on invalid theme keys [#2080](https://github.com/system-ui/theme-ui/pull/2080) ([@lachlanjc](https://github.com/lachlanjc))
  - `@theme-ui/color-modes`
    - feat(color-modes): Warn when theme color keys have leading/trailing whitespace [#2099](https://github.com/system-ui/theme-ui/pull/2099) ([@lachlanjc](https://github.com/lachlanjc))
  - `theme-ui`
    - feat(theme-ui): Add sx prop to BaseStyles component [#2081](https://github.com/system-ui/theme-ui/pull/2081) ([@lachlanjc](https://github.com/lachlanjc))
  
  #### 🐛 Bug Fix
  
  - fix(docs): make layout more consistent [#2168](https://github.com/system-ui/theme-ui/pull/2168) ([@hasparus](https://github.com/hasparus))
  - feat(docs): Add custom content for sketchy preset demo [#1236](https://github.com/system-ui/theme-ui/pull/1236) ([@atanasster](https://github.com/atanasster) [@hasparus](https://github.com/hasparus) [@lachlanjc](https://github.com/lachlanjc))
  - fix(docs): Update recommendations in Keyframes doc [#2079](https://github.com/system-ui/theme-ui/pull/2079) ([@lachlanjc](https://github.com/lachlanjc))
  - Release v0.13.2 [#2075](https://github.com/system-ui/theme-ui/pull/2075) ([@lachlanjc](https://github.com/lachlanjc) [@hasparus](https://github.com/hasparus) [@braaar](https://github.com/braaar) [@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@theme-ui/color-modes`
    - fix(color-modes): properly use print mode even if its name is `initialColorModeName` [#2090](https://github.com/system-ui/theme-ui/pull/2090) ([@hasparus](https://github.com/hasparus))
  - `gatsby-plugin-theme-ui`
    - fix(gatsby-plugin-theme-ui,docs): Dependency Updates [#2138](https://github.com/system-ui/theme-ui/pull/2138) ([@LekoArts](https://github.com/LekoArts))
  - `@theme-ui/style-guide`
    - fix(style-guide): use inherited fontSize for ColorPalette color labels [#2135](https://github.com/system-ui/theme-ui/pull/2135) ([@braaar](https://github.com/braaar))
  - `@theme-ui/components`
    - fix(components): Update IconButton type definition to include size prop [#2121](https://github.com/system-ui/theme-ui/pull/2121) ([@rtturner](https://github.com/rtturner))
    - components: Fix visual collapsing bug with Switch component [#2067](https://github.com/system-ui/theme-ui/pull/2067) ([@lachlanjc](https://github.com/lachlanjc))
  - `@theme-ui/sidenav`
    - fix(sidenav): Build with latest theme-ui version [#2084](https://github.com/system-ui/theme-ui/pull/2084) ([@lachlanjc](https://github.com/lachlanjc))
  
  #### 👨‍💻 Minor changes
  
  - Update jsx-pragma.mdx ([@hasparus](https://github.com/hasparus))
  - docs(examples/next): fix case insensitive import ([@hasparus](https://github.com/hasparus))
  
  #### 🏠 Internal
  
  - docs(sx-prop): add more detail for responsive values. [#2116](https://github.com/system-ui/theme-ui/pull/2116) ([@PeterlitsZo](https://github.com/PeterlitsZo) [@lachlanjc](https://github.com/lachlanjc))
  - docs(jsx-pragma): Add section on using with vite [#2119](https://github.com/system-ui/theme-ui/pull/2119) ([@PeterlitsZo](https://github.com/PeterlitsZo) [@lachlanjc](https://github.com/lachlanjc))
  - docs: Clarify usage of theme prop in MDX Layout docs [#2100](https://github.com/system-ui/theme-ui/pull/2100) ([@CannonLock](https://github.com/CannonLock))
  - docs(jsx): add some more detail to #with-swc section in jsx-pragma docs [#2094](https://github.com/system-ui/theme-ui/pull/2094) ([@hasparus](https://github.com/hasparus) [@lachlanjc](https://github.com/lachlanjc))
  - e2e: Upgrade dependencies [#2098](https://github.com/system-ui/theme-ui/pull/2098) ([@lachlanjc](https://github.com/lachlanjc))
  - Set up CodeSandbox CI [#2085](https://github.com/system-ui/theme-ui/pull/2085) ([@lachlanjc](https://github.com/lachlanjc))
  - examples: Remove CodeSandbox starter example [#2086](https://github.com/system-ui/theme-ui/pull/2086) ([@lachlanjc](https://github.com/lachlanjc))
  - docs: Document default theme values [#2087](https://github.com/system-ui/theme-ui/pull/2087) ([@lachlanjc](https://github.com/lachlanjc))
  - `@theme-ui/sidenav`
    - sidenav: Fix props leaking to DOM on Pagination component [#2057](https://github.com/system-ui/theme-ui/pull/2057) ([@lachlanjc](https://github.com/lachlanjc))
  
  #### Authors: 9
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Atanas Stoyanov ([@atanasster](https://github.com/atanasster))
  - Brage ([@braaar](https://github.com/braaar))
  - Cannon Lock ([@CannonLock](https://github.com/CannonLock))
  - Lachlan Campbell ([@lachlanjc](https://github.com/lachlanjc))
  - Lennart ([@LekoArts](https://github.com/LekoArts))
  - peterlits zo ([@PeterlitsZo](https://github.com/PeterlitsZo))
  - Piotr Monwid-Olechnowicz ([@hasparus](https://github.com/hasparus))
  - Ryan Turner ([@rtturner](https://github.com/rtturner))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
