### PR TITLE
docs(jsx): add some more detail to #with-swc section in jsx-pragma docs

### DIFF
--- a/packages/docs/src/pages/guides/jsx-pragma.mdx
+++ b/packages/docs/src/pages/guides/jsx-pragma.mdx
@@ -178,7 +178,9 @@ In `jsconfig.json` or `tsconfig.json` (since Next.js 12.0.4):
 ```json
 {
   "compilerOptions": {
-    "jsxImportSource": "theme-ui"
+    "jsx": "preserve",
+    "jsxImportSource": "@theme-ui/core" // or "theme-ui"
+    // ... the rest of your compilerOptions redacted for brevity
   }
 }
 ```

--- a/packages/docs/src/pages/guides/jsx-pragma.mdx
+++ b/packages/docs/src/pages/guides/jsx-pragma.mdx
@@ -145,12 +145,11 @@ typecheck), or for instance to run tests with `ts-jest`
 NOTE: this requires
 [TypeScript >= 4.1](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-1.html#react-17-jsx-factories)
 
-### Using next.js
+### Using Next.js
 
 #### With Babel
 
-```js
-// babel.config.js
+```js filename=babel.config.js
 module.exports = {
   presets: [
     [
@@ -173,13 +172,16 @@ You can read more about
 
 #### With SWC
 
+Next.js is [gradually migrating to SWC](https://nextjs.org/docs/advanced-features/compiler#why-swc),
+and recommends using it for all new projects.
+
 In `jsconfig.json` or `tsconfig.json` (since Next.js 12.0.4):
 
 ```json
 {
   "compilerOptions": {
     "jsx": "preserve",
-    "jsxImportSource": "@theme-ui/core" // or "theme-ui"
+    "jsxImportSource": "theme-ui" // or "@theme-ui/core"
     // ... the rest of your compilerOptions redacted for brevity
   }
 }


### PR DESCRIPTION
I think folks are now interpretting this section of the docs as "remove your entire config and leave this one key" and you need other stuff in your config too.