### PR TITLE
docs: Clarify usage of theme prop in MDX Layout docs

### DIFF
--- a/packages/docs/src/pages/guides/mdx-layout-components.mdx
+++ b/packages/docs/src/pages/guides/mdx-layout-components.mdx
@@ -24,7 +24,7 @@ export default (props) => (
 )
 ```
 
-To add styles to this component, add a `theme` prop to the `ThemeProvider` and an `sx` prop to the `div`.
+To add styles to this component, augment the required `theme` prop and add an `sx` prop to the `div`.
 
 ```jsx filename=Layout.js
 /** @jsxImportSource theme-ui */


### PR DESCRIPTION
Previously syntax implies that the `theme` prop is not required. As the lack of this prop spawns errors I think making this clear will be helpful.