### PR TITLE
fix(components): Update IconButton type definition to include size prop

### DIFF
--- a/packages/components/index.d.ts
+++ b/packages/components/index.d.ts
@@ -365,7 +365,9 @@ export type MessageProps = BoxProps
 export const Message: ForwardRef<HTMLDivElement, MessageProps>
 
 export interface IconButtonProps
-  extends Assign<React.ComponentPropsWithRef<'button'>, BoxOwnProps> {}
+  extends Assign<React.ComponentPropsWithRef<'button'>, BoxOwnProps> {
+  size?: number | string
+}
 /**
  * Transparent button for SVG icons
  *


### PR DESCRIPTION
`IconButton` has a `size` attribute defined but it is not reflected in the `IconButtonProps` interface.