### PR TITLE
fix(style-guide): use inherited fontSize for ColorPalette color labels

### DIFF
--- a/packages/style-guide/src/ColorPalette.tsx
+++ b/packages/style-guide/src/ColorPalette.tsx
@@ -30,7 +30,6 @@ export const ColorRow = ({
     <div>
       <div
         sx={{
-          fontSize: 0,
           display: 'flex',
           flexWrap: 'wrap',
         }}>


### PR DESCRIPTION
see #2112

This PR removes the fontSize specification from the ColorRow component, making it so that the color swatch labels are displayed in the inherited fontSize for wherever it is placed in the DOM.

The issue with the current code is that the color swatch labels will usually be displayed with the smallest fontSize in the project since that is the first entry in the array. 

As I discuss in #2112, in my case the smallest fontSize was 0, meaning that the labels didn't show up at all. I have seen some other theme pages such as [this one from Hack Club](https://theme.hackclub.com/) where it is clear that color labels appear quite small, which is not pleasing to the eye. It is also not so convenient that the fontSize is hard coded in this way.
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v0.14.0-develop.13`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from new contributors! :tada:
  
  Thanks for all your work!
  
  :heart: Brage ([@braaar](https://github.com/braaar))
  
  :heart: peterlits zo ([@PeterlitsZo](https://github.com/PeterlitsZo))
  
  :heart: Ryan Turner ([@rtturner](https://github.com/rtturner))
  
  :heart: Cannon Lock ([@CannonLock](https://github.com/CannonLock))
  
  #### 🚀 Enhancement
  
  - feat(examples/next): Add new deps, fully use TSX, rebuild [#2068](https://github.com/system-ui/theme-ui/pull/2068) ([@lachlanjc](https://github.com/lachlanjc))
  - `@theme-ui/tailwind`
    - feat(tailwind): Upgrade Tailwind theme conversion for v3.0 [#2082](https://github.com/system-ui/theme-ui/pull/2082) ([@lachlanjc](https://github.com/lachlanjc))
  - `@theme-ui/custom-properties`
    - feat(custom-properties): Warn in development on invalid theme keys [#2080](https://github.com/system-ui/theme-ui/pull/2080) ([@lachlanjc](https://github.com/lachlanjc))
  - `@theme-ui/color-modes`
    - feat(color-modes): Warn when theme color keys have leading/trailing whitespace [#2099](https://github.com/system-ui/theme-ui/pull/2099) ([@lachlanjc](https://github.com/lachlanjc))
  - `theme-ui`
    - feat(theme-ui): Add sx prop to BaseStyles component [#2081](https://github.com/system-ui/theme-ui/pull/2081) ([@lachlanjc](https://github.com/lachlanjc))
  
  #### 🐛 Bug Fix
  
  - feat(docs): Add custom content for sketchy preset demo [#1236](https://github.com/system-ui/theme-ui/pull/1236) ([@atanasster](https://github.com/atanasster) [@hasparus](https://github.com/hasparus) [@lachlanjc](https://github.com/lachlanjc))
  - Finish editing note [#2079](https://github.com/system-ui/theme-ui/pull/2079) ([@lachlanjc](https://github.com/lachlanjc))
  - fix(docs): Update recommendations in Keyframes doc [#2079](https://github.com/system-ui/theme-ui/pull/2079) ([@lachlanjc](https://github.com/lachlanjc))
  - Release v0.13.2 [#2075](https://github.com/system-ui/theme-ui/pull/2075) ([@lachlanjc](https://github.com/lachlanjc) [@hasparus](https://github.com/hasparus) [@braaar](https://github.com/braaar) [@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@theme-ui/style-guide`
    - fix(style-guide): use inherited fontSize for ColorPalette color labels [#2135](https://github.com/system-ui/theme-ui/pull/2135) ([@braaar](https://github.com/braaar))
  - `@theme-ui/components`
    - fix(components): Update IconButton type definition to include size prop [#2121](https://github.com/system-ui/theme-ui/pull/2121) ([@rtturner](https://github.com/rtturner))
    - components: Fix visual collapsing bug with Switch component [#2067](https://github.com/system-ui/theme-ui/pull/2067) ([@lachlanjc](https://github.com/lachlanjc))
  - `@theme-ui/sidenav`
    - fix(sidenav): Build with latest theme-ui version [#2084](https://github.com/system-ui/theme-ui/pull/2084) ([@lachlanjc](https://github.com/lachlanjc))
  
  #### 👨‍💻 Minor changes
  
  - Update jsx-pragma.mdx ([@hasparus](https://github.com/hasparus))
  - docs(examples/next): fix case insensitive import ([@hasparus](https://github.com/hasparus))
  
  #### 🏠 Internal
  
  - docs(sx-prop): add more detail for responsive values. [#2116](https://github.com/system-ui/theme-ui/pull/2116) ([@PeterlitsZo](https://github.com/PeterlitsZo) [@lachlanjc](https://github.com/lachlanjc))
  - docs(jsx-pragma): Add section on using with vite [#2119](https://github.com/system-ui/theme-ui/pull/2119) ([@PeterlitsZo](https://github.com/PeterlitsZo) [@lachlanjc](https://github.com/lachlanjc))
  - docs: Clarify usage of theme prop in MDX Layout docs [#2100](https://github.com/system-ui/theme-ui/pull/2100) ([@CannonLock](https://github.com/CannonLock))
  - docs(jsx): add some more detail to #with-swc section in jsx-pragma docs [#2094](https://github.com/system-ui/theme-ui/pull/2094) ([@hasparus](https://github.com/hasparus) [@lachlanjc](https://github.com/lachlanjc))
  - e2e: Upgrade dependencies [#2098](https://github.com/system-ui/theme-ui/pull/2098) ([@lachlanjc](https://github.com/lachlanjc))
  - Set up CodeSandbox CI [#2085](https://github.com/system-ui/theme-ui/pull/2085) ([@lachlanjc](https://github.com/lachlanjc))
  - examples: Remove CodeSandbox starter example [#2086](https://github.com/system-ui/theme-ui/pull/2086) ([@lachlanjc](https://github.com/lachlanjc))
  - docs: Document default theme values [#2087](https://github.com/system-ui/theme-ui/pull/2087) ([@lachlanjc](https://github.com/lachlanjc))
  - `@theme-ui/sidenav`
    - sidenav: Fix props leaking to DOM on Pagination component [#2057](https://github.com/system-ui/theme-ui/pull/2057) ([@lachlanjc](https://github.com/lachlanjc))
  
  #### Authors: 8
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Atanas Stoyanov ([@atanasster](https://github.com/atanasster))
  - Brage ([@braaar](https://github.com/braaar))
  - Cannon Lock ([@CannonLock](https://github.com/CannonLock))
  - Lachlan Campbell ([@lachlanjc](https://github.com/lachlanjc))
  - peterlits zo ([@PeterlitsZo](https://github.com/PeterlitsZo))
  - Piotr Monwid-Olechnowicz ([@hasparus](https://github.com/hasparus))
  - Ryan Turner ([@rtturner](https://github.com/rtturner))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
