### PR TITLE
fix(docs): make layout more consistent

### DIFF
--- a/packages/docs/src/components/layout.js
+++ b/packages/docs/src/components/layout.js
@@ -1,6 +1,6 @@
 /** @jsx jsx */
-import { jsx, Themed, useColorMode } from 'theme-ui'
-import { useState, useRef } from 'react'
+import { css, jsx, Themed, useColorMode } from 'theme-ui'
+import { useState, useRef, useEffect } from 'react'
 import { Flex, Box } from '@theme-ui/components'
 import { AccordionNav } from '@theme-ui/sidenav'
 import { Link } from 'gatsby'
@@ -45,10 +45,12 @@ export default function DocsLayout(props) {
   const nav = useRef(null)
   const [mode, setMode] = useColorMode()
 
+  const { pathname } = props.location
+  const isLanding = pathname === '/'
+
   const fullwidth =
-    (props.pageContext.frontmatter &&
-      props.pageContext.frontmatter.fullwidth) ||
-    props.location.pathname === '/'
+    isLanding ||
+    (props.pageContext.frontmatter && props.pageContext.frontmatter.fullwidth)
 
   const showNav = !props.pageContext?.frontmatter?.hidenav
 
@@ -62,16 +64,22 @@ export default function DocsLayout(props) {
         sx={{
           flexDirection: 'column',
           minHeight: '100vh',
-        }}>
+        }}
+      >
         {showNav && (
           <Flex
             as="header"
             sx={{
+              zIndex: 1,
               height: 64,
               px: 3,
               alignItems: 'center',
               justifyContent: 'space-between',
-            }}>
+              position: isLanding ? 'initial' : 'sticky',
+              top: 0,
+              background: 'background',
+            }}
+          >
             <Flex sx={{ alignItems: 'center' }}>
               <MenuButton
                 onClick={(e) => {
@@ -99,7 +107,8 @@ export default function DocsLayout(props) {
                     ml: 2,
                     whiteSpace: 'pre',
                   }}
-                  onClick={() => setMode(nextColorMode)}>
+                  onClick={() => setMode(nextColorMode)}
+                >
                   {getModeName(mode)}
                 </Button>
               </Flex>
@@ -112,7 +121,8 @@ export default function DocsLayout(props) {
             alignItems: 'flex-start',
             display: ['block', 'flex'],
             height: '100%',
-          }}>
+          }}
+        >
           <Sidebar
             ref={nav}
             role="navigation"
@@ -130,8 +140,9 @@ export default function DocsLayout(props) {
             }}
             open={menuOpen}
             components={sidebar}
-            pathname={props.location.pathname}
+            pathname={pathname}
             sx={{
+              background: 'background',
               display: [null, fullwidth ? 'none' : 'block'],
               width: 256,
               flex: 'none',
@@ -141,23 +152,68 @@ export default function DocsLayout(props) {
               pt: 3,
               pb: 4,
               mt: [64, 0],
+              position: [null, 'sticky'],
+              top: [null, '64px'],
             }}
           />
-          <main
-            id="content"
+          <div
             sx={{
               width: '100%',
               minWidth: 0,
-              maxWidth: fullwidth ? 'none' : 768,
-              mx: 'auto',
-              px: fullwidth ? 0 : 3,
-            }}>
-            {props.children}
-            <EditLink />
-            {!fullwidth && <Pagination />}
-          </main>
+
+              position: 'relative',
+            }}
+          >
+            {!isLanding && <HeaderScrollShadow />}
+            <main
+              id="content"
+              sx={{
+                maxWidth: fullwidth ? 'none' : 768,
+                mx: 'auto',
+                px: fullwidth ? 0 : 3,
+              }}
+            >
+              {props.children}
+              <EditLink />
+              {!fullwidth && <Pagination />}
+            </main>
+          </div>
         </Box>
       </Flex>
     </Themed.root>
+  )
+}
+
+function HeaderScrollShadow() {
+  const ref = useRef()
+
+  useEffect(() => {
+    const onScroll = () => {
+      const { current } = ref
+      if (current) {
+        current.style.opacity = window.scrollY > 0 ? 1 : 0
+      }
+    }
+
+    window.addEventListener('scroll', onScroll)
+    return () => window.removeEventListener('scroll', onScroll)
+  }, [])
+
+  return (
+    <div
+      ref={ref}
+      sx={{
+        content: "''",
+        top: '64px',
+        transform: 'translateY(-64px)',
+        left: 0,
+        right: 0,
+        height: '64px',
+        position: 'sticky',
+        boxShadow: '0 12px 18px -3px rgb(0 0 0 / 0.03)',
+        transition: 'opacity 250ms linear',
+        opacity: 0,
+      }}
+    />
   )
 }

--- a/packages/e2e/integration/docs-navigation.ts
+++ b/packages/e2e/integration/docs-navigation.ts
@@ -62,6 +62,12 @@ describe('docs navigation', () => {
 
     cy.percySnapshot('@theme-ui/color docs')
   })
+
+  it('displays 404 page', () => {
+    cy.visit(`/not-found-${Math.random()}`, { failOnStatusCode: false })
+    cy.findByRole('heading').should('have.text', '404')
+    cy.findByText('Page not found')
+  })
 })
 
 export {}

--- a/packages/e2e/integration/docs-navigation.ts
+++ b/packages/e2e/integration/docs-navigation.ts
@@ -1,0 +1,67 @@
+describe('docs navigation', () => {
+  it('works without 404', () => {
+    cy.visit('/')
+    cy.findByText('Documentation').click()
+    cy.location().should('have.property', 'pathname', '/getting-started')
+    cy.findByText('Theming').click()
+    cy.get('h1').should('have.text', 'Theming')
+    cy.findAllByRole('link').then(($links) => {
+      const links = $links.get()
+      const texts = links.map((link) => link.textContent)
+
+      const expectedLinkTexts = [
+        'Hooks',
+        'API',
+        'Theme Specification',
+        'Demo',
+        'Resources',
+        'Components',
+        'Packages',
+        'Guides',
+        'Recipes',
+        'Migrating',
+        'Edit the page on GitHub',
+        'Previous:Getting Started with Gatsby',
+      ]
+
+      for (const s of expectedLinkTexts) {
+        expect(texts).to.include(s)
+      }
+
+      const nextChapterLink = links.find(
+        (link) => link.textContent === 'Next:The sx Prop'
+      )!
+
+      nextChapterLink.click()
+
+      const packagesLink = links.find(
+        (link) => link.textContent === 'Packages'
+      )!
+
+      packagesLink.click()
+    })
+
+    for (const packageName of [
+      'css',
+      'core',
+      'components',
+      'presets',
+      'color',
+    ]) {
+      cy.findAllByText('@theme-ui/' + packageName, { selector: 'li > a' })
+        .first()
+        .click()
+      cy.location().should(
+        'have.property',
+        'pathname',
+        `/packages/${packageName}`
+      )
+    }
+
+    cy.window().then((win) => win.scrollTo(0, 200))
+
+    cy.percySnapshot('@theme-ui/color docs')
+  })
+})
+
+export {}


### PR DESCRIPTION
I gave the docs layout some more attention. We have a search input, so the sticky header is convenient, and as a side effect, it solves the visual glitch of too short sidebar.

### What's changed

- The header is now sticky and it casts a shadow when `window.scrollY` is greater than `0`.

![image](https://user-images.githubusercontent.com/15332326/159098149-d7b9dba8-36a2-46ca-b4b4-720138410c87.png)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @theme-ui/color-modes@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  npm install @theme-ui/color@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  npm install @theme-ui/components@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  npm install @theme-ui/core@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  npm install @theme-ui/css@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  npm install @theme-ui/custom-properties@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  npm install @theme-ui/editor@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  npm install gatsby-plugin-theme-ui@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  npm install gatsby-theme-style-guide@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  npm install gatsby-theme-ui-layout@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  npm install @theme-ui/match-media@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  npm install @theme-ui/mdx@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  npm install @theme-ui/parse-props@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  npm install @theme-ui/preset-base@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  npm install @theme-ui/preset-bootstrap@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  npm install @theme-ui/preset-bulma@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  npm install @theme-ui/preset-dark@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  npm install @theme-ui/preset-deep@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  npm install @theme-ui/preset-funk@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  npm install @theme-ui/preset-future@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  npm install @theme-ui/preset-polaris@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  npm install @theme-ui/preset-roboto@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  npm install @theme-ui/preset-sketchy@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  npm install @theme-ui/preset-swiss@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  npm install @theme-ui/preset-system@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  npm install @theme-ui/preset-tailwind@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  npm install @theme-ui/preset-tosh@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  npm install @theme-ui/presets@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  npm install @theme-ui/prism@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  npm install @theme-ui/sidenav@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  npm install @theme-ui/style-guide@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  npm install @theme-ui/tailwind@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  npm install @theme-ui/theme-provider@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  npm install theme-ui@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  npm install @theme-ui/typography@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  # or 
  yarn add @theme-ui/color-modes@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  yarn add @theme-ui/color@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  yarn add @theme-ui/components@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  yarn add @theme-ui/core@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  yarn add @theme-ui/css@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  yarn add @theme-ui/custom-properties@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  yarn add @theme-ui/editor@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  yarn add gatsby-plugin-theme-ui@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  yarn add gatsby-theme-style-guide@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  yarn add gatsby-theme-ui-layout@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  yarn add @theme-ui/match-media@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  yarn add @theme-ui/mdx@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  yarn add @theme-ui/parse-props@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  yarn add @theme-ui/preset-base@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  yarn add @theme-ui/preset-bootstrap@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  yarn add @theme-ui/preset-bulma@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  yarn add @theme-ui/preset-dark@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  yarn add @theme-ui/preset-deep@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  yarn add @theme-ui/preset-funk@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  yarn add @theme-ui/preset-future@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  yarn add @theme-ui/preset-polaris@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  yarn add @theme-ui/preset-roboto@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  yarn add @theme-ui/preset-sketchy@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  yarn add @theme-ui/preset-swiss@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  yarn add @theme-ui/preset-system@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  yarn add @theme-ui/preset-tailwind@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  yarn add @theme-ui/preset-tosh@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  yarn add @theme-ui/presets@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  yarn add @theme-ui/prism@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  yarn add @theme-ui/sidenav@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  yarn add @theme-ui/style-guide@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  yarn add @theme-ui/tailwind@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  yarn add @theme-ui/theme-provider@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  yarn add theme-ui@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  yarn add @theme-ui/typography@0.14.0--canary.2168.e7bb3221501b77b3893868142a95988f0e72ad8b.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v0.14.0-develop.22`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from new contributors! :tada:
  
  Thanks for all your work!
  
  :heart: Brage ([@braaar](https://github.com/braaar))
  
  :heart: peterlits zo ([@PeterlitsZo](https://github.com/PeterlitsZo))
  
  :heart: Ryan Turner ([@rtturner](https://github.com/rtturner))
  
  :heart: Cannon Lock ([@CannonLock](https://github.com/CannonLock))
  
  #### 🚀 Enhancement
  
  - feat(examples/next): Add new deps, fully use TSX, rebuild [#2068](https://github.com/system-ui/theme-ui/pull/2068) ([@lachlanjc](https://github.com/lachlanjc))
  - `@theme-ui/tailwind`
    - feat(tailwind): Upgrade Tailwind theme conversion for v3.0 [#2082](https://github.com/system-ui/theme-ui/pull/2082) ([@lachlanjc](https://github.com/lachlanjc))
  - `@theme-ui/custom-properties`
    - feat(custom-properties): Warn in development on invalid theme keys [#2080](https://github.com/system-ui/theme-ui/pull/2080) ([@lachlanjc](https://github.com/lachlanjc))
  - `@theme-ui/color-modes`
    - feat(color-modes): Warn when theme color keys have leading/trailing whitespace [#2099](https://github.com/system-ui/theme-ui/pull/2099) ([@lachlanjc](https://github.com/lachlanjc))
  - `theme-ui`
    - feat(theme-ui): Add sx prop to BaseStyles component [#2081](https://github.com/system-ui/theme-ui/pull/2081) ([@lachlanjc](https://github.com/lachlanjc))
  
  #### 🐛 Bug Fix
  
  - fix(docs): make layout more consistent [#2168](https://github.com/system-ui/theme-ui/pull/2168) ([@hasparus](https://github.com/hasparus))
  - feat(docs): Add custom content for sketchy preset demo [#1236](https://github.com/system-ui/theme-ui/pull/1236) ([@atanasster](https://github.com/atanasster) [@hasparus](https://github.com/hasparus) [@lachlanjc](https://github.com/lachlanjc))
  - fix(docs): Update recommendations in Keyframes doc [#2079](https://github.com/system-ui/theme-ui/pull/2079) ([@lachlanjc](https://github.com/lachlanjc))
  - Release v0.13.2 [#2075](https://github.com/system-ui/theme-ui/pull/2075) ([@lachlanjc](https://github.com/lachlanjc) [@hasparus](https://github.com/hasparus) [@braaar](https://github.com/braaar) [@dependabot[bot]](https://github.com/dependabot[bot]))
  - `gatsby-plugin-theme-ui`
    - fix(gatsby-plugin-theme-ui,docs): Dependency Updates [#2138](https://github.com/system-ui/theme-ui/pull/2138) ([@LekoArts](https://github.com/LekoArts))
  - `@theme-ui/style-guide`
    - fix(style-guide): use inherited fontSize for ColorPalette color labels [#2135](https://github.com/system-ui/theme-ui/pull/2135) ([@braaar](https://github.com/braaar))
  - `@theme-ui/components`
    - fix(components): Update IconButton type definition to include size prop [#2121](https://github.com/system-ui/theme-ui/pull/2121) ([@rtturner](https://github.com/rtturner))
    - components: Fix visual collapsing bug with Switch component [#2067](https://github.com/system-ui/theme-ui/pull/2067) ([@lachlanjc](https://github.com/lachlanjc))
  - `@theme-ui/sidenav`
    - fix(sidenav): Build with latest theme-ui version [#2084](https://github.com/system-ui/theme-ui/pull/2084) ([@lachlanjc](https://github.com/lachlanjc))
  
  #### 👨‍💻 Minor changes
  
  - Update jsx-pragma.mdx ([@hasparus](https://github.com/hasparus))
  - docs(examples/next): fix case insensitive import ([@hasparus](https://github.com/hasparus))
  
  #### 🏠 Internal
  
  - docs(sx-prop): add more detail for responsive values. [#2116](https://github.com/system-ui/theme-ui/pull/2116) ([@PeterlitsZo](https://github.com/PeterlitsZo) [@lachlanjc](https://github.com/lachlanjc))
  - docs(jsx-pragma): Add section on using with vite [#2119](https://github.com/system-ui/theme-ui/pull/2119) ([@PeterlitsZo](https://github.com/PeterlitsZo) [@lachlanjc](https://github.com/lachlanjc))
  - docs: Clarify usage of theme prop in MDX Layout docs [#2100](https://github.com/system-ui/theme-ui/pull/2100) ([@CannonLock](https://github.com/CannonLock))
  - docs(jsx): add some more detail to #with-swc section in jsx-pragma docs [#2094](https://github.com/system-ui/theme-ui/pull/2094) ([@hasparus](https://github.com/hasparus) [@lachlanjc](https://github.com/lachlanjc))
  - e2e: Upgrade dependencies [#2098](https://github.com/system-ui/theme-ui/pull/2098) ([@lachlanjc](https://github.com/lachlanjc))
  - Set up CodeSandbox CI [#2085](https://github.com/system-ui/theme-ui/pull/2085) ([@lachlanjc](https://github.com/lachlanjc))
  - examples: Remove CodeSandbox starter example [#2086](https://github.com/system-ui/theme-ui/pull/2086) ([@lachlanjc](https://github.com/lachlanjc))
  - docs: Document default theme values [#2087](https://github.com/system-ui/theme-ui/pull/2087) ([@lachlanjc](https://github.com/lachlanjc))
  - `@theme-ui/sidenav`
    - sidenav: Fix props leaking to DOM on Pagination component [#2057](https://github.com/system-ui/theme-ui/pull/2057) ([@lachlanjc](https://github.com/lachlanjc))
  
  #### Authors: 9
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Atanas Stoyanov ([@atanasster](https://github.com/atanasster))
  - Brage ([@braaar](https://github.com/braaar))
  - Cannon Lock ([@CannonLock](https://github.com/CannonLock))
  - Lachlan Campbell ([@lachlanjc](https://github.com/lachlanjc))
  - Lennart ([@LekoArts](https://github.com/LekoArts))
  - peterlits zo ([@PeterlitsZo](https://github.com/PeterlitsZo))
  - Piotr Monwid-Olechnowicz ([@hasparus](https://github.com/hasparus))
  - Ryan Turner ([@rtturner](https://github.com/rtturner))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
