### PR TITLE
chore(docs): Drop root Themed.root

### DIFF
--- a/packages/docs/src/components/layout.js
+++ b/packages/docs/src/components/layout.js
@@ -1,5 +1,6 @@
 /** @jsx jsx */
-import { css, jsx, Themed, useColorMode } from 'theme-ui'
+import { Fragment } from 'react'
+import { jsx, useColorMode } from 'theme-ui'
 import { useState, useRef, useEffect } from 'react'
 import { Flex, Box } from '@theme-ui/components'
 import { AccordionNav } from '@theme-ui/sidenav'
@@ -57,7 +58,7 @@ export default function DocsLayout(props) {
   const nextColorMode = modes[(modes.indexOf(mode) + 1) % modes.length]
 
   return (
-    <Themed.root>
+    <Fragment>
       <Head {...props} />
       <SkipLink>Skip to content</SkipLink>
       <Flex
@@ -180,7 +181,7 @@ export default function DocsLayout(props) {
           </div>
         </Box>
       </Flex>
-    </Themed.root>
+    </Fragment>
   )
 }
 

--- a/packages/docs/src/components/preset.js
+++ b/packages/docs/src/components/preset.js
@@ -16,7 +16,7 @@ export default ({ preset: presetName }) => {
   const preset = presets[presetName]
 
   return (
-    <div>
+    <>
       <Helmet>
         <link
           rel="stylesheet"
@@ -59,6 +59,6 @@ export default ({ preset: presetName }) => {
           />
         </Themed.root>
       </ThemeContext.Provider>
-    </div>
+    </>
   )
 }

--- a/packages/docs/src/components/preset.js
+++ b/packages/docs/src/components/preset.js
@@ -16,7 +16,7 @@ export default ({ preset: presetName }) => {
   const preset = presets[presetName]
 
   return (
-    <>
+    <div>
       <Helmet>
         <link
           rel="stylesheet"
@@ -35,15 +35,14 @@ export default ({ preset: presetName }) => {
             fontFamily="heading"
             fontWeight="heading"
             lineHeight="heading"
-            fontSize={7}>
+            fontSize={7}
+          >
             Heading: <FontFamily name="heading" />
           </HeadingStyle>
           <Themed.h2>Type Scale</Themed.h2>
           <TypeScale />
           <Components />
-          <Themed.h2 id="json">
-            Raw JSON
-          </Themed.h2>
+          <Themed.h2 id="json">Raw JSON</Themed.h2>
           <textarea
             value={JSON.stringify(preset, null, 2)}
             rows={16}
@@ -59,6 +58,6 @@ export default ({ preset: presetName }) => {
           />
         </Themed.root>
       </ThemeContext.Provider>
-    </>
+    </div>
   )
 }


### PR DESCRIPTION
Flagged by #2175, removing the unneeded `Themed.root` wrapping the docs site. (Apparently Gatsby still doesn't support `<></>` fragment syntax?)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @theme-ui/color-modes@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  npm install @theme-ui/color@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  npm install @theme-ui/components@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  npm install @theme-ui/core@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  npm install @theme-ui/css@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  npm install @theme-ui/custom-properties@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  npm install @theme-ui/editor@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  npm install gatsby-plugin-theme-ui@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  npm install gatsby-theme-style-guide@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  npm install gatsby-theme-ui-layout@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  npm install @theme-ui/match-media@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  npm install @theme-ui/mdx@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  npm install @theme-ui/parse-props@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  npm install @theme-ui/preset-base@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  npm install @theme-ui/preset-bootstrap@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  npm install @theme-ui/preset-bulma@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  npm install @theme-ui/preset-dark@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  npm install @theme-ui/preset-deep@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  npm install @theme-ui/preset-funk@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  npm install @theme-ui/preset-future@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  npm install @theme-ui/preset-polaris@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  npm install @theme-ui/preset-roboto@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  npm install @theme-ui/preset-sketchy@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  npm install @theme-ui/preset-swiss@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  npm install @theme-ui/preset-system@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  npm install @theme-ui/preset-tailwind@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  npm install @theme-ui/preset-tosh@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  npm install @theme-ui/presets@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  npm install @theme-ui/prism@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  npm install @theme-ui/sidenav@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  npm install @theme-ui/style-guide@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  npm install @theme-ui/tailwind@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  npm install @theme-ui/theme-provider@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  npm install theme-ui@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  npm install @theme-ui/typography@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  # or 
  yarn add @theme-ui/color-modes@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  yarn add @theme-ui/color@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  yarn add @theme-ui/components@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  yarn add @theme-ui/core@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  yarn add @theme-ui/css@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  yarn add @theme-ui/custom-properties@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  yarn add @theme-ui/editor@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  yarn add gatsby-plugin-theme-ui@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  yarn add gatsby-theme-style-guide@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  yarn add gatsby-theme-ui-layout@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  yarn add @theme-ui/match-media@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  yarn add @theme-ui/mdx@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  yarn add @theme-ui/parse-props@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  yarn add @theme-ui/preset-base@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  yarn add @theme-ui/preset-bootstrap@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  yarn add @theme-ui/preset-bulma@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  yarn add @theme-ui/preset-dark@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  yarn add @theme-ui/preset-deep@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  yarn add @theme-ui/preset-funk@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  yarn add @theme-ui/preset-future@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  yarn add @theme-ui/preset-polaris@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  yarn add @theme-ui/preset-roboto@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  yarn add @theme-ui/preset-sketchy@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  yarn add @theme-ui/preset-swiss@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  yarn add @theme-ui/preset-system@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  yarn add @theme-ui/preset-tailwind@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  yarn add @theme-ui/preset-tosh@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  yarn add @theme-ui/presets@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  yarn add @theme-ui/prism@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  yarn add @theme-ui/sidenav@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  yarn add @theme-ui/style-guide@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  yarn add @theme-ui/tailwind@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  yarn add @theme-ui/theme-provider@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  yarn add theme-ui@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  yarn add @theme-ui/typography@0.14.4--canary.2179.4a10e18f5414f2fb22a2d35f5d74488db9044c8d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v0.14.4-develop.0`

<details>
  <summary>Changelog</summary>

  
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
