### PR TITLE
fix: Donut component's `viewBox` svg property

### DIFF
--- a/packages/components/src/Donut.tsx
+++ b/packages/components/src/Donut.tsx
@@ -44,7 +44,7 @@ export const Donut: ForwardRef<SVGSVGElement, DonutProps> = React.forwardRef(
     const svgProps = {
       strokeWidth,
 
-      viewBo: '0 0 32 32',
+      viewBox: '0 0 32 32',
       width: size,
       height: size,
 

--- a/packages/components/test/__snapshots__/index.tsx.snap
+++ b/packages/components/test/__snapshots__/index.tsx.snap
@@ -397,7 +397,7 @@ exports[`Donut renders 1`] = `
   role="img"
   stroke="currentcolor"
   strokeWidth={2}
-  viewBo="0 0 32 32"
+  viewBox="0 0 32 32"
   width={128}
 >
   <title>


### PR DESCRIPTION
fix: `viewBo` to `viewBox`

Since version 0.14.0, the Donut component were not rendered in the correct size.