### PR TITLE
docs:  Specify MDX React version

### DIFF
--- a/packages/docs/src/pages/getting-started/index.mdx
+++ b/packages/docs/src/pages/getting-started/index.mdx
@@ -9,7 +9,7 @@ import IntroCodeSamples from '../../components/intro-code-samples'
 Install Theme UI.
 
 ```sh
-npm install theme-ui @emotion/react @mdx-js/react
+npm install theme-ui @emotion/react @mdx-js/react@1
 ```
 
 Create a theme object to include custom color, typography, and layout values.


### PR DESCRIPTION
It has been changed in the README and the Gatsby Getting Started page, but not in the main Getting Started page, so this fixes it.