### PR TITLE
fix(mdx): add .sx props to Themed.X styles

### DIFF
--- a/packages/mdx/src/index.tsx
+++ b/packages/mdx/src/index.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
-import { jsx, IntrinsicSxElements } from '@theme-ui/core'
-import { css, CSSObject, get, Theme } from '@theme-ui/css'
+import { jsx, IntrinsicSxElements, SxProp } from '@theme-ui/core'
+import { css, get, Theme } from '@theme-ui/css'
 import {
   ComponentType,
   FC,
@@ -88,16 +88,10 @@ export const themed =
   (key: ThemedComponentName | (string & {})) => (theme: Theme) =>
     css(get(theme, `styles.${key}`))(theme)
 
-// opt out of typechecking whenever `as` prop is used
-interface AnyComponentProps extends JSX.IntrinsicAttributes {
-  [key: string]: unknown
-}
-
 export interface ThemedComponent<Name extends string> {
   (
-    props: (Name extends keyof JSX.IntrinsicElements
-      ? ComponentProps<Name>
-      : {}) & { css?: CSSObject }
+    props: SxProp &
+      (Name extends keyof JSX.IntrinsicElements ? ComponentProps<Name> : {})
   ): JSX.Element
   displayName: string
 }
@@ -128,8 +122,6 @@ const createThemedComponent = <Name extends string>(
 
       if (align !== 'char') extraStyles.textAlign = align
     }
-
-    const css = (props as any)['css']
 
     return jsx(name, {
       ...props,

--- a/packages/mdx/test/index.tsx
+++ b/packages/mdx/test/index.tsx
@@ -7,7 +7,6 @@ import React from 'react'
 import { mdx } from '@mdx-js/react'
 import { render } from '@testing-library/react'
 import { matchers } from '@emotion/jest'
-import mockConsole from 'jest-mock-console'
 import { ThemeProvider } from '@theme-ui/core'
 import { renderJSON } from '@theme-ui/test-utils'
 
@@ -45,6 +44,19 @@ test('styles React components', () => {
   )!
   expect(json.type).toBe('h2')
   expect(json).toHaveStyleRule('color', 'tomato')
+})
+
+test('Themed.div accepts .sx prop', async () => {
+  const tree = render(
+    <ThemeProvider theme={{ colors: { primary: 'blue' } }}>
+      <Themed.div sx={{ color: 'primary' }}>blue text</Themed.div>
+    </ThemeProvider>
+  )!
+
+  const div = await tree.findByText('blue text')
+  const style = global.getComputedStyle(div)
+
+  expect(style.color).toBe('blue')
 })
 
 test('themed extracts styles from the theme', () => {


### PR DESCRIPTION
So, `sx` prop in _Themed.X_ components now is an undocumented and untested feature that works in JavaScript, but not TypeScript.

While I'm still not sure if _Themed.X_ is the best way to use Theme UI, it's quite easy to fix this discrepancy and close https://github.com/system-ui/theme-ui/issues/1350.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @theme-ui/color-modes@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  npm install @theme-ui/color@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  npm install @theme-ui/components@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  npm install @theme-ui/core@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  npm install @theme-ui/css@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  npm install @theme-ui/custom-properties@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  npm install @theme-ui/editor@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  npm install gatsby-plugin-theme-ui@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  npm install gatsby-theme-style-guide@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  npm install gatsby-theme-ui-layout@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  npm install @theme-ui/match-media@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  npm install @theme-ui/mdx@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  npm install @theme-ui/parse-props@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  npm install @theme-ui/preset-base@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  npm install @theme-ui/preset-bootstrap@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  npm install @theme-ui/preset-bulma@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  npm install @theme-ui/preset-dark@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  npm install @theme-ui/preset-deep@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  npm install @theme-ui/preset-funk@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  npm install @theme-ui/preset-future@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  npm install @theme-ui/preset-polaris@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  npm install @theme-ui/preset-roboto@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  npm install @theme-ui/preset-sketchy@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  npm install @theme-ui/preset-swiss@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  npm install @theme-ui/preset-system@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  npm install @theme-ui/preset-tailwind@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  npm install @theme-ui/preset-tosh@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  npm install @theme-ui/presets@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  npm install @theme-ui/prism@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  npm install @theme-ui/sidenav@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  npm install @theme-ui/style-guide@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  npm install @theme-ui/tailwind@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  npm install @theme-ui/theme-provider@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  npm install theme-ui@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  npm install @theme-ui/typography@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  # or 
  yarn add @theme-ui/color-modes@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  yarn add @theme-ui/color@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  yarn add @theme-ui/components@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  yarn add @theme-ui/core@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  yarn add @theme-ui/css@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  yarn add @theme-ui/custom-properties@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  yarn add @theme-ui/editor@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  yarn add gatsby-plugin-theme-ui@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  yarn add gatsby-theme-style-guide@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  yarn add gatsby-theme-ui-layout@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  yarn add @theme-ui/match-media@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  yarn add @theme-ui/mdx@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  yarn add @theme-ui/parse-props@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  yarn add @theme-ui/preset-base@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  yarn add @theme-ui/preset-bootstrap@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  yarn add @theme-ui/preset-bulma@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  yarn add @theme-ui/preset-dark@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  yarn add @theme-ui/preset-deep@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  yarn add @theme-ui/preset-funk@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  yarn add @theme-ui/preset-future@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  yarn add @theme-ui/preset-polaris@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  yarn add @theme-ui/preset-roboto@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  yarn add @theme-ui/preset-sketchy@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  yarn add @theme-ui/preset-swiss@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  yarn add @theme-ui/preset-system@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  yarn add @theme-ui/preset-tailwind@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  yarn add @theme-ui/preset-tosh@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  yarn add @theme-ui/presets@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  yarn add @theme-ui/prism@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  yarn add @theme-ui/sidenav@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  yarn add @theme-ui/style-guide@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  yarn add @theme-ui/tailwind@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  yarn add @theme-ui/theme-provider@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  yarn add theme-ui@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  yarn add @theme-ui/typography@0.15.0--canary.2250.a5dfac6ee7342fb74c68b915d82541eea905f5a7.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v0.15.0-develop.14`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from new contributors! :tada:
  
  Thanks for all your work!
  
  :heart: Luke Watts ([@thisislawatts](https://github.com/thisislawatts))
  
  :heart: Valto ([@pointlessrapunzel](https://github.com/pointlessrapunzel))
  
  ### Release Notes
  
  #### Drop support for React 16 + 17 ([#2215](https://github.com/system-ui/theme-ui/pull/2215))
  
  Theme UI **0.15.0** drops support for React 16 and React 17. Your use case may still work, but we don't guarantee it.
  
  ---
  
  #### 🚀 Enhancement
  
  - `@theme-ui/color-modes`, `@theme-ui/components`, `@theme-ui/core`, `@theme-ui/editor`, `gatsby-plugin-theme-ui`, `gatsby-theme-style-guide`, `gatsby-theme-ui-layout`, `@theme-ui/match-media`, `@theme-ui/mdx`, `@theme-ui/parse-props`, `@theme-ui/preset-base`, `@theme-ui/preset-bootstrap`, `@theme-ui/preset-bulma`, `@theme-ui/preset-dark`, `@theme-ui/preset-deep`, `@theme-ui/preset-funk`, `@theme-ui/preset-polaris`, `@theme-ui/preset-roboto`, `@theme-ui/preset-swiss`, `@theme-ui/preset-system`, `@theme-ui/preset-tailwind`, `@theme-ui/preset-tosh`, `@theme-ui/prism`, `@theme-ui/sidenav`, `@theme-ui/style-guide`, `@theme-ui/theme-provider`, `theme-ui`
    - Drop support for React 16 + 17 [#2215](https://github.com/system-ui/theme-ui/pull/2215) ([@hasparus](https://github.com/hasparus))
  
  #### 🐛 Bug Fix
  
  - `@theme-ui/mdx`
    - fix(mdx): add .sx props to Themed.X styles [#2250](https://github.com/system-ui/theme-ui/pull/2250) ([@hasparus](https://github.com/hasparus))
  
  #### 👨‍💻 Minor changes
  
  - `theme-ui`
    - Specify MDX React version ([@hasparus](https://github.com/hasparus))
  
  #### 🏠 Internal
  
  - Docs: Group project templates by framework, add Remix [#2276](https://github.com/system-ui/theme-ui/pull/2276) ([@lachlanjc](https://github.com/lachlanjc))
  - docs: re-order sidebar components into alphabetical order [#2232](https://github.com/system-ui/theme-ui/pull/2232) ([@thisislawatts](https://github.com/thisislawatts))
  - docs:  Specify MDX React version [#2233](https://github.com/system-ui/theme-ui/pull/2233) ([@pointlessrapunzel](https://github.com/pointlessrapunzel))
  
  #### Authors: 4
  
  - Lachlan Campbell ([@lachlanjc](https://github.com/lachlanjc))
  - Luke Watts ([@thisislawatts](https://github.com/thisislawatts))
  - Piotr Monwid-Olechnowicz ([@hasparus](https://github.com/hasparus))
  - Valto ([@pointlessrapunzel](https://github.com/pointlessrapunzel))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
