### PR TITLE
prism: Fix crash when className prop is missing

### DIFF
--- a/packages/prism/src/index.tsx
+++ b/packages/prism/src/index.tsx
@@ -40,7 +40,7 @@ export interface ThemeUIPrismProps
 }
 export default function ThemeUIPrism({
   children,
-  className: outerClassName,
+  className: outerClassName = '',
   ...props
 }: ThemeUIPrismProps) {
   const [language] = outerClassName.replace(/language-/, '').split(' ')

--- a/packages/prism/test/__snapshots__/index.tsx.snap
+++ b/packages/prism/test/__snapshots__/index.tsx.snap
@@ -349,6 +349,23 @@ exports[`renders a code block 1`] = `
 </pre>
 `;
 
+exports[`renders with no className 1`] = `
+<pre
+  className=" prism-code language- emotion-0"
+  style={Object {}}
+>
+  <div
+    className="token-line"
+  >
+    <span
+      className="token plain"
+    >
+      &lt;h1&gt;Hello&lt;/h1&gt;
+    </span>
+  </div>
+</pre>
+`;
+
 exports[`renders with other languages 1`] = `
 <pre
   className="language-php prism-code language-php emotion-0"

--- a/packages/prism/test/index.tsx
+++ b/packages/prism/test/index.tsx
@@ -18,6 +18,11 @@ test('renders a code block', () => {
   expect(result).toMatchSnapshot()
 })
 
+test('renders with no className', () => {
+  const json = render(<Prism children="<h1>Hello</h1>" />)
+  expect(json).toMatchSnapshot()
+})
+
 test('renders with other languages', () => {
   const json = render(
     <Prism className="language-php" children="<h1>Hello</h1>" />


### PR DESCRIPTION
Fixes #2016
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v0.15.0-develop.27`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from new contributors! :tada:
  
  Thanks for all your work!
  
  :heart: Luke Watts ([@thisislawatts](https://github.com/thisislawatts))
  
  :heart: Valto Savi ([@pointlessrapunzel](https://github.com/pointlessrapunzel))
  
  ### Release Notes
  
  #### Pull out MDX to be opt-in ([#2288](https://github.com/system-ui/theme-ui/pull/2288))
  
  #### Breaking: `theme-ui` no longer includes `@theme-ui/mdx` — MDX is now opt-in.
  
  _If your project is not using MDX or importing `Themed`, you shouldn't need to
  change anything._
   
   - `MDXProvider` is no longer included in Theme UI `ThemeProvider`, and has been
    removed in favour of an `useThemedStylesWithMdx` hook.
     - **Migration:** Use `useThemedStylesWithMdx` together with `MDXProvider` and `useMDXComponents` from `@mdx-js/react`.
   
        ```tsx
        import {
          MDXProvider,
          useMDXComponents,
          Components as MDXComponents,
          MergeComponents as MergeMDXComponents,
        } from '@mdx-js/react'
        import { useThemedStylesWithMdx } from '@theme-ui/mdx'
        import { ThemeProvider, Theme } from 'theme-ui'
        
        interface MyProviderProps {
          theme: Theme
          components?: MDXComponents | MergeMDXComponents
          children: React.ReactNode
        }
        function MyProvider({ theme, components, children }: MyProviderProps) {
          const componentsWithStyles = useThemedStylesWithMdx(useMDXComponents(components))
        
          return (
            <ThemeProvider theme={theme}>
              <MDXProvider components={componentsWithStyles}>
                {children}
              </MDXProvider>
            </ThemeProvider>
          )
        }
        ```
       
       
   
  - `Themed` components dict and other exports from `@theme-ui/mdx` are no longer reexported from `theme-ui`.
    - **Migration:** Import it from `@theme-ui/mdx` instead.
     
       ```diff
       -  import { Themed } from 'theme-ui'
       +  import { Themed } from '@theme-ui/mdx'
       ```
  
  #### Remove @theme-ui/editor ([#2292](https://github.com/system-ui/theme-ui/pull/2292))
  
  - **Breaking:** `@theme-ui/editor` was removed. Use [CSS GUI](https://components.ai/css-gui/properties) instead.
    - `/customize` page in Theme UI docs has been removed. Use [Components.ai Theme Builder](https://components.ai/theme) or an alternative instead.
  
  #### Drop support for React 16 + 17 ([#2215](https://github.com/system-ui/theme-ui/pull/2215))
  
  Theme UI **0.15.0** drops support for React 16 and React 17. Your use case may still work, but we don't guarantee it.
  
  ---
  
  #### 🚀 Enhancement
  
  - Pull out MDX to be opt-in [#2288](https://github.com/system-ui/theme-ui/pull/2288) ([@hasparus](https://github.com/hasparus) [@beerose](https://github.com/beerose) [@lachlanjc](https://github.com/lachlanjc) hasparus@Piotrs-MacBook.local)
  - Drop support for React 16 + 17 [#2215](https://github.com/system-ui/theme-ui/pull/2215) ([@hasparus](https://github.com/hasparus))
  
  #### 🐛 Bug Fix
  
  - fix(e2e): add force=true to a test ([@hasparus](https://github.com/hasparus))
  - fix: fix release workflow (empty commit) ([@hasparus](https://github.com/hasparus))
  - Remove @theme-ui/editor [#2292](https://github.com/system-ui/theme-ui/pull/2292) ([@hasparus](https://github.com/hasparus))
  - fix(mdx): add .sx props to Themed.X styles [#2250](https://github.com/system-ui/theme-ui/pull/2250) ([@hasparus](https://github.com/hasparus))
  
  #### 👨‍💻 Minor changes
  
  - Specify MDX React version ([@hasparus](https://github.com/hasparus))
  
  #### 🏠 Internal
  
  - prism: Fix crash when className prop is missing [#2322](https://github.com/system-ui/theme-ui/pull/2322) ([@lachlanjc](https://github.com/lachlanjc))
  - Docs: Group project templates by framework, add Remix [#2276](https://github.com/system-ui/theme-ui/pull/2276) ([@lachlanjc](https://github.com/lachlanjc))
  - docs: re-order sidebar components into alphabetical order [#2232](https://github.com/system-ui/theme-ui/pull/2232) ([@thisislawatts](https://github.com/thisislawatts))
  - docs:  Specify MDX React version [#2233](https://github.com/system-ui/theme-ui/pull/2233) ([@pointlessrapunzel](https://github.com/pointlessrapunzel))
  
  #### Authors: 6
  
  - Aleksandra ([@beerose](https://github.com/beerose))
  - Lachlan Campbell ([@lachlanjc](https://github.com/lachlanjc))
  - Luke Watts ([@thisislawatts](https://github.com/thisislawatts))
  - Piotr (hasparus@Piotrs-MacBook.local)
  - Piotr Monwid-Olechnowicz ([@hasparus](https://github.com/hasparus))
  - Valto Savi ([@pointlessrapunzel](https://github.com/pointlessrapunzel))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
