### PR TITLE
fix: show color hex value as swatch title

### DIFF
--- a/packages/style-guide/package.json
+++ b/packages/style-guide/package.json
@@ -11,6 +11,7 @@
   "scripts": {},
   "dependencies": {
     "@theme-ui/presets": "workspace:^",
+    "@theme-ui/color": "workspace:^",
     "@types/color": "^3.0.3",
     "color": "^3.1.2",
     "lodash.get": "^4.4.2"

--- a/packages/style-guide/src/ColorSwatch.tsx
+++ b/packages/style-guide/src/ColorSwatch.tsx
@@ -1,6 +1,7 @@
 /** @jsx jsx */
+import { getColor } from '@theme-ui/color'
 import { ComponentProps } from 'react'
-import { jsx, get, ResponsiveStyleValue } from 'theme-ui'
+import { jsx, ResponsiveStyleValue } from 'theme-ui'
 import { toHex } from './color'
 import { useTheme } from './context'
 
@@ -17,8 +18,8 @@ export const ColorSwatch = ({
   label = true,
   ...props
 }: ColorSwatchProps) => {
-  const { colors } = useTheme()!
-  const value = get(colors!, color)
+  const theme = useTheme()!
+  const value = getColor(theme, color)
   return (
     <div {...props} title={`${toHex(value)}`}>
       <div

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -844,6 +844,7 @@ importers:
 
   packages/style-guide:
     specifiers:
+      '@theme-ui/color': workspace:^
       '@theme-ui/presets': workspace:^
       '@types/color': ^3.0.3
       '@types/react': ^18.0.8
@@ -852,6 +853,7 @@ importers:
       react: ^18
       theme-ui: workspace:^
     dependencies:
+      '@theme-ui/color': link:../color
       '@theme-ui/presets': link:../presets
       '@types/color': 3.0.3
       color: 3.2.1


### PR DESCRIPTION
get color value using `getColor` from `@theme-ui/color` instead of `get` from `theme-ui`. 

fixes #2112

See the issue for more details
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v0.15.0-develop.29`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from new contributors! :tada:
  
  Thanks for all your work!
  
  :heart: Luke Watts ([@thisislawatts](https://github.com/thisislawatts))
  
  :heart: Valto Savi ([@pointlessrapunzel](https://github.com/pointlessrapunzel))
  
  ### Release Notes
  
  #### Pull out MDX to be opt-in ([#2288](https://github.com/system-ui/theme-ui/pull/2288))
  
  #### Breaking: `theme-ui` no longer includes `@theme-ui/mdx` — MDX is now opt-in.
  
  _If your project is not using MDX or importing `Themed`, you shouldn't need to
  change anything._
   
   - `MDXProvider` is no longer included in Theme UI `ThemeProvider`, and has been
    removed in favour of an `useThemedStylesWithMdx` hook.
     - **Migration:** Use `useThemedStylesWithMdx` together with `MDXProvider` and `useMDXComponents` from `@mdx-js/react`.
   
        ```tsx
        import {
          MDXProvider,
          useMDXComponents,
          Components as MDXComponents,
          MergeComponents as MergeMDXComponents,
        } from '@mdx-js/react'
        import { useThemedStylesWithMdx } from '@theme-ui/mdx'
        import { ThemeProvider, Theme } from 'theme-ui'
        
        interface MyProviderProps {
          theme: Theme
          components?: MDXComponents | MergeMDXComponents
          children: React.ReactNode
        }
        function MyProvider({ theme, components, children }: MyProviderProps) {
          const componentsWithStyles = useThemedStylesWithMdx(useMDXComponents(components))
        
          return (
            <ThemeProvider theme={theme}>
              <MDXProvider components={componentsWithStyles}>
                {children}
              </MDXProvider>
            </ThemeProvider>
          )
        }
        ```
       
       
   
  - `Themed` components dict and other exports from `@theme-ui/mdx` are no longer reexported from `theme-ui`.
    - **Migration:** Import it from `@theme-ui/mdx` instead.
     
       ```diff
       -  import { Themed } from 'theme-ui'
       +  import { Themed } from '@theme-ui/mdx'
       ```
  
  #### Remove @theme-ui/editor ([#2292](https://github.com/system-ui/theme-ui/pull/2292))
  
  - **Breaking:** `@theme-ui/editor` was removed. Use [CSS GUI](https://components.ai/css-gui/properties) instead.
    - `/customize` page in Theme UI docs has been removed. Use [Components.ai Theme Builder](https://components.ai/theme) or an alternative instead.
  
  #### Drop support for React 16 + 17 ([#2215](https://github.com/system-ui/theme-ui/pull/2215))
  
  Theme UI **0.15.0** drops support for React 16 and React 17. Your use case may still work, but we don't guarantee it.
  
  ---
  
  #### 🚀 Enhancement
  
  - Pull out MDX to be opt-in [#2288](https://github.com/system-ui/theme-ui/pull/2288) ([@hasparus](https://github.com/hasparus) [@beerose](https://github.com/beerose) [@lachlanjc](https://github.com/lachlanjc) hasparus@Piotrs-MacBook.local)
  - Drop support for React 16 + 17 [#2215](https://github.com/system-ui/theme-ui/pull/2215) ([@hasparus](https://github.com/hasparus))
  
  #### 🐛 Bug Fix
  
  - fix(e2e): add force=true to a test ([@hasparus](https://github.com/hasparus))
  - fix: fix release workflow (empty commit) ([@hasparus](https://github.com/hasparus))
  - Remove @theme-ui/editor [#2292](https://github.com/system-ui/theme-ui/pull/2292) ([@hasparus](https://github.com/hasparus))
  - fix(mdx): add .sx props to Themed.X styles [#2250](https://github.com/system-ui/theme-ui/pull/2250) ([@hasparus](https://github.com/hasparus))
  
  #### 👨‍💻 Minor changes
  
  - Specify MDX React version ([@hasparus](https://github.com/hasparus))
  
  #### 🏠 Internal
  
  - docs: Update Contributing doc with pnpm info [#2320](https://github.com/system-ui/theme-ui/pull/2320) ([@lachlanjc](https://github.com/lachlanjc) [@hasparus](https://github.com/hasparus))
  - prism: Fix crash when className prop is missing [#2322](https://github.com/system-ui/theme-ui/pull/2322) ([@lachlanjc](https://github.com/lachlanjc))
  - Docs: Group project templates by framework, add Remix [#2276](https://github.com/system-ui/theme-ui/pull/2276) ([@lachlanjc](https://github.com/lachlanjc))
  - docs: re-order sidebar components into alphabetical order [#2232](https://github.com/system-ui/theme-ui/pull/2232) ([@thisislawatts](https://github.com/thisislawatts))
  - docs:  Specify MDX React version [#2233](https://github.com/system-ui/theme-ui/pull/2233) ([@pointlessrapunzel](https://github.com/pointlessrapunzel))
  
  #### Authors: 7
  
  - Aleksandra ([@beerose](https://github.com/beerose))
  - Brage Sekse Aarset ([@braaar](https://github.com/braaar))
  - Lachlan Campbell ([@lachlanjc](https://github.com/lachlanjc))
  - Luke Watts ([@thisislawatts](https://github.com/thisislawatts))
  - Piotr (hasparus@Piotrs-MacBook.local)
  - Piotr Monwid-Olechnowicz ([@hasparus](https://github.com/hasparus))
  - Valto Savi ([@pointlessrapunzel](https://github.com/pointlessrapunzel))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
