### PR TITLE
Fix MDXProvider example

### DIFF
--- a/packages/docs/src/pages/styling-mdx.mdx
+++ b/packages/docs/src/pages/styling-mdx.mdx
@@ -46,7 +46,7 @@ function Provider({ children, theme, components }) {
 
   return (
     <ThemeProvider theme={theme}>
-      <MDXProvider components={useThemedStylesWithMdx(components)}>
+      <MDXProvider components={componentsWithStyles}>
         {children}
       </MDXProvider>
     </ThemeProvider>


### PR DESCRIPTION
In [Styling MDX] docs, the first code example doesn't do anything with the `componentsWithStyles` value. This PR passes it as the `MDXProvider` component's `components ` prop, which seems like what was intended.