### PR TITLE
Add `@mdx-js/react` to peerDeps for `gatsby-plugin-theme-ui`

### DIFF
--- a/packages/gatsby-plugin-theme-ui/package.json
+++ b/packages/gatsby-plugin-theme-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-theme-ui",
-  "version": "0.15.1",
+  "version": "0.15.2-canary.1",
   "main": "dist/gatsby-plugin-theme-ui.cjs.js",
   "author": "Brent Jackson",
   "license": "MIT",

--- a/packages/gatsby-plugin-theme-ui/package.json
+++ b/packages/gatsby-plugin-theme-ui/package.json
@@ -10,7 +10,8 @@
     "@theme-ui/css": "workspace:^",
     "gatsby": "^4",
     "react": ">=18",
-    "theme-ui": "workspace:^"
+    "theme-ui": "workspace:^",
+    "@mdx-js/react": "^1 || ^2"
   },
   "devDependencies": {
     "@types/react": "^18",


### PR DESCRIPTION
Closes https://github.com/system-ui/theme-ui/issues/2330, hopefully.

Published as `0.15.2-canary.1`
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v0.15.2-develop.0`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - Add `@mdx-js/react` to peerDeps for `gatsby-plugin-theme-ui` [#2331](https://github.com/system-ui/theme-ui/pull/2331) ([@hasparus](https://github.com/hasparus))
  
  #### Authors: 1
  
  - Piotr Monwid-Olechnowicz ([@hasparus](https://github.com/hasparus))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
