### PR TITLE
fix(css): Prevent transforming @page properties like size

### DIFF
--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -368,7 +368,7 @@ export const css =
       const x = styles[key as keyof typeof styles]
       const val = typeof x === 'function' ? x(theme) : x
 
-      if (val && typeof val === 'object') {
+      if (val && typeof val === 'object' && key !== '@page') {
         if (hasDefault(val)) {
           result[key] = val[THEME_UI_DEFAULT_KEY]
           continue

--- a/packages/css/test/past-bugs.ts
+++ b/packages/css/test/past-bugs.ts
@@ -31,4 +31,15 @@ describe('theme scales, get and default object property (#1439)', () => {
 
     expect(actual).toStrictEqual({ zIndex: 1 })
   })
+
+  // https://github.com/system-ui/theme-ui/issues/2166
+  test('size property works inside at page', () => {
+    const actual = css({ size: '2rem', '@page': { size: 'A4' } })({})
+
+    expect(actual).toStrictEqual({
+      width: '2rem',
+      height: '2rem',
+      '@page': { size: 'A4' },
+    })
+  })
 })


### PR DESCRIPTION
Closes #2166. This may not be ideal because it prevents transforms of _all_ properties inside `@page`, but the way our transform function is setup, it doesn't seem easy to fix otherwise. This means use of margin properties inside `@page` will no longer be transformed; in my experience you're only using those properties so you can define physical units like `in` & `cm` instead of pixels, so doesn't seem like a big deal to me.