### PR TITLE
chore: Add `@theme-ui/mdx` to Gatsby install instructions

### DIFF
--- a/packages/docs/src/pages/getting-started/gatsby.mdx
+++ b/packages/docs/src/pages/getting-started/gatsby.mdx
@@ -8,7 +8,7 @@ To use Theme UI with [Gatsby][], install and use
 [`gatsby-plugin-theme-ui`](/packages/gatsby-plugin).
 
 ```sh
-npm i theme-ui gatsby-plugin-theme-ui @emotion/react @mdx-js/react
+npm i theme-ui @theme-ui/mdx gatsby-plugin-theme-ui @emotion/react @mdx-js/react
 ```
 
 Add the plugin to your `gatsby-config.js`.

--- a/packages/gatsby-plugin-theme-ui/README.md
+++ b/packages/gatsby-plugin-theme-ui/README.md
@@ -3,7 +3,7 @@
 Gatsby plugin for adding Theme UI context
 
 ```sh
-npm i theme-ui gatsby-plugin-theme-ui @emotion/react @mdx-js/react
+npm i theme-ui @theme-ui/mdx gatsby-plugin-theme-ui @emotion/react @mdx-js/react
 ```
 
 ```js


### PR DESCRIPTION
Hi!

I guess until Theme UI v1 (and it's clearly decided that the Gatsby plugin shouldn't include MDX anymore) the instructions need to be updated to also install `@theme-ui/mdx` for now.