### PR TITLE
Add theme-aware Global component

### DIFF
--- a/examples/next/components/Header.tsx
+++ b/examples/next/components/Header.tsx
@@ -2,9 +2,11 @@ import { Button, useColorMode } from 'theme-ui'
 
 const Header = () => {
   const [colorMode, setColorMode] = useColorMode()
+
   return (
     <header>
       <Button
+        suppressHydrationWarning
         onClick={() => setColorMode(colorMode === 'light' ? 'dark' : 'light')}
       >
         Toggle {colorMode === 'light' ? 'Dark' : 'Light'}

--- a/examples/next/lib/theme.ts
+++ b/examples/next/lib/theme.ts
@@ -1,6 +1,6 @@
-// import { makeTheme } from '@theme-ui/css/utils'
+import { makeTheme } from '@theme-ui/css/utils'
 
-export const theme = {
+export const theme = makeTheme({
   config: {
     initialColorModeName: 'light',
     useColorSchemeMediaQuery: true,
@@ -49,4 +49,4 @@ export const theme = {
       cursor: 'pointer',
     },
   },
-}
+})

--- a/examples/next/lib/theme.ts
+++ b/examples/next/lib/theme.ts
@@ -1,6 +1,6 @@
-import { makeTheme } from '@theme-ui/css/utils'
+// import { makeTheme } from '@theme-ui/css/utils'
 
-export const theme = makeTheme({
+export const theme = {
   config: {
     initialColorModeName: 'light',
     useColorSchemeMediaQuery: true,
@@ -49,4 +49,4 @@ export const theme = makeTheme({
       cursor: 'pointer',
     },
   },
-})
+}

--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -16,6 +16,7 @@
     "@mdx-js/loader": "^2.1.2",
     "@mdx-js/react": "^2.1.2",
     "@next/mdx": "^12.0.7",
+    "@theme-ui/css": "workspace:^",
     "next": "^12.1.0",
     "react": "^18",
     "react-dom": "^18",

--- a/examples/next/pages/index.tsx
+++ b/examples/next/pages/index.tsx
@@ -1,5 +1,6 @@
 import Head from 'next/head'
 import About from '../components/about.mdx'
+import { Global } from 'theme-ui'
 
 export default function Page() {
   return (
@@ -7,6 +8,7 @@ export default function Page() {
       <Head>
         <title>Next.js Theme UI</title>
       </Head>
+      <Global sx={{ h1: { color: 'salmon !important' } }} />
       <About />
     </>
   )

--- a/examples/next/pages/index.tsx
+++ b/examples/next/pages/index.tsx
@@ -8,7 +8,7 @@ export default function Page() {
       <Head>
         <title>Next.js Theme UI</title>
       </Head>
-      <Global sx={{ h1: { color: 'salmon !important' } }} />
+      <Global styles={{ h1: { color: 'salmon !important' } }} />
       <About />
     </>
   )

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -26,6 +26,7 @@
     "@theme-ui/core": "workspace:^",
     "@theme-ui/components": "workspace:^",
     "@theme-ui/css": "workspace:^",
+    "@theme-ui/global": "workspace:^",
     "@theme-ui/match-media": "workspace:^",
     "@theme-ui/mdx": "workspace:^",
     "@theme-ui/presets": "workspace:^",

--- a/packages/docs/src/pages/guides/global-styles.mdx
+++ b/packages/docs/src/pages/guides/global-styles.mdx
@@ -24,7 +24,7 @@ import { Global } from 'theme-ui'
 
 export default (props) => (
   <Global
-    sx={{
+    styles={{
       button: {
         m: 0,
         bg: 'primary',

--- a/packages/docs/src/pages/guides/global-styles.mdx
+++ b/packages/docs/src/pages/guides/global-styles.mdx
@@ -4,10 +4,15 @@ title: 'Global Styles'
 
 # Global Styles
 
-Use the Emotion `Global` component to add global CSS with theme-based values.
+Theme UI offers a `Global` component (that wraps Emotion’s) for adding global
+CSS with theme-based values.
 
-By default, the `ThemeProvider` component will apply styles in `theme.styles.root` to the `<html>` element.
-It will also apply `color` and `background-color` styles based on `theme.colors.text` and `theme.colors.background` respectively.
+By default (or, unless the
+[`useRootStyles` configuration option](/theming#configuration-flags)is
+disabled), the `ThemeProvider` component will apply styles in
+`theme.styles.root` to the `<html>` element. It will also apply `color` and
+`background-color` styles based on `theme.colors.text` and
+`theme.colors.background` respectively.
 
 <Note>
   Generally, you should try to avoid adding CSS to global scope. Many styles can
@@ -15,23 +20,18 @@ It will also apply `color` and `background-color` styles based on `theme.colors.
 </Note>
 
 ```jsx
-import { Global } from '@emotion/react'
+import { Global } from 'theme-ui'
 
 export default (props) => (
   <Global
-    styles={(theme) => ({
-      '*': {
-        boxSizing: 'border-box',
+    sx={{
+      button: {
+        m: 0,
+        bg: 'primary',
+        color: 'background',
+        border: 0,
       },
-    })}
+    }}
   />
 )
 ```
-
-<Note>
-
-  If you are upgrading from a version of theme-ui older that v0.6.0, be aware the import
-  package has changed from `@emotion/core` to `@emotion/react`. For more information see
-  the [Migration Notes for 0.6](https://theme-ui.com/migrating/#breaking-changes).
-
-</Note>

--- a/packages/docs/src/pages/packages/global.mdx
+++ b/packages/docs/src/pages/packages/global.mdx
@@ -1,0 +1,7 @@
+---
+title: '@theme-ui/global'
+---
+
+import Readme from '@theme-ui/global/README.md'
+
+<Readme />

--- a/packages/docs/src/sidebar.mdx
+++ b/packages/docs/src/sidebar.mdx
@@ -58,6 +58,7 @@
   - [@theme-ui/core](/packages/core)
   - [@theme-ui/components](/packages/components)
   - [@theme-ui/mdx](/packages/mdx)
+  - [@theme-ui/global](/packages/global)
   - [@theme-ui/presets](/packages/presets)
   - [@theme-ui/prism](/packages/prism)
   - [@theme-ui/color](/packages/color)

--- a/packages/docs/static/card.svg
+++ b/packages/docs/static/card.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 720" width="1280" height="720" style="color:white;max-width:100%;height:auto"><rect width="1280" height="720" fill="black"></rect><g transform="translate(512 232)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="256" height="256" style="font-family:Inter, sans-serif;font-size:12px;letter-spacing:0.1em;fill:currentcolor;color:inherit"><defs><style type="text/css">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 720" width="1280" height="720" style="display:block;color:white;width:1280px;height:720px"><rect width="1280" height="720" fill="black"></rect><g transform="translate(512 232)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="256" height="256" style="font-family:Inter, sans-serif;font-size:12px;letter-spacing:0.1em;fill:currentcolor;color:inherit;pointer-events:none"><defs><style type="text/css">
 <![CDATA[
 @font-face {
   font-family: 'Inter';

--- a/packages/docs/static/logo.svg
+++ b/packages/docs/static/logo.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="256" height="256" style="font-family:Inter, sans-serif;font-size:12px;letter-spacing:0.1em;fill:currentcolor;color:inherit"><defs><style type="text/css">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="256" height="256" style="font-family:Inter, sans-serif;font-size:12px;letter-spacing:0.1em;fill:currentcolor;color:inherit;pointer-events:none"><defs><style type="text/css">
 <![CDATA[
 @font-face {
   font-family: 'Inter';

--- a/packages/global/README.md
+++ b/packages/global/README.md
@@ -14,7 +14,7 @@ import Global from '@theme-ui/global'
 
 export default (props) => (
   <Global
-    sx={{
+    styles={{
       button: {
         m: 0,
         bg: 'primary',

--- a/packages/global/README.md
+++ b/packages/global/README.md
@@ -1,0 +1,27 @@
+# @theme-ui/global
+
+Wrapper around the Emotion `Global` component, made Theme UI theme-aware.
+
+**Note:** _This package is included in the main `theme-ui` package and a
+separate installation is not required unless you’re using `@theme-ui/core`._
+
+```sh
+npm i @theme-ui/global @theme-ui/core @emotion/react
+```
+
+```jsx
+import Global from '@theme-ui/global'
+
+export default (props) => (
+  <Global
+    sx={{
+      button: {
+        m: 0,
+        bg: 'primary',
+        color: 'background',
+        border: 0,
+      },
+    }}
+  />
+)
+```

--- a/packages/global/package.json
+++ b/packages/global/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@theme-ui/global",
+  "version": "0.15.4",
+  "repository": "system-ui/theme-ui",
+  "main": "dist/theme-ui-global.cjs.js",
+  "module": "dist/theme-ui-global.esm.js",
+  "source": "src/index.tsx",
+  "author": "Lachlan Campbell",
+  "license": "MIT",
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@theme-ui/core": "workspace:^",
+    "@theme-ui/css": "workspace:^"
+  },
+  "peerDependencies": {
+    "@emotion/react": "^11",
+    "react": ">=18"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.0.0",
+    "@types/react": "^18",
+    "@theme-ui/test-utils": "workspace:^"
+  }
+}

--- a/packages/global/src/index.tsx
+++ b/packages/global/src/index.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { jsx, type ThemeUIStyleObject } from '@theme-ui/core'
+import { css, type Theme } from '@theme-ui/css'
+import { Global as EmotionGlobal } from '@emotion/react'
+
+const Global = ({ sx }: { sx: ThemeUIStyleObject }) =>
+  jsx(EmotionGlobal, {
+    styles: (emotionTheme: unknown) => {
+      const theme = emotionTheme as Theme
+      return css(sx)(theme)
+    },
+  })
+
+export default Global

--- a/packages/global/src/index.tsx
+++ b/packages/global/src/index.tsx
@@ -1,13 +1,12 @@
-import React from 'react'
 import { jsx, type ThemeUIStyleObject } from '@theme-ui/core'
 import { css, type Theme } from '@theme-ui/css'
 import { Global as EmotionGlobal } from '@emotion/react'
 
-const Global = ({ sx }: { sx: ThemeUIStyleObject }) =>
+const Global = ({ styles }: { styles: ThemeUIStyleObject }) =>
   jsx(EmotionGlobal, {
     styles: (emotionTheme: unknown) => {
       const theme = emotionTheme as Theme
-      return css(sx)(theme)
+      return css(styles)(theme)
     },
   })
 

--- a/packages/global/src/index.tsx
+++ b/packages/global/src/index.tsx
@@ -2,7 +2,10 @@ import { jsx, type ThemeUIStyleObject } from '@theme-ui/core'
 import { css, type Theme } from '@theme-ui/css'
 import { Global as EmotionGlobal } from '@emotion/react'
 
-const Global = ({ styles }: { styles: ThemeUIStyleObject }) =>
+export interface GlobalProps {
+  styles: ThemeUIStyleObject
+}
+const Global = ({ styles }: GlobalProps): JSX.Element =>
   jsx(EmotionGlobal, {
     styles: (emotionTheme: unknown) => {
       const theme = emotionTheme as Theme

--- a/packages/global/test/__snapshots__/index.tsx.snap
+++ b/packages/global/test/__snapshots__/index.tsx.snap
@@ -45,32 +45,25 @@ exports[`renders global styles 1`] = `
 <html>
   <head>
     <style
-      data-emotion="css"
-      data-s=""
-    >
-      
-      .css-ck0s41{}
-    </style>
-    <style
-      data-emotion="css"
+      data-emotion="css-global"
       data-s=""
     >
       
       @font-face{font-family:some-name;}
     </style>
     <style
-      data-emotion="css"
+      data-emotion="css-global"
       data-s=""
     >
       
-      .css-ck0s41 body{font-family:Georgia,serif;margin:0;}
+      body{font-family:Georgia,serif;margin:0;}
     </style>
     <style
-      data-emotion="css"
+      data-emotion="css-global"
       data-s=""
     >
       
-      .css-ck0s41 h1{color:salmon;}
+      h1{color:salmon;}
     </style>
   </head>
   <body>

--- a/packages/global/test/__snapshots__/index.tsx.snap
+++ b/packages/global/test/__snapshots__/index.tsx.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders global styles 1`] = `
+<h1>
+  Hello
+</h1>
+`;

--- a/packages/global/test/__snapshots__/index.tsx.snap
+++ b/packages/global/test/__snapshots__/index.tsx.snap
@@ -1,7 +1,84 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`renders global and component styles 1`] = `
+.emotion-0 {
+  color: pink;
+}
+
+<html>
+  <head>
+    <style
+      data-emotion="css"
+      data-s=""
+    >
+      
+      .css-2cx43c{}
+    </style>
+    <style
+      data-emotion="css"
+      data-s=""
+    >
+      
+      .css-2cx43c html{background-color:hotpink;}
+    </style>
+    <style
+      data-emotion="css"
+      data-s=""
+    >
+      
+      .emotion-0{color:pink;}
+    </style>
+  </head>
+  <body>
+    <div>
+      <header>
+        <div
+          class="emotion-0"
+        />
+      </header>
+    </div>
+  </body>
+</html>
+`;
+
 exports[`renders global styles 1`] = `
-<h1>
-  Hello
-</h1>
+<html>
+  <head>
+    <style
+      data-emotion="css"
+      data-s=""
+    >
+      
+      .css-ck0s41{}
+    </style>
+    <style
+      data-emotion="css"
+      data-s=""
+    >
+      
+      @font-face{font-family:some-name;}
+    </style>
+    <style
+      data-emotion="css"
+      data-s=""
+    >
+      
+      .css-ck0s41 body{font-family:Georgia,serif;margin:0;}
+    </style>
+    <style
+      data-emotion="css"
+      data-s=""
+    >
+      
+      .css-ck0s41 h1{color:salmon;}
+    </style>
+  </head>
+  <body>
+    <div>
+      <h1>
+        Hello
+      </h1>
+    </div>
+  </body>
+</html>
 `;

--- a/packages/global/test/index.tsx
+++ b/packages/global/test/index.tsx
@@ -20,7 +20,7 @@ beforeEach(() => {
 
 afterEach(cleanup)
 
-test('renders global styles', async () => {
+test.only('renders global styles', async () => {
   const root = (
     <ThemeProvider
       theme={{
@@ -56,14 +56,14 @@ test('renders global styles', async () => {
   const document = render(root)
   expect(document.baseElement.parentElement).toMatchSnapshot()
 
-  // const style = window.getComputedStyle(document.baseElement.parentElement!)
-  // expect(style.fontFamily).toBe('Georgia,serif')
-  // expect(style.margin).toBe('0px')
+  const style = window.getComputedStyle(document.baseElement.parentElement!)
+  expect(style.fontFamily).toBe('Georgia,serif')
+  expect(style.margin).toBe('0px')
 
-  // const h1 = document.baseElement.querySelector('h1')!
-  // const h1Style = global.getComputedStyle(h1)
-  // expect(h1Style.fontFamily).toBe('Georgia,serif')
-  // expect(h1Style.color).toBe('salmon')
+  const h1 = document.baseElement.querySelector('h1')!
+  const h1Style = global.getComputedStyle(h1)
+  expect(h1Style.fontFamily).toBe('Georgia,serif')
+  expect(h1Style.color).toBe('salmon')
 })
 
 test('renders global and component styles', () => {

--- a/packages/global/test/index.tsx
+++ b/packages/global/test/index.tsx
@@ -56,14 +56,12 @@ test.only('renders global styles', async () => {
   const document = render(root)
   expect(document.baseElement.parentElement).toMatchSnapshot()
 
-  const style = window.getComputedStyle(document.baseElement.parentElement!)
-  expect(style.fontFamily).toBe('Georgia,serif')
-  expect(style.margin).toBe('0px')
+  const bodyStyle = global.getComputedStyle(document.baseElement)
+  expect(bodyStyle.fontFamily).toBe('Georgia,serif')
+  expect(bodyStyle.margin).toBe('0px')
 
   const h1 = document.baseElement.querySelector('h1')!
-  const h1Style = global.getComputedStyle(h1)
-  expect(h1Style.fontFamily).toBe('Georgia,serif')
-  expect(h1Style.color).toBe('salmon')
+  expect(global.getComputedStyle(h1).color).toBe('salmon')
 })
 
 test('renders global and component styles', () => {

--- a/packages/global/test/index.tsx
+++ b/packages/global/test/index.tsx
@@ -13,10 +13,15 @@ import Global from '../src'
 
 expect.extend(matchers)
 
+beforeEach(() => {
+  document.head.innerHTML = ''
+  jest.resetAllMocks()
+})
+
 afterEach(cleanup)
 
 test('renders global styles', async () => {
-  const root = render(
+  const root = (
     <ThemeProvider
       theme={{
         config: {
@@ -25,6 +30,9 @@ test('renders global styles', async () => {
         fonts: {
           body: 'Georgia,serif',
         },
+        colors: {
+          primary: 'salmon',
+        },
       }}
     >
       <Global
@@ -32,12 +40,12 @@ test('renders global styles', async () => {
           '@font-face': {
             fontFamily: 'some-name',
           },
-          h1: {
-            color: 'salmon',
-            fontFamily: 'body',
-          },
           body: {
+            fontFamily: 'body',
             margin: 0,
+          },
+          h1: {
+            color: 'primary',
           },
         }}
       />
@@ -45,12 +53,32 @@ test('renders global styles', async () => {
     </ThemeProvider>
   )
 
-  const style = window.getComputedStyle(root.baseElement)
-  expect(style.margin).toBe('0px')
+  const document = render(root)
+  expect(document.baseElement.parentElement).toMatchSnapshot()
 
-  // const h1 = root.baseElement.querySelector('h1')!
-  // const style = global.getComputedStyle(h1)
-  // console.log(style)
+  // const style = window.getComputedStyle(document.baseElement.parentElement!)
   // expect(style.fontFamily).toBe('Georgia,serif')
-  // expect(style.color).toBe('salmon')
+  // expect(style.margin).toBe('0px')
+
+  // const h1 = document.baseElement.querySelector('h1')!
+  // const h1Style = global.getComputedStyle(h1)
+  // expect(h1Style.fontFamily).toBe('Georgia,serif')
+  // expect(h1Style.color).toBe('salmon')
+})
+
+test('renders global and component styles', () => {
+  const root = (
+    <header>
+      <Global
+        sx={{
+          html: {
+            backgroundColor: 'hotpink',
+          },
+        }}
+      />
+      <div sx={{ color: 'pink' }} />
+    </header>
+  )
+  const { baseElement } = render(root)
+  expect(baseElement.parentElement).toMatchSnapshot()
 })

--- a/packages/global/test/index.tsx
+++ b/packages/global/test/index.tsx
@@ -1,0 +1,56 @@
+/**
+ * @jest-environment jsdom
+ * @jsx jsx
+ */
+
+import { jsx } from '@theme-ui/core'
+import { cleanup } from '@testing-library/react'
+import { render } from '@theme-ui/test-utils'
+import { matchers } from '@emotion/jest'
+
+import { ThemeProvider } from '@theme-ui/core'
+import Global from '../src'
+
+expect.extend(matchers)
+
+afterEach(cleanup)
+
+test('renders global styles', async () => {
+  const root = render(
+    <ThemeProvider
+      theme={{
+        config: {
+          useRootStyles: false,
+        },
+        fonts: {
+          body: 'Georgia,serif',
+        },
+      }}
+    >
+      <Global
+        sx={{
+          '@font-face': {
+            fontFamily: 'some-name',
+          },
+          h1: {
+            color: 'salmon',
+            fontFamily: 'body',
+          },
+          body: {
+            margin: 0,
+          },
+        }}
+      />
+      <h1>Hello</h1>
+    </ThemeProvider>
+  )
+
+  const style = window.getComputedStyle(root.baseElement)
+  expect(style.margin).toBe('0px')
+
+  // const h1 = root.baseElement.querySelector('h1')!
+  // const style = global.getComputedStyle(h1)
+  // console.log(style)
+  // expect(style.fontFamily).toBe('Georgia,serif')
+  // expect(style.color).toBe('salmon')
+})

--- a/packages/global/test/index.tsx
+++ b/packages/global/test/index.tsx
@@ -36,7 +36,7 @@ test.only('renders global styles', async () => {
       }}
     >
       <Global
-        sx={{
+        styles={{
           '@font-face': {
             fontFamily: 'some-name',
           },
@@ -70,7 +70,7 @@ test('renders global and component styles', () => {
   const root = (
     <header>
       <Global
-        sx={{
+        styles={{
           html: {
             backgroundColor: 'hotpink',
           },

--- a/packages/sidenav/src/index.tsx
+++ b/packages/sidenav/src/index.tsx
@@ -65,7 +65,7 @@ const Overlay = ({ onClick }: OverlayProps) => (
       }}
     />
     <Global
-      sx={{
+      styles={{
         body: {
           overflow: ['hidden', 'auto'],
         },

--- a/packages/sidenav/src/index.tsx
+++ b/packages/sidenav/src/index.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { jsx, ThemeProvider, Theme, ThemeStyles } from 'theme-ui'
+import { jsx, ThemeProvider, Theme, ThemeStyles, Global } from 'theme-ui'
 import { MDXProvider, MDXProviderComponents } from '@mdx-js/react'
 import React, {
   useState,
@@ -11,7 +11,6 @@ import React, {
   ReactComponentElement,
   ReactElement,
 } from 'react'
-import { Global } from '@emotion/react'
 import merge from 'deepmerge'
 
 const createNestedLinks = (
@@ -66,7 +65,7 @@ const Overlay = ({ onClick }: OverlayProps) => (
       }}
     />
     <Global
-      styles={{
+      sx={{
         body: {
           overflow: ['hidden', 'auto'],
         },

--- a/packages/theme-ui/package.json
+++ b/packages/theme-ui/package.json
@@ -16,6 +16,7 @@
     "@theme-ui/components": "workspace:^",
     "@theme-ui/core": "workspace:^",
     "@theme-ui/css": "workspace:^",
+    "@theme-ui/global": "workspace:^",
     "@theme-ui/theme-provider": "workspace:^"
   },
   "peerDependencies": {

--- a/packages/theme-ui/src/index.ts
+++ b/packages/theme-ui/src/index.ts
@@ -29,6 +29,7 @@ export type {
 } from '@theme-ui/core'
 export { useColorMode, InitializeColorMode } from '@theme-ui/color-modes'
 export { ThemeProvider } from '@theme-ui/theme-provider'
+export { default as Global } from '@theme-ui/global'
 export * from '@theme-ui/components'
 export { css, get } from '@theme-ui/css'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,8 +138,8 @@ importers:
       '@mdx-js/react': 2.1.3_react@18.2.0
       '@theme-ui/mdx': link:../../packages/mdx
       gatsby: 4.21.1_ygwdrcfl3m6rdu4ibcq7rpa2au
-      gatsby-plugin-mdx: 4.0.0_ve3aao32jeear4r54inaytsdlm
-      gatsby-source-filesystem: 5.0.0_gatsby@4.21.1
+      gatsby-plugin-mdx: 4.0.0_p463e5ujixl6uoianntvxnxv6u
+      gatsby-source-filesystem: 5.4.0_gatsby@4.21.1
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       theme-ui: link:../../packages/theme-ui
@@ -392,6 +392,7 @@ importers:
       '@theme-ui/components': workspace:^
       '@theme-ui/core': workspace:^
       '@theme-ui/css': workspace:^
+      '@theme-ui/global': workspace:^
       '@theme-ui/match-media': workspace:^
       '@theme-ui/mdx': workspace:^
       '@theme-ui/presets': workspace:^
@@ -472,6 +473,7 @@ importers:
       '@theme-ui/components': link:../components
       '@theme-ui/core': link:../core
       '@theme-ui/css': link:../css
+      '@theme-ui/global': link:../global
       '@theme-ui/match-media': link:../match-media
       '@theme-ui/mdx': link:../mdx
       '@theme-ui/presets': link:../presets
@@ -1101,7 +1103,7 @@ packages:
       '@babel/core': 7.18.13
       '@babel/generator': 7.18.13
       '@babel/parser': 7.18.13
-      '@babel/runtime': 7.18.9
+      '@babel/runtime': 7.20.7
       '@babel/traverse': 7.18.13
       '@babel/types': 7.18.13
       babel-preset-fbjs: 3.4.0_@babel+core@7.18.13
@@ -2662,13 +2664,19 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       core-js-pure: 3.25.0
-      regenerator-runtime: 0.13.9
+      regenerator-runtime: 0.13.11
 
   /@babel/runtime/7.18.9:
     resolution: {integrity: sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.13.9
+
+  /@babel/runtime/7.20.7:
+    resolution: {integrity: sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      regenerator-runtime: 0.13.11
 
   /@babel/template/7.18.10:
     resolution: {integrity: sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==}
@@ -2825,7 +2833,7 @@ packages:
       '@babel/core': 7.18.13
       '@babel/helper-module-imports': 7.18.6
       '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.18.13
-      '@babel/runtime': 7.18.9
+      '@babel/runtime': 7.20.7
       '@emotion/hash': 0.9.0
       '@emotion/memoize': 0.8.0
       '@emotion/serialize': 1.1.0
@@ -3003,7 +3011,7 @@ packages:
     resolution: {integrity: sha512-Z5RuA+CuhVTb/xyZePxzFG5KhzDkRzs3e6sBz+WOZnTKGEleN8yxGpATjINL9V7suO9by7bKY3RdRv77qMP+rA==}
     engines: {node: '>=14.15.0', parcel: 2.x}
     dependencies:
-      '@babel/runtime': 7.18.9
+      '@babel/runtime': 7.20.7
       '@parcel/namer-default': 2.6.2_@parcel+core@2.6.2
       '@parcel/plugin': 2.6.2_@parcel+core@2.6.2
       gatsby-core-utils: 3.24.0
@@ -4484,7 +4492,7 @@ packages:
       browserslist: 4.21.3
       detect-libc: 1.0.3
       nullthrows: 1.1.1
-      regenerator-runtime: 0.13.9
+      regenerator-runtime: 0.13.11
       semver: 5.7.1
 
   /@parcel/transformer-json/2.6.2_@parcel+core@2.6.2:
@@ -5102,7 +5110,7 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@babel/code-frame': 7.18.6
-      '@babel/runtime': 7.18.9
+      '@babel/runtime': 7.20.7
       '@types/aria-query': 4.2.2
       aria-query: 5.0.2
       chalk: 4.1.2
@@ -6317,7 +6325,7 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
     dependencies:
-      '@babel/runtime': 7.18.9
+      '@babel/runtime': 7.20.7
       async: 3.2.4
       chalk: 4.1.2
       didyoumean: 1.2.2
@@ -6456,7 +6464,7 @@ packages:
     resolution: {integrity: sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==}
     engines: {node: '>=6.0'}
     dependencies:
-      '@babel/runtime': 7.18.9
+      '@babel/runtime': 7.20.7
       '@babel/runtime-corejs3': 7.18.9
 
   /aria-query/5.0.2:
@@ -6844,7 +6852,7 @@ packages:
     resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
     engines: {node: '>=10', npm: '>=6'}
     dependencies:
-      '@babel/runtime': 7.18.9
+      '@babel/runtime': 7.20.7
       cosmiconfig: 7.0.1
       resolve: 1.22.1
 
@@ -6889,7 +6897,7 @@ packages:
       gatsby: ^4.0.0-next || ^4 || ^5
     dependencies:
       '@babel/core': 7.18.13
-      '@babel/runtime': 7.18.9
+      '@babel/runtime': 7.20.7
       '@babel/types': 7.18.13
       gatsby: 4.21.1_ygwdrcfl3m6rdu4ibcq7rpa2au
       gatsby-core-utils: 3.24.0
@@ -7019,7 +7027,7 @@ packages:
       '@babel/preset-env': 7.18.10_@babel+core@7.18.13
       '@babel/preset-react': 7.18.6_@babel+core@7.18.13
       '@babel/preset-typescript': 7.18.6_@babel+core@7.18.13
-      '@babel/runtime': 7.18.9
+      '@babel/runtime': 7.20.7
       babel-plugin-macros: 3.1.0
       babel-plugin-transform-react-remove-prop-types: 0.4.24
     transitivePeerDependencies:
@@ -8466,7 +8474,7 @@ packages:
     resolution: {integrity: sha512-fVkaAtlfNwitTyIZHLNzPoU+WfnXkDBMt6Gfh4E2mpocG5O3QS6hD10k1rVwTO+zzLON0BSi9OXHWy0PopMwmQ==}
     hasBin: true
     dependencies:
-      '@babel/runtime': 7.18.9
+      '@babel/runtime': 7.20.7
 
   /create-hash/1.2.0:
     resolution: {integrity: sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==}
@@ -10147,7 +10155,7 @@ packages:
     peerDependencies:
       graphql: ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
     dependencies:
-      '@babel/runtime': 7.18.9
+      '@babel/runtime': 7.20.7
       graphql: 15.8.0
       graphql-config: 3.4.1_bd4dqfuh23qh62sufat7weqjza
       lodash.flatten: 4.4.0
@@ -10279,7 +10287,7 @@ packages:
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || 8
     dependencies:
-      '@babel/runtime': 7.18.9
+      '@babel/runtime': 7.20.7
       aria-query: 4.2.2
       array-includes: 3.1.5
       ast-types-flow: 0.0.7
@@ -10301,7 +10309,7 @@ packages:
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || 8
     dependencies:
-      '@babel/runtime': 7.18.9
+      '@babel/runtime': 7.20.7
       aria-query: 4.2.2
       array-includes: 3.1.5
       ast-types-flow: 0.0.7
@@ -11369,7 +11377,7 @@ packages:
       '@babel/generator': 7.18.13
       '@babel/helper-plugin-utils': 7.18.9
       '@babel/preset-typescript': 7.18.6_@babel+core@7.18.13
-      '@babel/runtime': 7.18.9
+      '@babel/runtime': 7.20.7
       '@babel/template': 7.18.10
       '@babel/types': 7.18.13
       '@jridgewell/trace-mapping': 0.3.15
@@ -11430,7 +11438,7 @@ packages:
     resolution: {integrity: sha512-pCDa9EGU8niRJQVv7ow3ijzmG0PegZaBc5Yt6z4enc4m7Dl5ZT6Edkcw9p8q/FhGiZUkzQhWaRDxUvtaoPwAOQ==}
     engines: {node: '>=14.15.0'}
     dependencies:
-      '@babel/runtime': 7.18.9
+      '@babel/runtime': 7.20.7
       ci-info: 2.0.0
       configstore: 5.0.1
       fastq: 1.13.0
@@ -11450,7 +11458,7 @@ packages:
     resolution: {integrity: sha512-P4tbcYOJ1DSYKRP4gIAR9Xta/d/AzjmsK2C6PzX7sNcGnviDKtAIoeV9sE0kNXOqBfUCez25zmAi2cq8NlaxKw==}
     engines: {node: '>=14.15.0'}
     dependencies:
-      '@babel/runtime': 7.18.9
+      '@babel/runtime': 7.20.7
       ci-info: 2.0.0
       configstore: 5.0.1
       fastq: 1.13.0
@@ -11466,11 +11474,11 @@ packages:
       tmp: 0.2.1
       xdg-basedir: 4.0.0
 
-  /gatsby-core-utils/4.0.0:
-    resolution: {integrity: sha512-ucrEUfVWVUMTEfqZO4o9XHZgVg2airwm2WJSSFUroIAZ2/7YjEiKtZV3RDO1iEqB1beNjrSLa+eZ1LJhbvsHDQ==}
+  /gatsby-core-utils/4.4.0:
+    resolution: {integrity: sha512-/ibilcGENKH6qqkcT17SIZgc2kjZn3HiGpD+ixbXYkMGqHiM5pj9XIHjy3DfvZvDt2ujkYV5EinmUdqx7CI81w==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@babel/runtime': 7.18.9
+      '@babel/runtime': 7.20.7
       ci-info: 2.0.0
       configstore: 5.0.1
       fastq: 1.13.0
@@ -11491,12 +11499,12 @@ packages:
     resolution: {integrity: sha512-aFHIH7HDb6uozq0uWI+Xn4k7KaWbd1NkKo88q9rhigKfcUpEkux8UV6n5x9QMz/AUOg430pDC6/33h7f0OGX9Q==}
     engines: {node: '>=14.15.0'}
     dependencies:
-      '@babel/runtime': 7.18.9
+      '@babel/runtime': 7.20.7
 
   /gatsby-legacy-polyfills/2.21.0:
     resolution: {integrity: sha512-GUvL4M4JabC59N1B9PmXGHXmVESliKEqqIjqb96yOG5aA3xgt/uDGt2bKhUmjFfkJ20fyTYUu49absLuUXzaxg==}
     dependencies:
-      '@babel/runtime': 7.18.9
+      '@babel/runtime': 7.20.7
       core-js-compat: 3.9.0
 
   /gatsby-link/4.21.0_jrmehtgkntpgvrzvp7eiismjfa:
@@ -11518,7 +11526,7 @@ packages:
     resolution: {integrity: sha512-Oxw2Kq0xkjKLeBVPav5Vw+XHEorn/0koy3TSyCOxH3XedrV7Y6Xk1K8IbHqDbguNiK+wxRaKnMl0eyVwxUVC7Q==}
     engines: {node: '>=14.15.0'}
     dependencies:
-      '@babel/runtime': 7.18.9
+      '@babel/runtime': 7.20.7
       bluebird: 3.7.2
       chokidar: 3.5.3
       fs-exists-cached: 1.0.0
@@ -11720,7 +11728,7 @@ packages:
       - supports-color
     dev: false
 
-  /gatsby-plugin-mdx/4.0.0_ve3aao32jeear4r54inaytsdlm:
+  /gatsby-plugin-mdx/4.0.0_p463e5ujixl6uoianntvxnxv6u:
     resolution: {integrity: sha512-/n9ys4/n6cNZaQ/JmTukv3SuWorpbDCPnfilBlH/ZwmGrb7DIOnzk0Q1wSYaBXopZir8FAwq6JRTT1uCzfAxTQ==}
     peerDependencies:
       '@mdx-js/react': ^2.0.0
@@ -11740,7 +11748,7 @@ packages:
       gatsby: 4.21.1_ygwdrcfl3m6rdu4ibcq7rpa2au
       gatsby-core-utils: 3.21.0
       gatsby-plugin-utils: 3.15.0_fnjxbvnvq6hi5rysf65llm6zjq
-      gatsby-source-filesystem: 5.0.0_gatsby@4.21.1
+      gatsby-source-filesystem: 5.4.0_gatsby@4.21.1
       gray-matter: 4.0.3
       mdast-util-mdx: 2.0.0
       mdast-util-to-hast: 10.2.0
@@ -11763,7 +11771,7 @@ packages:
     peerDependencies:
       gatsby: ^4.0.0-next || ^4 || ^5
     dependencies:
-      '@babel/runtime': 7.18.9
+      '@babel/runtime': 7.20.7
       '@babel/traverse': 7.18.13
       '@sindresorhus/slugify': 1.1.2
       chokidar: 3.5.3
@@ -11814,7 +11822,7 @@ packages:
       '@babel/plugin-proposal-numeric-separator': 7.18.6_@babel+core@7.18.13
       '@babel/plugin-proposal-optional-chaining': 7.18.9_@babel+core@7.18.13
       '@babel/preset-typescript': 7.18.6_@babel+core@7.18.13
-      '@babel/runtime': 7.18.9
+      '@babel/runtime': 7.20.7
       babel-plugin-remove-graphql-queries: 4.21.0_qnprua7uctaly7jm4ovouj4biu
       gatsby: 4.21.1_ygwdrcfl3m6rdu4ibcq7rpa2au
     transitivePeerDependencies:
@@ -11827,7 +11835,7 @@ packages:
       gatsby: ^4.0.0-next || ^4 || ^5
       graphql: ^15.0.0
     dependencies:
-      '@babel/runtime': 7.18.9
+      '@babel/runtime': 7.20.7
       '@gatsbyjs/potrace': 2.3.0
       fastq: 1.13.0
       fs-extra: 10.1.0
@@ -11850,7 +11858,7 @@ packages:
       react: ^16.9.0 || ^17.0.0 || ^18.0.0 || 18
       react-dom: ^16.9.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      '@babel/runtime': 7.18.9
+      '@babel/runtime': 7.20.7
       '@gatsbyjs/reach-router': 1.3.9_biqbaboplfbrettd7655fr4n2y
       prop-types: 15.8.1
       react: 18.2.0
@@ -11909,23 +11917,23 @@ packages:
       xstate: 4.32.1
     dev: false
 
-  /gatsby-source-filesystem/5.0.0_gatsby@4.21.1:
-    resolution: {integrity: sha512-GBHqJ+NXQhru83DFssgJQkgqM2h1ZALb0+4+TXvRUPQWIK9UyZ1Yb4nXAC6EWi+vx2m/B1W+mZH77WTNdh32Bw==}
+  /gatsby-source-filesystem/5.4.0_gatsby@4.21.1:
+    resolution: {integrity: sha512-vYJM5mJu3vJAo9x5i1k+teBNHi2Fn9aPIrF2zgzqMz6x3iAaila0rD3hMLhNBCzo+GosCnkkQW9g/Tk4OcR0gg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       gatsby: ^5.0.0-next || ^4 || ^5
     dependencies:
-      '@babel/runtime': 7.18.9
+      '@babel/runtime': 7.20.7
       chokidar: 3.5.3
       file-type: 16.5.4
       fs-extra: 10.1.0
       gatsby: 4.21.1_ygwdrcfl3m6rdu4ibcq7rpa2au
-      gatsby-core-utils: 4.0.0
+      gatsby-core-utils: 4.4.0
       md5-file: 5.0.0
       mime: 2.6.0
       pretty-bytes: 5.6.0
       valid-url: 1.0.9
-      xstate: 4.32.1
+      xstate: 4.35.2
     dev: false
 
   /gatsby-telemetry/3.21.0:
@@ -11934,7 +11942,7 @@ packages:
     requiresBuild: true
     dependencies:
       '@babel/code-frame': 7.18.6
-      '@babel/runtime': 7.18.9
+      '@babel/runtime': 7.20.7
       '@turist/fetch': 7.2.0_node-fetch@2.6.7
       '@turist/time': 0.0.2
       async-retry-ng: 2.0.1
@@ -11954,7 +11962,7 @@ packages:
     engines: {node: '>=14.15.0'}
     dependencies:
       '@babel/core': 7.18.13
-      '@babel/runtime': 7.18.9
+      '@babel/runtime': 7.20.7
     transitivePeerDependencies:
       - supports-color
 
@@ -14750,7 +14758,7 @@ packages:
     resolution: {integrity: sha512-9VINeH7NYVcdoNybe82oubnm9WqsJ0GsPppIqPQgxrjoUxwMq5ObCE8d+39CBBDnb/TPi9ymRCJ5twklYebdqQ==}
     engines: {node: '>=10'}
     dependencies:
-      '@babel/runtime': 7.18.9
+      '@babel/runtime': 7.20.7
       chalk: 4.1.2
       pegjs: 0.10.0
     dev: true
@@ -18778,7 +18786,7 @@ packages:
   /redux/4.1.2:
     resolution: {integrity: sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==}
     dependencies:
-      '@babel/runtime': 7.18.9
+      '@babel/runtime': 7.20.7
 
   /regenerate-unicode-properties/10.0.1:
     resolution: {integrity: sha512-vn5DU6yg6h8hP/2OkQo3K7uVILvY4iu0oI4t3HFa81UPkhGJwkRwM10JEc3upjdhHjs/k8GJY1sRBhk5sr69Bw==}
@@ -18804,13 +18812,16 @@ packages:
     resolution: {integrity: sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==}
     dev: true
 
+  /regenerator-runtime/0.13.11:
+    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
+
   /regenerator-runtime/0.13.9:
     resolution: {integrity: sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==}
 
   /regenerator-transform/0.15.0:
     resolution: {integrity: sha512-LsrGtPmbYg19bcPHwdtmXwbW+TqNvtY4riE3P83foeHRroMbH6/2ddFBfab3t7kbzc7v7p4wbkIecHImqt0QNg==}
     dependencies:
-      '@babel/runtime': 7.18.9
+      '@babel/runtime': 7.20.7
 
   /regex-escape/3.4.10:
     resolution: {integrity: sha512-qEqf7uzW+iYcKNLMDFnMkghhQBnGdivT6KqVQyKsyjSWnoFyooXVnxrw9dtv3AFLnD6VBGXxtZGAQNFGFTnCqA==}
@@ -18905,7 +18916,7 @@ packages:
   /relay-runtime/12.0.0:
     resolution: {integrity: sha512-QU6JKr1tMsry22DXNy9Whsq5rmvwr3LSZiiWV/9+DFpuTWvp+WFhobWMc8TC4OjKFfNhEZy7mOiqUAn5atQtug==}
     dependencies:
-      '@babel/runtime': 7.18.9
+      '@babel/runtime': 7.20.7
       fbjs: 3.0.4
       invariant: 2.2.4
     transitivePeerDependencies:
@@ -22325,6 +22336,10 @@ packages:
 
   /xstate/4.32.1:
     resolution: {integrity: sha512-QYUd+3GkXZ8i6qdixnOn28bL3EvA++LONYL/EMWwKlFSh/hiLndJ8YTnz77FDs+JUXcwU7NZJg7qoezoRHc4GQ==}
+
+  /xstate/4.35.2:
+    resolution: {integrity: sha512-5X7EyJv5OHHtGQwN7DsmCAbSnDs3Mxl1cXQ4PVaLwi+7p/RRapERnd1dFyHjYin+KQoLLfuXpl1dPBThgyIGNg==}
+    dev: false
 
   /xtend/4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,6 +182,7 @@ importers:
       '@mdx-js/loader': ^2.1.2
       '@mdx-js/react': ^2.1.2
       '@next/mdx': ^12.0.7
+      '@theme-ui/css': workspace:^
       '@types/react': ^18.0.8
       next: ^12.1.0
       react: ^18
@@ -194,6 +195,7 @@ importers:
       '@mdx-js/loader': 2.1.3_webpack@4.46.0
       '@mdx-js/react': 2.1.3_react@18.2.0
       '@next/mdx': 12.2.5_hbo3tj2k5fhsh63l2ltjrymaq4
+      '@theme-ui/css': link:../../packages/css
       next: 12.2.5_rlaikcoslzwwtqyk7brpdzej5y
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -628,6 +630,25 @@ importers:
       babel-eslint: 10.1.0_eslint@8.23.0
       typescript: 4.8.2
 
+  packages/global:
+    specifiers:
+      '@babel/core': ^7.0.0
+      '@emotion/react': ^11
+      '@theme-ui/core': workspace:^
+      '@theme-ui/css': workspace:^
+      '@theme-ui/test-utils': workspace:^
+      '@types/react': ^18.0.8
+      react: '>=18 || 18'
+    dependencies:
+      '@emotion/react': 11.10.0_tu23i5xxn6kbev62oblybgbdem
+      '@theme-ui/core': link:../core
+      '@theme-ui/css': link:../css
+      react: 18.2.0
+    devDependencies:
+      '@babel/core': 7.18.13
+      '@theme-ui/test-utils': link:../test-utils
+      '@types/react': 18.0.17
+
   packages/match-media:
     specifiers:
       '@theme-ui/core': workspace:^
@@ -942,6 +963,7 @@ importers:
       '@theme-ui/components': workspace:^
       '@theme-ui/core': workspace:^
       '@theme-ui/css': workspace:^
+      '@theme-ui/global': workspace:^
       '@theme-ui/test-utils': workspace:^
       '@theme-ui/theme-provider': workspace:^
       '@types/react': ^18.0.8
@@ -952,6 +974,7 @@ importers:
       '@theme-ui/components': link:../components
       '@theme-ui/core': link:../core
       '@theme-ui/css': link:../css
+      '@theme-ui/global': link:../global
       '@theme-ui/theme-provider': link:../theme-provider
     devDependencies:
       '@theme-ui/test-utils': link:../test-utils
@@ -12023,7 +12046,7 @@ packages:
       fs-exists-cached: 1.0.0
       fs-extra: 10.1.0
       gatsby-cli: 4.21.0
-      gatsby-core-utils: 3.24.0
+      gatsby-core-utils: 3.21.0
       gatsby-graphiql-explorer: 2.21.0
       gatsby-legacy-polyfills: 2.21.0
       gatsby-link: 4.21.0_jrmehtgkntpgvrzvp7eiismjfa


### PR DESCRIPTION
At long last, we no longer have to recommend using Emotion's Global component if you need page-specific global CSS. The API:

```js
 <Global sx={{ h1: { color: 'primary', fontSize: 3 } }} />
```

@hasparus: While it's working fine in projects, in the test environment, I'm getting scoped class names from Emotion, which is causing the tests to fail. I've commented those out, but if you look at the snapshot you can see what's happening—any ideas appreciated so it has full test coverage. Both [Emotion's tests](https://github.com/emotion-js/emotion/blob/main/packages/react/__tests__/global.js) & [MUI's tests](https://github.com/mui/material-ui/blob/master/packages/mui-styled-engine/src/GlobalStyles/GlobalStyles.test.js) somehow don't run into this issue; I can't tell what's different in our environment.
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v0.15.5-develop.1`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from a new contributor! :tada:
  
  Thank you, Nischal Shakya ([@Nischal2015](https://github.com/Nischal2015)), for all your work!
  
  #### 🐛 Bug Fix
  
  - Add theme-aware Global component [#2385](https://github.com/system-ui/theme-ui/pull/2385) ([@lachlanjc](https://github.com/lachlanjc) [@hasparus](https://github.com/hasparus))
  - fix: Fix logo script typo ([@lachlanjc](https://github.com/lachlanjc))
  
  #### 🏠 Internal
  
  - docs: Add missing `useMDXComponents` import [#2370](https://github.com/system-ui/theme-ui/pull/2370) ([@Nischal2015](https://github.com/Nischal2015))
  - docs: Reorganize Color Modes doc for clarity [#2365](https://github.com/system-ui/theme-ui/pull/2365) ([@lachlanjc](https://github.com/lachlanjc))
  
  #### Authors: 3
  
  - Lachlan Campbell (they/them) ([@lachlanjc](https://github.com/lachlanjc))
  - Nischal Shakya ([@Nischal2015](https://github.com/Nischal2015))
  - Piotr Monwid-Olechnowicz ([@hasparus](https://github.com/hasparus))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
