### PR TITLE
fix: Use `type` imports consistently on src/index

### DIFF
--- a/packages/theme-ui/src/index.ts
+++ b/packages/theme-ui/src/index.ts
@@ -1,9 +1,7 @@
-import {
-  jsx as coreJsx,
-  ThemeUIJSX,
-  type ThemeUIStyleObject,
-} from '@theme-ui/core'
+import { jsx as coreJsx } from '@theme-ui/core'
+import type { ThemeUIJSX, ThemeUIStyleObject } from '@theme-ui/core'
 import React from 'react'
+
 export {
   __ThemeUIContext,
   merge,


### PR DESCRIPTION
Closes #2391
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v0.15.6-develop.0`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from a new contributor! :tada:
  
  Thank you, Justin Cooper ([@JustinotherGitter](https://github.com/JustinotherGitter)), for all your work!
  
  #### 🐛 Bug Fix
  
  - fix: Use `type` imports on src/index [#2392](https://github.com/system-ui/theme-ui/pull/2392) ([@lachlanjc](https://github.com/lachlanjc))
  
  #### 🏠 Internal
  
  - docs: Fix color modes code sample typo [#2399](https://github.com/system-ui/theme-ui/pull/2399) ([@JustinotherGitter](https://github.com/JustinotherGitter))
  
  #### Authors: 2
  
  - Justin Cooper ([@JustinotherGitter](https://github.com/JustinotherGitter))
  - Lachlan Campbell ([@lachlanjc](https://github.com/lachlanjc))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
