### PR TITLE
tailwind: Switch font sizes to an array

### DIFF
--- a/packages/preset-tailwind/src/index.ts
+++ b/packages/preset-tailwind/src/index.ts
@@ -413,21 +413,21 @@ export const fonts = {
   monospace: baseFonts.mono,
 }
 
-export const fontSizes = {
-  xs: '0.75rem',
-  sm: '0.875rem',
-  default: '1rem',
-  lg: '1.125rem',
-  xl: '1.25rem',
-  '2xl': '1.5rem',
-  '3xl': '1.875rem',
-  '4xl': '2.25rem',
-  '5xl': '3rem',
-  '6xl': '3.75rem',
-  '7xl': '4.5rem',
-  '8xl': '6rem',
-  '9xl': '8rem',
-}
+export const fontSizes = [
+  '0.75rem',
+  '0.875rem',
+  '1rem',
+  '1.125rem',
+  '1.25rem',
+  '1.5rem',
+  '1.875rem',
+  '2.25rem',
+  '3rem',
+  '3.75rem',
+  '4.5rem',
+  '6rem',
+  '8rem',
+]
 
 export const baseFontWeights = {
   hairline: 100,


### PR DESCRIPTION
The `fontSizes` key takes an array of values (not an object). This fixes the heading size settings issue causing the text for headings to default to "6px" which can be seen on the [Demo page](https://theme-ui.com/demo) when selecting "Tailwind" from the drop down.