### PR TITLE
Remove deprecated ThemeProvider export

### DIFF
--- a/packages/theme-provider/src/index.tsx
+++ b/packages/theme-provider/src/index.tsx
@@ -56,30 +56,3 @@ export const ThemeUIProvider = ({ theme, children }: ThemeProviderProps) => {
     </CoreProvider>
   )
 }
-
-/** @deprecated ThemeProvider is now called ThemeUIProvider to reduce confusion with Emotion */
-export const ThemeProvider: React.FC<ThemeProviderProps> = ({
-  theme,
-  children,
-}) => {
-  React.useEffect(() => {
-    if (process.env.NODE_ENV !== 'production') {
-      console.warn(
-        '[theme-ui] The export ThemeProvider is deprecated and is now called ThemeUIProvider to reduce confusion with Emotion. Please update your import; ThemeProvider will be removed in a future version.'
-      )
-    }
-  }, [])
-
-  const outer = useThemeUI()
-
-  const isTopLevel = outer === __themeUiDefaultContextValue
-
-  return (
-    <CoreProvider theme={theme}>
-      <ColorModeProvider>
-        {isTopLevel && <RootStyles />}
-        {children}
-      </ColorModeProvider>
-    </CoreProvider>
-  )
-}

--- a/packages/theme-ui/test/index.tsx
+++ b/packages/theme-ui/test/index.tsx
@@ -8,7 +8,6 @@ import mockConsole from 'jest-mock-console'
 import { fireEvent, render, renderJSON } from '@theme-ui/test-utils'
 
 import {
-  ThemeProvider as DeprecatedThemeProvider,
   ThemeUIProvider,
   jsx,
   BaseStyles,
@@ -48,17 +47,6 @@ test('warns when multiple versions of emotion are installed', () => {
     </__ThemeUIContext.Provider>
   )
   expect(console.warn).toBeCalled()
-  restore()
-})
-
-test('warns deprecated ThemeUIProvider', () => {
-  const restore = mockConsole()
-  render(
-    <DeprecatedThemeProvider theme={{}}>
-      <div />
-    </DeprecatedThemeProvider>
-  )
-  expect(console.warn).toHaveBeenCalled()
   restore()
 })
 


### PR DESCRIPTION
It's been a year since I deprecated `ThemeProvider`, so dropping the deprecated code now.