### PR TITLE
Use GITHUB_OUTPUT envvar instead of set-output command as the latter is deprecated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     needs: [build]
     steps:
       - id: can_release
-        run: echo '::set-output name=CAN_RELEASE::${{ env.CAN_RELEASE }}'
+        run: echo 'CAN_RELEASE=${{ env.CAN_RELEASE }}' >> $GITHUB_OUTPUT
     env:
       CAN_RELEASE: ${{ secrets.AUTO_RELEASE_GH_TOKEN != '' }}
     outputs:


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
