### PR TITLE
Add accentColor to css properties

### DIFF
--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -112,6 +112,7 @@ export const multiples = {
 export const scales = {
   color: 'colors',
   background: 'colors',
+  accentColor: 'colors',
   backgroundColor: 'colors',
   borderColor: 'colors',
   caretColor: 'colors',

--- a/packages/css/test/index.ts
+++ b/packages/css/test/index.ts
@@ -577,16 +577,18 @@ test('flexBasis uses theme.sizes', () => {
   })
 })
 
-test('fill and stroke and caretColor use theme.colors', () => {
+test('fill, stroke, caretColor, and accentColor use theme.colors', () => {
   const style = css({
     fill: 'primary',
     stroke: 'secondary',
     caretColor: 'primary',
+    accentColor: 'secondary',
   })(theme)
   expect(style).toEqual({
     fill: 'tomato',
     stroke: 'cyan',
     caretColor: 'tomato',
+    accentColor: 'cyan',
   })
 })
 

--- a/packages/docs/src/pages/sx-prop.mdx
+++ b/packages/docs/src/pages/sx-prop.mdx
@@ -60,6 +60,7 @@ available.
 | `letterSpacing`           | `letterSpacings` |
 | `color`                   | `colors`         |
 | `bg`, `backgroundColor`   | `colors`         |
+| `accentColor`             | `colors`         |
 | `borderColor`             | `colors`         |
 | `caretColor`              | `colors`         |
 | `outlineColor`            | `colors`         |


### PR DESCRIPTION
### Summary of Changes

This PR adds `accentColor` to the list of theme-supported properties under the `color` space. This way, the chose accent-color can be set using a color from the theme.

### The Problem

Today, setting the accent color to a key in the theme does not pull the corresponding value from the theme. Our team ran into this issue recently trying to set the accent color for a `checkbox` <input> element.

i.e. `accentColor: 'primary'` -> `accentColor: 'primary'`

### Expected Behavior

`accentColor: 'primary'` -> `accentColor: 'tomato'` ('tomato' would be the value in the theme in this example)

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v0.16.2-develop.2`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from new contributors! :tada:
  
  Thanks for all your work!
  
  :heart: Jeff Bell ([@jhbell](https://github.com/jhbell))
  
  :heart: Paweł Kowalewski ([@pawkow](https://github.com/pawkow))
  
  #### 🐛 Bug Fix
  
  
  #### 🏠 Internal
  
  - docs: Fix incorrect config sample [#2467](https://github.com/system-ui/theme-ui/pull/2467) ([@pawkow](https://github.com/pawkow))
  
  #### Authors: 2
  
  - Jeff Bell ([@jhbell](https://github.com/jhbell))
  - Paweł Kowalewski ([@pawkow](https://github.com/pawkow))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
