### PR TITLE
Handle derived sx in Flex.tsx

### DIFF
--- a/packages/components/src/Flex.tsx
+++ b/packages/components/src/Flex.tsx
@@ -11,14 +11,15 @@ export type FlexProps = BoxProps
  */
 export const Flex: ForwardRef<HTMLElement, FlexProps> = React.forwardRef(
   function Flex(props: FlexProps, ref) {
+    const { sx } = props;
     return (
       <Box
         ref={ref}
         {...props}
-        sx={{
+        sx={theme => ({
           display: 'flex',
-          ...props.sx,
-        }}
+          ...(typeof sx === "function" ? sx(theme) : sx),
+        })}
       />
     )
   }


### PR DESCRIPTION
Reported this issue #2534

Derived styles are not applied to `Flex` as it is spread (assumed to be an object?)

Handling the instance where passed `sx` is a function applies styles appropriately

```jsx
// This does not work currently
<Flex sx={() => ({ backgroundColor: "red" })} />

// However, this does work
<Box sx={() => ({ backgroundColor: "red" })} />
```

Wanted to provide a PR along with issue.